### PR TITLE
Fix GitHub Issue #40: Server error 'email' when disabling users from …

### DIFF
--- a/backend/creator_interface/main.py
+++ b/backend/creator_interface/main.py
@@ -1324,7 +1324,7 @@ async def update_user_status_admin(
         
         # Prevent users from disabling themselves
         current_user = get_creator_user_from_token(auth_header)
-        if current_user and current_user.get('email') == user.get('email') and not enabled:
+        if current_user and current_user.get('email') == user.get('user_email') and not enabled:
             raise HTTPException(
                 status_code=403,
                 detail="You cannot disable your own account. Please ask another administrator to disable your account if needed."
@@ -1332,21 +1332,21 @@ async def update_user_status_admin(
         
         # Update user status in OWI auth system
         owi_manager = OwiUserManager()
-        if not owi_manager.update_user_status(user['email'], enabled):
+        if not owi_manager.update_user_status(user.get('user_email'), enabled):
             raise HTTPException(
                 status_code=500,
                 detail="Failed to update user status"
             )
         
         status_text = "enabled" if enabled else "disabled"
-        logger.info(f"Admin updated user {user['email']} (ID: {user_id}) status to {status_text}")
+        logger.info(f"Admin updated user {user.get('user_email')} (ID: {user_id}) status to {status_text}")
         
         return {
             "success": True,
             "message": f"User has been {status_text}",
             "data": {
                 "user_id": user_id,
-                "email": user['email'],
+                "email": user.get('user_email'),
                 "enabled": enabled
             }
         }


### PR DESCRIPTION
…Admin section

Root cause: Key name mismatch in update_user_status_admin endpoint
- Database returns 'user_email' key but code accessed 'email' key
- Fixed 4 instances in backend/creator_interface/main.py lines 1327, 1335, 1342, 1349

The fix aligns admin endpoint with working org admin endpoint which already used correct key name.