### PR TITLE
Add delete user functionality for global admin

### DIFF
--- a/frontend/svelte-app/src/routes/admin/+page.svelte
+++ b/frontend/svelte-app/src/routes/admin/+page.svelte
@@ -59,6 +59,13 @@
     let changePasswordSuccess = $state(false);
     let selectedUserName = $state('');
 
+    // --- Delete User Modal State ---
+    let isDeleteUserModalOpen = $state(false);
+    let userToDelete = $state(null);
+    let isDeletingUser = $state(false);
+    /** @type {string | null} */
+    let deleteUserError = $state(null);
+
     // --- Organizations Management State ---
     /** @type {Array<any>} */
     let organizations = $state([]);
@@ -195,6 +202,83 @@
         // Clear any previous state
         changePasswordError = null;
         selectedUserName = '';
+    }
+
+    /**
+     * Open the delete user modal for a specific user
+     * @param {any} user - User object
+     */
+    function openDeleteUserModal(user) {
+        // Prevent users from deleting themselves
+        if (currentUserData && currentUserData.email === user.email) {
+            return;
+        }
+        
+        userToDelete = user;
+        deleteUserError = null;
+        isDeleteUserModalOpen = true;
+    }
+
+    function closeDeleteUserModal() {
+        isDeleteUserModalOpen = false;
+        userToDelete = null;
+        deleteUserError = null;
+        isDeletingUser = false;
+    }
+
+    async function confirmDeleteUser() {
+        if (!userToDelete) return;
+
+        isDeletingUser = true;
+        deleteUserError = null;
+
+        try {
+            const token = getAuthToken();
+            if (!token) {
+                throw new Error('Authentication token not found. Please log in again.');
+            }
+
+            // For global admin, we need to pass the org parameter to target the system organization
+            // The system organization slug is 'lamb'
+            const systemOrgSlug = 'lamb';
+            const apiUrl = getApiUrl(`/admin/org-admin/users/${userToDelete.id}?org=${systemOrgSlug}`);
+            console.log(`Deleting user ${userToDelete.email} at: ${apiUrl}`);
+
+            const response = await axios.delete(apiUrl, {
+                headers: {
+                    'Authorization': `Bearer ${token}`
+                }
+            });
+
+            console.log('User delete response:', response.data);
+
+            // Remove the user from the local list
+            const userIndex = users.findIndex(u => u.id === userToDelete.id);
+            if (userIndex !== -1) {
+                users.splice(userIndex, 1);
+                users = [...users]; // Trigger reactivity
+            }
+
+            // Close modal
+            closeDeleteUserModal();
+
+            // Show success message
+            alert(`User ${userToDelete.name} has been permanently deleted.`);
+
+        } catch (err) {
+            console.error('Error deleting user:', err);
+            
+            let errorMessage = 'Failed to delete user.';
+            if (axios.isAxiosError(err) && err.response?.data?.detail) {
+                errorMessage = err.response.data.detail;
+            } else if (err instanceof Error) {
+                errorMessage = err.message;
+            }
+            
+            deleteUserError = errorMessage;
+        } finally {
+            isDeletingUser = false;
+        }
     }
 
     // User enable/disable functions for system admin  
@@ -1161,8 +1245,8 @@
                                     </button>
                                     <button
                                         class={currentUserData && currentUserData.email === user.email && user.enabled 
-                                            ? "text-gray-400 cursor-not-allowed" 
-                                            : "text-blue-600 hover:text-blue-800"}
+                                            ? "text-gray-400 cursor-not-allowed mr-3" 
+                                            : "text-blue-600 hover:text-blue-800 mr-3"}
                                         title={currentUserData && currentUserData.email === user.email && user.enabled 
                                             ? "You cannot disable your own account" 
                                             : (user.enabled ? 'Disable User' : 'Enable User')}
@@ -1181,6 +1265,23 @@
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                             </svg>
                                         {/if}
+                                    </button>
+                                    <button
+                                        class={currentUserData && currentUserData.email === user.email 
+                                            ? "text-gray-400 cursor-not-allowed" 
+                                            : "text-red-600 hover:text-red-800"}
+                                        title={currentUserData && currentUserData.email === user.email 
+                                            ? "You cannot delete your own account" 
+                                            : 'Delete User'}
+                                        aria-label={currentUserData && currentUserData.email === user.email 
+                                            ? "You cannot delete your own account" 
+                                            : 'Delete User'}
+                                        onclick={() => openDeleteUserModal(user)}
+                                        disabled={currentUserData && currentUserData.email === user.email}
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                                        </svg>
                                     </button>
                                 </td>
                             </tr>
@@ -1857,6 +1958,74 @@
                         class="bg-gray-300 hover:bg-gray-400 text-gray-800 py-2 px-4 rounded focus:outline-none focus:shadow-outline"
                     >
                         Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+<!-- Delete User Modal -->
+{#if isDeleteUserModalOpen && userToDelete}
+    <div class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center">
+        <div class="relative mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white">
+            <div class="mt-3">
+                <!-- Warning Icon -->
+                <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
+                    <svg class="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                </div>
+                
+                <!-- Modal Header -->
+                <h3 class="text-lg leading-6 font-medium text-gray-900 text-center mt-4">
+                    {localeLoaded ? $_('admin.users.delete.title', { default: 'Delete User' }) : 'Delete User'}
+                </h3>
+                
+                <!-- Modal Content -->
+                <div class="mt-4 text-center">
+                    <p class="text-sm text-gray-600">
+                        {localeLoaded ? $_('admin.users.delete.confirmText', { default: 'Are you sure you want to permanently delete' }) : 'Are you sure you want to permanently delete'}
+                    </p>
+                    <p class="text-base font-semibold text-gray-900 mt-2">
+                        {userToDelete.name}
+                    </p>
+                    <p class="text-sm text-gray-600 mt-1">
+                        ({userToDelete.email})
+                    </p>
+                    <div class="mt-4 bg-red-50 border-l-4 border-red-400 p-3 rounded">
+                        <p class="text-sm text-red-800">
+                            <strong>{localeLoaded ? $_('admin.users.delete.warningLabel', { default: 'Warning:' }) : 'Warning:'}</strong> 
+                            {localeLoaded ? $_('admin.users.delete.warningText', { default: 'This action cannot be undone. The user will be permanently removed from the system and will not be able to log in.' }) : 'This action cannot be undone. The user will be permanently removed from the system and will not be able to log in.'}
+                        </p>
+                    </div>
+                </div>
+
+                {#if deleteUserError}
+                    <div class="mt-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+                        <span class="block sm:inline">{deleteUserError}</span>
+                    </div>
+                {/if}
+                
+                <!-- Modal Actions -->
+                <div class="flex items-center justify-between mt-6 gap-3">
+                    <button 
+                        type="button" 
+                        onclick={closeDeleteUserModal}
+                        class="flex-1 bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50" 
+                        disabled={isDeletingUser}
+                    >
+                        {localeLoaded ? $_('admin.users.delete.cancel', { default: 'Cancel' }) : 'Cancel'}
+                    </button>
+                    <button 
+                        type="button" 
+                        onclick={confirmDeleteUser}
+                        class="flex-1 bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:opacity-50" 
+                        disabled={isDeletingUser}
+                    >
+                        {isDeletingUser 
+                            ? (localeLoaded ? $_('admin.users.delete.deleting', { default: 'Deleting...' }) : 'Deleting...')
+                            : (localeLoaded ? $_('admin.users.delete.deleteButton', { default: 'Delete User' }) : 'Delete User')}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
The user deletion option has been added in [5138492](https://github.com/Lamb-Project/lamb/commit/513849226256c13b693c7f1e58a4b4242cb32d83) but it works just for Org Admin users.

Currently the Global admin cannot delete system organization users.

This PR adds the delete user functionality for Global admin over the system (LAMB) organization.

Fixes #53 