### PR TITLE
Fix: avoid race conditions docker compose (#90)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - openwebui-build
     command: >
       sh -lc "echo 'Waiting for open-webui build marker...' && \
-      while [ ! -f ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete ]; do echo 'waiting for open-webui build...'; sleep 1; done && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete ]; do echo 'waiting for open-webui build...'; sleep 30; done && \
       echo 'Build folder found, starting backend server...' && \
       cd ${LAMB_PROJECT_PATH}/open-webui/backend && \
       python -m pip install --upgrade pip && \
@@ -88,8 +88,8 @@ services:
       - frontend-build
     command: >
       sh -lc "echo 'Waiting for required build markers (openwebui + frontend)...' && \
-      while [ ! -f ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete ]; do echo 'waiting for open-webui build...'; sleep 1; done && \
-      while [ ! -f ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete ]; do echo 'waiting for frontend build...'; sleep 1; done && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete ]; do echo 'waiting for open-webui build...'; sleep 30; done && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete ]; do echo 'waiting for frontend build...'; sleep 30; done && \
       python -m pip install --upgrade pip && \
       pip install -r requirements.txt && \
       uvicorn main:app --port $$PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload"
@@ -110,7 +110,7 @@ services:
       - frontend-build
     command: >
       sh -lc "echo 'Waiting for frontend build marker...' && \
-      while [ ! -f ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete ]; do echo 'waiting for frontend build...'; sleep 1; done && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete ]; do echo 'waiting for frontend build...'; sleep 30; done && \
       test -f static/config.js || cp static/config.js.sample static/config.js; \
       npm install; \
       npm run dev -- --host 0.0.0.0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,9 @@ services:
     depends_on:
       - openwebui-build
     command: >
-      sh -lc "echo 'Build folder found, starting backend server...' && \
+      sh -lc "echo 'Waiting for open-webui build marker...' && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete ]; do echo 'waiting for open-webui build...'; sleep 1; done && \
+      echo 'Build folder found, starting backend server...' && \
       cd ${LAMB_PROJECT_PATH}/open-webui/backend && \
       python -m pip install --upgrade pip && \
       pip install -r requirements.txt && \
@@ -33,7 +35,7 @@ services:
     environment:
       - NODE_OPTIONS=--max-old-space-size=4096
     command: >
-      sh -lc "if [ ! -d ${LAMB_PROJECT_PATH}/open-webui/build ] || [ -z \"$(ls -A ${LAMB_PROJECT_PATH}/open-webui/build 2>/dev/null)\" ]; then npm install && npm run build; else echo 'Build folder already exists, skipping build.'; fi"
+      sh -lc "if [ ! -d ${LAMB_PROJECT_PATH}/open-webui/build ] || [ -z \"$(ls -A ${LAMB_PROJECT_PATH}/open-webui/build 2>/dev/null)\" ]; then npm install && npm run build && mkdir -p ${LAMB_PROJECT_PATH}/open-webui/build && touch ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete; else echo 'Build folder already exists, skipping build.' && mkdir -p ${LAMB_PROJECT_PATH}/open-webui/build && touch ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete; fi"
     # This service only runs the build step and exits
 
   frontend-build:
@@ -43,7 +45,7 @@ services:
     volumes:
       - ${LAMB_PROJECT_PATH}:${LAMB_PROJECT_PATH}
     command: >
-      sh -lc "npm install && npm run build"
+      sh -lc "npm install && npm run build && touch ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete"
     # This service only runs the build step and exits
 
   kb:
@@ -85,7 +87,10 @@ services:
       - kb
       - frontend-build
     command: >
-      sh -lc "python -m pip install --upgrade pip && \
+      sh -lc "echo 'Waiting for required build markers (openwebui + frontend)...' && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/open-webui/build/.build_complete ]; do echo 'waiting for open-webui build...'; sleep 1; done && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete ]; do echo 'waiting for frontend build...'; sleep 1; done && \
+      python -m pip install --upgrade pip && \
       pip install -r requirements.txt && \
       uvicorn main:app --port $$PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload"
 
@@ -104,10 +109,13 @@ services:
       - backend
       - frontend-build
     command: >
-      sh -lc "test -f static/config.js || cp static/config.js.sample static/config.js; \
+      sh -lc "echo 'Waiting for frontend build marker...' && \
+      while [ ! -f ${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete ]; do echo 'waiting for frontend build...'; sleep 1; done && \
+      test -f static/config.js || cp static/config.js.sample static/config.js; \
       npm install; \
       npm run dev -- --host 0.0.0.0"
 
 networks:
   default:
     name: lamb
+    


### PR DESCRIPTION
# Fix: avoid race conditions in docker-compose

## Solution for issue #90 

## Summary
- Ensure services that depend on build artifacts wait until the build steps complete.
- Build services now create a marker file when finished; runtime services poll for that marker before starting.

## What changed
### Build services:
- openwebui-build and frontend-build create a marker file after successful build:
- open-webui: `${LAMB_PROJECT_PATH}/open-webui/build/.build_complete`
- frontend: `${LAMB_PROJECT_PATH}/frontend/svelte-app/.build_complete`
- Implementation: after build step the containers run `mkdir -p ... && touch ...` to ensure the marker exists in the host-mounted workspace.

### Runtime services:
- openwebui, backend and frontend were updated to wait for the corresponding marker files before starting their main process.
- Each waiting loop checks for the existence of the marker file every 30 seconds:
- openwebui waits for openwebui build marker.
- backend waits for both openwebui and frontend build markers.
- frontend waits for frontend build marker.
- The polling is a simple shell loop that delays service startup until the marker is present.

## Rationale
- Docker Compose `depends_on` only controls start order, not completion of build tasks or guarantees that a build container finished building the files needed by other services.
- Adding explicit build-complete marker files + polling avoids race conditions where a service starts before a build artifact is fully available.

## Files touched
### docker-compose.yaml
- Added marker creation to build services.
- Added shell loops in runtime services to wait for marker files before launching servers.

## How this affects local development
- When running `docker-compose up` the UI/backend services will start only after builds complete and marker files exist.
- If a build is already present, the build services will skip re-building and still ensure the marker file exists so dependent services can start immediately.