### PR TITLE
Fix broken doc links in fix_launch.md

### DIFF
--- a/Documentation/slop-docs/fix_launch.md
+++ b/Documentation/slop-docs/fix_launch.md
@@ -523,10 +523,10 @@ docker restart lamb-openwebui
 
 ## 📚 Related Documentation
 
-- [LAMB Architecture](Documentation/lamb_architecture.md)
-- [Product Requirements](Documentation/prd.md)
-- [Deployment Guide](Documentation/deployment.md)
-- [Installation Guide](Documentation/installationguide.md)
+- [LAMB Architecture](../lamb_architecture.md)
+- [Product Requirements](../prd.md)
+- [Deployment Guide](deployment.md)
+- [Installation Guide](../installationguide.md)
 
 ---
 


### PR DESCRIPTION
Fixes 4 broken relative links in "Documentation/slop-docs/fix_launch.md" (lines 526 to 529).

These links were pointing to "Documentation/..." but since the file is inside "slop-docs/" the paths resolved incorrectly and brought error.

Before:
526 - Documentation/lamb_architecture.md
527 - Documentation/prd.md
528 - Documentation/deployment.md
529 - Documentation/installationguide.md

After:
526 - ../lamb_architecture.md
527 - ../prd.md
528 - deployment.md
529 - ../installationguide.md

Tested locally, all paths now resolve correctly.

Related to #132 (Additional broken links found while reviewing #133)