### PR TITLE
Add markdown rendering toggle to chat interface

### DIFF
--- a/frontend/svelte-app/package.json
+++ b/frontend/svelte-app/package.json
@@ -50,7 +50,7 @@
 		"axios": "^1.8.1",
 		"flowbite-svelte": "^0.48.6",
 		"flowbite-svelte-icons": "^2.1.1",
-		"marked": "^15.0.11",
+		"marked": "^15.0.12",
 		"openai": "^4.53.3",
 		"svelte-i18n": "^4.0.1"
 	}

--- a/frontend/svelte-app/src/lib/components/ChatInterface.svelte
+++ b/frontend/svelte-app/src/lib/components/ChatInterface.svelte
@@ -1,6 +1,7 @@
 <script>
     import { writable } from 'svelte/store';
     import { onMount } from 'svelte';
+    import { marked } from 'marked';
     // Note: 'ai' and '@ai-sdk/openai' might not be strictly necessary if only using fetch
     // import { streamText } from 'ai'; 
     // import { openai } from '@ai-sdk/openai'; 
@@ -35,6 +36,7 @@
     let models = $state(/** @type {string[]} */([]));
     let selectedModel = $state(initialModel ?? 'gpt-3.5-turbo'); // Use initialModel prop if provided
     let isLoadingModels = $state(false);
+    let renderMarkdown = $state(false);
     let modelsError = $state(/** @type {string|null} */ (null));
     let isStreaming = $state(false);
     let chatContainer = $state(/** @type {HTMLElement | null} */(null)); // For autoscroll
@@ -277,6 +279,10 @@
     <!-- Header / Model Selector -->
     <div class="p-2 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
         <h2 class="text-lg font-semibold text-gray-700">Chat</h2>
+        <label class="flex items-center space-x-2 text-sm text-gray-600">
+            <input type="checkbox" bind:checked={renderMarkdown} class="rounded" />
+            <span>Render as markdown</span>
+    </label>
         {#if false} <!-- Start: Hide model selector -->
         {#if isLoadingModels}
             <span class="text-sm text-gray-500">Loading models...</span>
@@ -305,8 +311,12 @@
                         <!-- Basic streaming indicator -->
                          <span class="italic">{message.content || 'Thinking...'}</span> 
                      {:else}
-                        <!-- Render markdown or plain text here eventually -->
-                        <p class="whitespace-pre-wrap">{message.content}</p> 
+                        <!-- Render markdown or plain text based on checkbox -->
+                        {#if renderMarkdown}
+                            <div class="prose prose-sm">{@html marked(message.content)}</div>
+                        {:else}
+                            <p class="whitespace-pre-wrap">{message.content}</p>
+                        {/if} 
                      {/if}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Adds a "Render as markdown" checkbox to the chat interface, allowing functionality for users to toggle between raw text and rendered markdown views.

## Changes
- Added "marked" library for markdown parsing
- Added "renderMarkdown" state variable to track toggle state
- Added checkbox in chat header to toggle rendering mode
- Messages render as formatted markdown when enabled, plain text when disabled

## Testing
- Verified the frontend compiles and runs without errors (npm run dev)
- Confirmed "marked" dependency loads correctly
- Unable to fully test the chat UI as it requires backend authentication and a configured assistant

## Related
Closes #106 

Implements the "Render as markdown" checkbox as discussed by @granludo and @juananpe in the issue comments.