### PR TITLE
Real-Time Ingestion Job Progress Tracking Enhancement

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -176,3 +176,7 @@ LANGCHAIN_TRACING_V2=false
 LANGCHAIN_API_KEY=your-langsmith-api-key-here
 LANGCHAIN_PROJECT=lamb-assistants
 # LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
+
+
+# Refresh rate (in seconds) for the ingestion job status updates
+INGESTION_JOB_REFRESH_RATE=3

--- a/backend/creator_interface/main.py
+++ b/backend/creator_interface/main.py
@@ -134,6 +134,23 @@ router.include_router(chats_router, prefix="/chats")
 # REMOVED: assistant_sharing_router - functionality moved to services, accessed via /creator/lamb/* proxy
 
 
+# Configuration Endpoints
+
+@router.get("/config/ingestion")
+async def get_ingestion_config():
+    """Get ingestion configuration values.
+    
+    Returns configuration such as:
+    - refresh_rate: How often (in seconds) the frontend should poll job status
+    
+    Returns:
+        Dictionary with configuration values
+    """
+    return {
+        "refresh_rate": int(os.getenv("INGESTION_JOB_REFRESH_RATE", "3"))
+    }
+
+
 # Initialize security
 security = HTTPBearer()
 

--- a/frontend/svelte-app/src/lib/services/knowledgeBaseService.js
+++ b/frontend/svelte-app/src/lib/services/knowledgeBaseService.js
@@ -3,6 +3,11 @@ import { getApiUrl } from '$lib/config'; // Use the helper for API base
 import { browser } from '$app/environment';
 
 /**
+ * @typedef {Object} IngestionConfig
+ * @property {number} refresh_rate - Polling interval in seconds
+ */
+
+/**
  * @typedef {Object} KnowledgeBase
  * @property {string} id
  * @property {string} name
@@ -11,6 +16,31 @@ import { browser } from '$app/environment';
  * @property {number} created_at
  * @property {object} [metadata]
  */
+
+/**
+ * Get ingestion configuration from backend.
+ * 
+ * @returns {Promise<IngestionConfig>} Configuration including refresh rate
+ * @throws {Error} If the request fails
+ */
+export async function getIngestionConfig() {
+    if (!browser) {
+        throw new Error('Configuration fetching is only available in the browser.');
+    }
+
+    const url = getApiUrl('/config/ingestion');
+    console.log(`Fetching ingestion config from: ${url}`);
+
+    try {
+        const response = await axios.get(url);
+        console.log('Ingestion config response:', response.data);
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching ingestion config:', error);
+        // Return default values if fetch fails
+        return { refresh_rate: 3 };
+    }
+}
 
 /**
  * Fetches user's owned knowledge bases.

--- a/lamb-kb-server-stable/backend/main.py
+++ b/lamb-kb-server-stable/backend/main.py
@@ -155,6 +155,35 @@ app.add_middleware(
 # Ingestion Plugin Endpoints
 
 @app.get(
+    "/config/ingestion",
+    summary="Get ingestion configuration",
+    description="""Get configuration values for ingestion monitoring.
+    
+    Returns configuration such as:
+    - refresh_rate: How often (in seconds) the frontend should poll job status
+    
+    Example:
+    ```bash
+    curl -X GET 'http://localhost:9090/config/ingestion'
+    ```
+    """,
+    tags=["Configuration"],
+    responses={
+        200: {"description": "Configuration values"}
+    }
+)
+async def get_ingestion_config():
+    """Get ingestion configuration values.
+    
+    Returns:
+        Dictionary with configuration values
+    """
+    return {
+        "refresh_rate": int(os.getenv("INGESTION_JOB_REFRESH_RATE", "3"))
+    }
+
+
+@app.get(
     "/ingestion/plugins",
     response_model=List[IngestionPluginInfo],
     summary="List ingestion plugins",

--- a/lamb-kb-server-stable/backend/routers/collections.py
+++ b/lamb-kb-server-stable/backend/routers/collections.py
@@ -198,7 +198,8 @@ def process_file_in_background_enhanced(file_path: str, plugin_name: str, params
             result = IngestionService.add_documents_to_collection(
                 db=db_background,
                 collection_id=collection_id,
-                documents=documents
+                documents=documents,
+                file_registry_id=file_registry_id
             )
         except Exception as e:
             raise Exception(f"Failed to add documents to collection: {str(e)}")
@@ -362,7 +363,8 @@ def process_urls_in_background_enhanced(urls: List[str], plugin_name: str, param
         result = IngestionService.add_documents_to_collection(
             db=db_background,
             collection_id=collection_id,
-            documents=documents
+            documents=documents,
+            file_registry_id=file_registry_id
         )
         
         # Mark as completed


### PR DESCRIPTION
# Real-Time Ingestion Job Progress Tracking Enhancement

**Related GitHub Issue:** #162  
**Status:** ✅ Complete and Tested

## Overview

This enhancement implements real-time progress tracking for ingestion jobs across all plugins. Previously, the progress bar remained stuck at 0% during chunk insertion, and users had no visibility into long-running operations. The fix includes backend batch-level progress updates, a configurable polling interval via environment variables, and improved frontend UI that intelligently displays progress based on the current processing phase.

## Problem Statement

### Issues Encountered

1. **Progress Bar Frozen at 0%**
   - During file ingestion, the progress bar would show "0%"
   - Root cause: Backend's `add_documents_to_collection()` method only set progress at the start (0) and end (total), with no updates during the actual chunk insertion loop
   - User experience: Users had no way to know if processing was proceeding normally or had stalled

2. **Hardcoded Polling Interval**
   - The frontend had a hardcoded 3-second polling interval
   - No way for administrators to customize polling frequency
   - Couldn't balance between server load and user responsiveness

## Solution Overview

### Architecture

The solution implements real-time progress tracking at three levels:

1. **Backend Service Layer** (`services/ingestion.py`)
   - Progress updates happen in batches (every 5 chunks inserted to ChromaDB)
   - Updates stored in database `FileRegistry` table

2. **Backend Configuration** (`creator_interface/main.py`)
   - New `/config/ingestion` endpoint returns polling configuration
   - Reads `INGESTION_JOB_REFRESH_RATE` environment variable (seconds)
   - Falls back to 3-second default if not configured
   - Accessible to frontend for dynamic polling interval

3. **Frontend Polling** (`KnowledgeBaseDetail.svelte`)
   - Automatically polls job status when modal is open
   - Uses configurable interval from backend (converted to milliseconds)
   - Only polls when job is in `processing` or `pending` state
   - Phase-aware display: shows chunk counter only during insertion phase

### Implementation Details

#### Backend: Batch Progress Updates

**File:** `lamb-kb-server-stable/backend/services/ingestion.py`

Modified `add_documents_to_collection()` to accept optional `file_registry_id` parameter and update progress after each batch:

```python
def add_documents_to_collection(db, collection_id, documents, embeddings_function=None, file_registry_id=None):
    # ... initialization code ...
    
    batch_size = 5
    total_docs = len(ids)
    
    for i in range(0, len(ids), batch_size):
        batch_end = min(i + batch_size, len(ids))
        # Add batch to ChromaDB
        collection.add(
            ids=ids[i:batch_end],
            documents=documents[i:batch_end],
            # ... other parameters ...
        )
        
        # Update progress in database if file_registry_id provided
        if file_registry_id:
            file_reg = db.query(FileRegistry).filter(
                FileRegistry.id == file_registry_id
            ).first()
            if file_reg:
                file_reg.progress_current = batch_end
                file_reg.progress_total = total_docs
                file_reg.progress_message = f"Adding chunks to collection... ({batch_end}/{total_docs})"
                file_reg.updated_at = datetime.utcnow()
                db.commit()
```

**Benefits:**
- Progress updates every ~5 chunks (configurable via `batch_size`)
- Minimal performance impact
- Works for all plugins that use the central service
- Database persists progress for resilience

#### Backend: Configuration Endpoint

**File:** `backend/creator_interface/main.py`

New endpoint serves polling configuration:

```python
@router.get("/config/ingestion")
async def get_ingestion_config():
    """Get ingestion job polling configuration."""
    return {
        "refresh_rate": int(os.getenv("INGESTION_JOB_REFRESH_RATE", "3"))
    }
```

Routes as `/creator/config/ingestion` (creator interface router uses `/creator` prefix).

**Environment Variable:**
- `INGESTION_JOB_REFRESH_RATE` - Polling interval in seconds (default: 3)
- Can be set in `.env` file or system environment

#### Frontend: Service Function

**File:** `frontend/svelte-app/src/lib/services/knowledgeBaseService.js`

New function fetches configuration from backend:

```javascript
export async function getIngestionConfig() {
    const url = getApiUrl('/config/ingestion');
    try {
        const response = await axios.get(url);
        return response.data;  // { refresh_rate: 3 }
    } catch (error) {
        console.warn('Failed to fetch ingestion config:', error);
        return { refresh_rate: 3 };  // Fallback to 3 seconds
    }
}
```

#### Frontend: Dynamic Polling

**File:** `frontend/svelte-app/src/lib/components/KnowledgeBaseDetail.svelte`

Component fetches configuration on mount and uses it for polling:

```svelte
<script>
    let pollingRefreshRate = $state(3000);  // milliseconds
    
    onMount(async () => {
        const config = await getIngestionConfig();
        // Convert seconds to milliseconds
        pollingRefreshRate = config.refresh_rate * 1000;
    });
    
    // Polling effect
    $effect(() => {
        if (showJobModal && selectedJob && 
            (selectedJob.status === 'processing' || selectedJob.status === 'pending')) {
            
            const pollInterval = setInterval(async () => {
                const updatedJob = await getIngestionJobStatus(kbId, selectedJob.id);
                console.log('[Job Poll Response]', {
                    jobId: updatedJob.id,
                    status: updatedJob.status,
                    progress: updatedJob.progress
                });
                selectedJob = updatedJob;
                
                // Stop polling if terminal state reached
                if (['completed', 'failed', 'cancelled'].includes(updatedJob.status)) {
                    clearInterval(pollInterval);
                }
            }, pollingRefreshRate);
            
            return () => clearInterval(pollInterval);
        }
    });
</script>
```

## Files Modified

### Backend Files

1. **`lamb-kb-server-stable/backend/services/ingestion.py`**
   - Added optional `file_registry_id` parameter to `add_documents_to_collection()`
   - Added batch progress updates inside chunk insertion loop
   - Progress message format: `"Adding chunks to collection... (X/Y)"`

2. **`lamb-kb-server-stable/backend/routers/collections.py`**
   - Line ~198: Pass `file_registry_id` during file ingestion
   - Line ~363: Pass `file_registry_id` during URL ingestion
   - Set initial progress in background task before calling service

3. **`backend/creator_interface/main.py`**
   - Added `/config/ingestion` endpoint
   - Loads both local `.env` and KB server `.env` for environment variables
   - Returns `{ "refresh_rate": int }`

4. **`backend/.env.example`**
   - Added line 182: `INGESTION_JOB_REFRESH_RATE=3`
   - Documents polling interval configuration for deployments

### Frontend Files

5. **`frontend/svelte-app/src/lib/services/knowledgeBaseService.js`**
   - Added `getIngestionConfig()` async function
   - Calls `/config/ingestion` endpoint
   - Implements fallback to default 3-second interval

6. **`frontend/svelte-app/src/lib/components/KnowledgeBaseDetail.svelte`**
   - Added `pollingRefreshRate` state variable (milliseconds)
   - Mount hook: Fetch config and convert seconds→milliseconds
   - Polling effect: Auto-poll when job modal open and job in non-terminal state
   - Progress display: Conditional chunk counter based on `progress.total`
   - Fixed TypeScript error with nullish coalescing: `(progress.total ?? 0) > 1`

### Documentation Files

7. **`lamb-kb-server-stable/Docs/slop-docs/gh-issue-ingestion-status-api.md`**
   - Added "Real-Time Progress Monitoring" section
   - Documents progress percentage and chunk counter display
   - Explains configurable polling interval via `INGESTION_JOB_REFRESH_RATE`
   - Updated "Files Changed" section with all modified files

## Configuration

### Environment Variable

Add to your `.env` file:

```bash
# Polling interval for ingestion job status updates (in seconds)
INGESTION_JOB_REFRESH_RATE=3
```

**Default:** 3 seconds  
**Recommended range:** 1-10 seconds
- 1-2 seconds: More responsive, higher server load
- 3-5 seconds: Balanced (recommended)
- 10+ seconds: Lower server load, less responsive

## Screenshots of ingestion-jobs progress

<img width="1919" height="910" alt="Captura de pantalla 2026-01-12 200421" src="https://github.com/user-attachments/assets/868a7a1a-8995-40f8-9b65-23a6f9e8044b" />

<img width="1919" height="907" alt="Captura de pantalla 2026-01-12 200511" src="https://github.com/user-attachments/assets/f4fea85f-b946-4d8c-a0f5-99e5f127e9b2" />
