### PR TITLE
Rename organization assistant defaults methods

### DIFF
--- a/backend/creator_interface/organization_router.py
+++ b/backend/creator_interface/organization_router.py
@@ -3641,7 +3641,7 @@ async def get_organization_assistant_defaults(
         
         # Use OrganizationService instead of HTTP call
         org_service = OrganizationService()
-        defaults = org_service.get_organization_assistant_defaults(slug)
+        defaults = org_service.get_assistant_defaults(slug)
         
         if defaults is None:
             raise HTTPException(status_code=404, detail="Organization not found")
@@ -3692,7 +3692,7 @@ async def update_organization_assistant_defaults(
         
         # Use OrganizationService instead of HTTP call
         org_service = OrganizationService()
-        updated_defaults = org_service.update_organization_assistant_defaults(slug, body)
+        updated_defaults = org_service.update_assistant_defaults(slug, body)
         
         if updated_defaults is None:
             raise HTTPException(status_code=404, detail="Organization not found")


### PR DESCRIPTION
It fixes issue #197 


This pull request updates method calls in the `organization_router.py` file to use the new method names in `OrganizationService` for handling assistant defaults. The changes ensure consistency with updated service method names.

**Refactoring for consistency with service method names:**

-  Updated the call to retrieve organization assistant defaults to use `get_assistant_defaults` instead of the old `get_organization_assistant_defaults` method in the `get_organization_assistant_defaults` endpoint.
-  Updated the call to update organization assistant defaults to use `update_assistant_defaults` instead of the old `update_organization_assistant_defaults` method in the `update_organization_assistant_defaults` endpoint.