### PR TITLE
[BACKEND] fix(ingest): warning for 429 error youtube subtitles for issue 219

### DIFF
--- a/lamb-kb-server-stable/backend/plugins/youtube_transcript_ingest.py
+++ b/lamb-kb-server-stable/backend/plugins/youtube_transcript_ingest.py
@@ -231,7 +231,7 @@ def _fetch_transcript(video_id: str, languages: Iterable[str], proxy_url: Option
             response.raise_for_status()
 
             return {    # still returning pieces, adding metadata, useful for frontend user-facing warning to work
-                "pieces": _parse_vtt_content(response.text),
+                "pieces": _parse_srt_content(response.text),
                 "metadata": {
                     "is_translated": is_translated,
                     "native_lang": native_lang,


### PR DESCRIPTION
In _fetch_transcripts, there is now a bool tag called is_translated, always false for manual subtitles, always false for subtitles with language code having "-orig" on the end, and true for auto-captions IF the caption is not native. In this original priority is how subtitles were selected anyways.

If a different language than native is selected AND the result is a translated transcript, the bool is_translated is true, so then a warning is sent in logs, and I've tried my best to make it easy to connect this to a future frontend fix that isn't here yet.

This is only a partial fix to issue #219 and the fix has been tied in a knot so it doesn't cause errors but ready to connect to a potential frontend user facing warning. When an Error 429 happens, this is caught in lines 416-418 and the process gracefully fails and allows the continuing of other videos.