### PR TITLE
Scripts to create a Dbizi dataset and evaluate an assistant

### DIFF
--- a/lamb-kb-server-stable/backend/.env.example
+++ b/lamb-kb-server-stable/backend/.env.example
@@ -37,6 +37,7 @@ API_BASE_URL=http://localhost:9099
 JWT_TOKEN=your-jwt-token-here
 ASSISTANT_ID=1 # your-assistant-id-here
 DATASET_NAME=your-dataset-name
+EVALUATOR_MODEL=gpt-4.1
 
 # Logging
 # LAMB KB webapp-specific log level (falls back to GLOBAL_LOG_LEVEL if unset)

--- a/lamb-kb-server-stable/backend/.env.example
+++ b/lamb-kb-server-stable/backend/.env.example
@@ -32,6 +32,12 @@ FIRECRAWL_API_URL=http://host.docker.internal:3002
 # FIRECRAWL_API_URL=https://api.firecrawl.dev
 # FIRECRAWL_API_KEY=your-firecrawl-api-key-here
 
+# LangSmith Evaluation Configuration
+API_BASE_URL=http://localhost:9099
+JWT_TOKEN=your-jwt-token-here
+ASSISTANT_ID=1 # your-assistant-id-here
+DATASET_NAME=your-dataset-name
+
 # Logging
 # LAMB KB webapp-specific log level (falls back to GLOBAL_LOG_LEVEL if unset)
 LAMB_KB_LOG_LEVEL=WARNING

--- a/scripts/langsmith/dbizi_dataset.py
+++ b/scripts/langsmith/dbizi_dataset.py
@@ -1,0 +1,134 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from langsmith import Client
+
+# Load environment variables from backend
+project_root = Path(__file__).parent.parent.parent
+load_dotenv(project_root / "backend" / ".env")
+
+example_inputs = [
+    (
+        "¿Cómo inicio el servicio con una bicicleta tanto mecánica como eléctrica?",
+        "Mediante la app de PBSC. Selecciona la opción 'obtener una bicicleta' dentro del mapa principal, escanea el código QR y espera a que la luz amarilla se vuelva verde para poder retirar tu bicicleta. Fuente: https://www.dbizi.eus/es/preguntas-frecuentes",
+    ),
+    (
+        "¿Cómo contacto con atención al cliente si tengo una incidencia o duda?",
+        "Para contactar con atención al cliente de Dbizi en caso de tener una incidencia o duda, puedes enviar un correo electrónico a mailto:soporte@dbizi.eus explicando lo que te ha ocurrido. Si se trata de una emergencia o de un problema más urgente, es recomendable llamar al 943 060 888, que está dedicado a averías. Fuente: https://www.dbizi.eus/es/preguntas-frecuentes",
+    ),
+    (
+        "¿Cómo puedo contactar con Dbizi?",
+        "Puedes contactar por WhatsApp/Telegram al 648 019 332, teléfono 943 060 888 y correo info@dbizi.eus. Fuente: https://www.dbizi.eus/es/contacto",
+    ),
+    (
+        "¿Qué pasa cuando no hay espacio disponible en una estación para devolver la bicicleta?",
+        "Si quieres dejar una bicicleta y la estación está llena, solicita la ampliación de 10 minutos adicionales sin coste en la app para poder llegar a la estación más próxima con espacio. Fuente: https://www.dbizi.eus/es/preguntas-frecuentes",
+    ),
+    (
+        "¿Existen descuentos para familias numerosas o empresas?",
+        "Sí, hay descuentos del 20% (normal) y 50% (especial) para familias numerosas, y descuentos para empresas a partir del sexto miembro. Fuente: https://www.dbizi.eus/es/tarifas",
+    ),
+    (
+        "¿Qué tipos de abonos existen, cuál es su duración y cómo funcionan los precios?",
+        "Hay abonos ordinarios (individual y grupal, 12 meses) y ocasionales (individual, 30 días). El abono grupal es para 2-5 personas. El abono no incluye viajes, se cobra por uso. Fuente: https://www.dbizi.eus/es/tarifas",
+    ),
+    (
+        "¿Qué ocurre si la estación está llena al devolver la bicicleta?",
+        "Si la estación está llena, el sistema te otorga 10 minutos extra para devolver la bicicleta en la estación más cercana sin coste adicional. Fuente: https://www.dbizi.eus/es/como-funciona",
+    ),
+    (
+        "¿En qué ámbito se pueden utilizar las bicicletas del sistema?",
+        "Las bicicletas del sistema podrán utilizarse única y exclusivamente dentro del término municipal de San Sebastián y deberán ser recogidas y devueltas en las estaciones del sistema. Fuente: https://www.dbizi.eus/es/preguntas-frecuentes",
+    ),
+    (
+        "¿A partir de qué edad está permitida la utilización del sistema?",
+        "El servicio está permitido a mayores de 16 años. Las personas de 16 o 17 años han de aportar la autorización del tutor legal como requisito indispensable para darse de alta. Fuente: https://www.dbizi.eus/es/preguntas-frecuentes",
+    ),
+    (
+        "¿Cuál es el horario de atención para contactos?",
+        "El horario publicado es Lunes-Viernes: 8h-16h. Fuente: https://www.dbizi.eus/es/contacto",
+    ),
+    (
+        "¿Cómo puedo inscribirme y quién puede hacerlo?",
+        "Puedes inscribirte en la web de Dbizi eligiendo la tarifa que prefieras. Los mayores de 16 y menores de 18 años pueden inscribirse con autorización. Fuente: https://www.dbizi.eus/es/como-funciona",
+    ),
+    (
+        "¿Qué es Dbizi?",
+        "Dbizi es el sistema de alquiler de bicicletas del Ayuntamiento de San Sebastián (Donostia). Fuente: https://www.dbizi.eus/es/bienvenido",
+    ),
+    (
+        "¿Cuántas bicicletas y estaciones hay?",
+        "Según la web, hay 317 bicicletas mecánicas, 317 bicicletas eléctricas y 70 estaciones. Fuente: https://www.dbizi.eus/es/bienvenido",
+    ),
+    (
+        "¿Dónde puedo consultar el mapa de estaciones y la disponibilidad de bicicletas?",
+        "En la sección 'Plano y estaciones' de la web puedes ver un mapa interactivo con la ubicación y disponibilidad de bicicletas en tiempo real. Fuente: https://www.dbizi.eus/es/plano-y-estaciones",
+    ),
+    (
+        "¿Qué tipos de bicicletas ofrece Dbizi y cómo se desbloquean?",
+        "Dbizi ofrece bicicletas mecánicas y eléctricas, que se desbloquean utilizando la app PBSC en tu móvil. Fuente: https://www.dbizi.eus/es/como-funciona",
+    ),
+]
+
+
+DATASET_NAME = "dbizi dataset"
+
+DATASET_DESCRIPTION = (
+    "FAQ de Dbizi con respuestas de referencia para evaluar al asistente."
+)
+
+
+def get_or_create_dataset(client: Client):
+    """Retrieves the dataset by name or creates it if it doesn't exist."""
+    existing = list(client.list_datasets(dataset_name=DATASET_NAME))
+
+    if existing:
+        dataset = existing[0]
+        print(f"ℹ️ Existing dataset '{DATASET_NAME}' -> {dataset.id}")
+        return dataset
+
+    dataset = client.create_dataset(
+        dataset_name=DATASET_NAME, description=DATASET_DESCRIPTION
+    )
+    print(f"✅ Dataset created '{DATASET_NAME}' -> {dataset.id}")
+    return dataset
+
+
+def main() -> None:
+    client = Client()
+
+    dataset = get_or_create_dataset(client)
+
+    # Build idempotent examples based on the question
+    existing_questions = {
+        example.inputs.get("question")
+        for example in client.list_examples(dataset_id=dataset.id)
+        if isinstance(example.inputs, dict)
+    }
+
+    examples = [
+        {
+            "inputs": {"question": input_prompt},
+            "outputs": {"answer": output_answer}, 
+        }
+        for input_prompt, output_answer in example_inputs
+        if input_prompt not in existing_questions
+    ]
+
+    if not examples:
+        print(
+            "ℹ️ The dataset already contains all questions, no new examples were added."
+        )
+        return
+
+    client.create_examples(
+        dataset_id=dataset.id,
+        examples=examples,
+    )
+
+    print(f"✅ Done: created {len(examples)} examples in dataset {dataset.id}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/langsmith/dbizi_dataset_eus.py
+++ b/scripts/langsmith/dbizi_dataset_eus.py
@@ -1,0 +1,132 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from langsmith import Client
+
+# Load environment variables from backend
+project_root = Path(__file__).parent.parent.parent
+load_dotenv(project_root / "backend" / ".env")
+
+example_inputs = [
+    (
+        "Nola hasten da zerbitzua bizikleta mekaniko zein elektriko batekin?",
+        "PBSC-ko app-aren bidez. Hautatu 'bizikleta bat lortu' aukera mapa nagusiaren barruan, eskaneatu QR kodea, eta itxaron argi horia berde jarri arte zure bizikleta hartu ahal izateko. 3 minutu dituzu bizikletaren egoera egiaztatzeko, eta egoera onean ez dagoela uste baduzu, itzuli dezakezu, eta beste bat hartu, 10 minutu itxaron beharrik gabe. Iturria: https://www.dbizi.eus/eu/ohiko-galderak",
+    ),
+    (
+        "Nola jarri naiteke harremanetan bezeroarentzako arreta zerbitzuarekin intzidentzia edo zalantza bat badut?",
+        "Dbiziko bezeroarentzako arreta zerbitzuarekin harremanetan jartzeko, mezu elektroniko bat bidal dezakezu mailto:soporte@dbizi.eus helbidera gertatutakoa azalduz. Larrialdi edo arazo larriagoetan, gomendagarria da 943 060 888 zenbakira deitzea; zenbaki hori aberientzako da. Iturria: https://www.dbizi.eus/eu/ohiko-galderak",
+    ),
+    (
+        "Nola jar naiteke harremanetan Dbizirekin?",
+        "WhatsApp/Telegram bidez 648 019 332 zenbakira, telefono bidez 943 060 888ra eta info@dbizi.eus helbidera idatziz jar zaitezke harremanetan. Iturria: https://www.dbizi.eus/eu/kontaktua",
+    ),
+    (
+        "Zer gertatzen da geltoki batean bizikleta itzultzeko lekurik ez dagoenean?",
+        "Bizikleta bat utzi nahi baduzu eta geltokia beteta badago, eskatu 10 minutu gehiago appean, kosturik gabe, zugandik hurbilen dagoen eta leku libreak dituen geltoki batera iritsi ahal izateko. Horrez gain, zerbitzuak geltoki+ sistema du honako geltoki hauetan: Añorga, Buenavista, Herrera, Txaparrene, Nornahi, Atarizar, Munto, Andoain, Tranbia, Urbia eta Av. Barcelona. Iturria: https://www.dbizi.eus/eu/ohiko-galderak",
+    ),
+    (
+        "Familia ugarientzako edo enpresentzako deskontuak badaude?",
+        "Bai, %20ko (ohikoa) eta %50eko (berezia) deskontuak daude familia ugarientzat, eta deskontuak enpresentzat seigarren kidetik aurrera. Iturria: https://www.dbizi.eus/eu/tarifak",
+    ),
+    (
+        "Zer bonu mota daude, zenbat irauten dute eta nola funtzionatzen dute prezioek?",
+        "Abonu arruntak daude (banakakoa eta taldekoa, 12 hilabete) eta noizbehinkakoak (banakakoa, 30 egun). Taldeko abonoa 2-5 pertsonarentzat da. Bonuak ez ditu bidaiak barne hartzen; erabileraren arabera kobratzen da. Iturria: https://www.dbizi.eus/eu/tarifak",
+    ),
+    (
+        "Zer gertatzen da bizikleta itzultzean geltokia beteta badago?",
+        "Geltokia beteta badago, sistemak 10 minutu gehigarri ematen dizkizu kosturik gabe bizikleta hurbileneko geltokian uzteko. Iturria: https://www.dbizi.eus/eu/nola-erabili",
+    ),
+    (
+        "Zein eremutan erabil daitezke sistemako bizikletak?",
+        "Sistemako bizikletak Donostiako udal mugartean baino ezingo dira erabili, eta sistemaren geltokietan jaso eta itzuli beharko dira. Iturria: https://www.dbizi.eus/eu/ohiko-galderak",
+    ),
+    (
+        "Zein adinetik aurrera erabil daiteke sistema?",
+        "Zerbitzua 16 urtetik gorakoentzat dago baimenduta. 16 edo 17 urteko pertsonek legezko tutorearen baimena aurkeztu/erantsi behar dute, alta emateko ezinbesteko baldintza baita. Iturria: https://www.dbizi.eus/eu/ohiko-galderak",
+    ),
+    (
+        "Zein da harremanetarako arreta ordutegia?",
+        "Argitaratutako ordutegia astelehenetik ostiralera 8:00etatik 16:00etara da. Iturria: https://www.dbizi.eus/eu/kontaktua",
+    ),
+    (
+        "Nola eman dezaket izena eta nork egin dezake?",
+        "Dbiziren webgunean eman dezakezu izena aukeratzen duzun tarifa hautatuz. 16 urtetik gorako eta 18 urtetik beherako pertsonek baimenarekin eman dezakete izena. Iturria: https://www.dbizi.eus/eu/nola-erabili",
+    ),
+    (
+        "Zer da Dbizi?",
+        "Dbizi Donostiako Udalaren bizikleta alokairu sistema da. Iturria: https://www.dbizi.eus/eu/ongi-etorri",
+    ),
+    (
+        "Zenbat bizikleta eta geltoki daude?",
+        "Webguneak dioenez, 317 bizikleta mekaniko, 317 bizikleta elektriko eta 70 geltoki daude. Iturria: https://www.dbizi.eus/eu/ongi-etorri",
+    ),
+    (
+        "Non kontsulta dezaket geltokien mapa eta bizikleten erabilgarritasuna?",
+        "Webguneko 'Mapa eta geltokiak' atalean mapa interaktibo bat ikus dezakezu bizikleten kokapena eta erabilgarritasuna denbora errealean kontsultatzeko. Iturria: https://www.dbizi.eus/eu/mapa-eta-geltokiak",
+    ),
+    (
+        "Zer motatako bizikletak eskaintzen ditu Dbizik eta nola desblokeatzen dira?",
+        "Dbizik bizikleta mekanikoak eta elektrikoak eskaintzen ditu; mugikorrean PBSC aplikazioa erabiliz desblokeatzen dira. Iturria: https://www.dbizi.eus/eu/nola-erabili",
+    ),
+]
+
+DATASET_NAME = "dbizi dataset eus"
+DATASET_DESCRIPTION = (
+    "Dbiziren maiz egiten diren galderak erantzun erreferentedunekin, laguntzailea ebaluatzeko."
+)
+
+
+def get_or_create_dataset(client: Client):
+    """Retrieves the dataset by name or creates it if it doesn't exist."""
+    existing = list(client.list_datasets(dataset_name=DATASET_NAME))
+
+    if existing:
+        dataset = existing[0]
+        print(f"ℹ️ Existing dataset '{DATASET_NAME}' -> {dataset.id}")
+        return dataset
+
+    dataset = client.create_dataset(
+        dataset_name=DATASET_NAME, description=DATASET_DESCRIPTION
+    )
+    print(f"✅ Dataset created '{DATASET_NAME}' -> {dataset.id}")
+    return dataset
+
+
+def main() -> None:
+    client = Client()
+
+    dataset = get_or_create_dataset(client)
+
+    # Build idempotent examples based on the question
+    existing_questions = {
+        example.inputs.get("question")
+        for example in client.list_examples(dataset_id=dataset.id)
+        if isinstance(example.inputs, dict)
+    }
+
+    examples = [
+        {
+            "inputs": {"question": input_prompt},
+            "outputs": {"answer": output_answer}, 
+        }
+        for input_prompt, output_answer in example_inputs
+        if input_prompt not in existing_questions
+    ]
+
+    if not examples:
+        print(
+            "ℹ️ The dataset already contains all questions, no new examples were added."
+        )
+        return
+
+    client.create_examples(
+        dataset_id=dataset.id,
+        examples=examples,
+    )
+
+    print(f"✅ Done: created {len(examples)} examples in dataset {dataset.id}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/langsmith/evaluate_assistant.py
+++ b/scripts/langsmith/evaluate_assistant.py
@@ -1,0 +1,195 @@
+# evaluations/evaluate_assistant.py
+import os
+import requests
+import re
+from pathlib import Path
+from typing import Dict, Any, Union
+from dotenv import load_dotenv
+from langsmith import evaluate, Client, wrappers
+from langsmith.schemas import Run, Example
+from openai import OpenAI
+
+# Load environment variables from backend
+project_root = Path(__file__).parent.parent.parent
+load_dotenv(project_root / "backend" / ".env")
+
+# Configuration
+API_BASE_URL = "http://localhost:9099"
+JWT_TOKEN = "your_jwt_token_here"  # Replace with your actual JWT token
+ASSISTANT_ID = 1  # Replace with your actual assistant ID
+DATASET_NAME = "dbizi dataset"
+
+# Initialize OpenAI client for the evaluator
+openai_client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+def chat_with_assistant(
+    token: str,
+    assistant_id: int,
+    message: str,
+    stream: bool = False,
+    base_url: str = API_BASE_URL
+) -> Union[Dict[Any, Any], requests.Response]:
+    """
+    Sends a message to an assistant and gets the response.
+    """
+    url = f"{base_url}/creator/assistant/{assistant_id}/chat/completions"
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json"
+    }
+
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": message
+            }
+        ],
+        "stream": stream
+    }
+
+    response = requests.post(url, json=payload, headers=headers, stream=stream)
+    response.raise_for_status()
+
+    if stream:
+        return response
+    else:
+        return response.json()
+
+
+def ask_question(question: str) -> str:
+    """
+    Sends a question to the assistant and returns the response.
+    """
+    try:
+        response = chat_with_assistant(
+            token=JWT_TOKEN,
+            assistant_id=ASSISTANT_ID,
+            message=question,
+            stream=False
+        )
+        
+        # Adjust this according to your actual response format
+        if isinstance(response, dict) and "choices" in response:
+            return response["choices"][0]["message"]["content"]
+        else:
+            return str(response)
+    
+    except Exception as e:
+        print(f"Error processing question '{question}': {e}")
+        return None
+
+
+def target_function(inputs: dict) -> dict:
+    """
+    Target function for LangSmith evaluate.
+    
+    Receives inputs from the dataset and returns outputs that the evaluator can use.
+    """
+    question = inputs["question"]
+    answer = ask_question(question)
+    return {"output": answer}
+
+def similarity_score_evaluator(run: Run, example: Example) -> dict:
+    """
+    LLM-as-a-Judge evaluator that assesses the similarity between the 
+    generated output and the reference output, given an input context.
+    
+    Returns a score from 1-10 where:
+    - 1 is the least similar
+    - 10 is almost identical
+    
+    Args:
+        run: Contains the generated output
+        example: Contains the input and the reference output (answer)
+    """
+    # Extract data
+    input_text = example.inputs.get("question", "")
+    output_text = run.outputs.get("output", "")
+    reference_output = example.outputs.get("answer", "")
+    
+    # Build the prompt according to LangSmith structure
+    system_prompt = """You are an expert at comparing two answers.
+You are assessing a similarity between the reference and the submission output, given an input question as context."""
+    
+    user_prompt = f"""Please grade the following example according to the above instructions:
+
+<example>
+<input>
+{input_text}
+</input>
+
+<output>
+{output_text}
+</output>
+
+<reference_outputs>
+{reference_output}
+</reference_outputs>
+</example>
+
+IMPORTANT: You must end your response with exactly this format:
+Grade:X
+where X is a number from 1 to 10 indicating the similarity score."""
+    
+    try:
+        # Call the LLM judge (gpt-4o-mini)
+        response = openai_client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt}
+            ],
+            temperature=0
+        )
+        
+        # Get the response
+        judge_response = response.choices[0].message.content
+
+        # Extract the numeric score in "Grade:X" format
+        score_match = re.search(r'Grade:\s*([1-9]|10)', judge_response, re.IGNORECASE)
+        
+        if score_match:
+            score = int(score_match.group(1))
+        else:
+            score = 0
+        
+    except Exception as e:
+        print(f"Error in LLM evaluator: {e}")
+        score = 0  # Default score in case of error
+    
+    return {
+        "key": "similarity",
+        "score": score
+    }
+
+def run_evaluation():
+    """
+    Runs the assistant evaluation using an LLM-as-a-judge evaluator.
+    """
+    print(f"🚀 Starting evaluation of assistant {ASSISTANT_ID}")
+    print(f"📊 Dataset: {DATASET_NAME}")
+    print(f"🌐 API URL: {API_BASE_URL}")
+    
+    client = Client()
+    
+    results = evaluate(
+        target_function,
+        data=DATASET_NAME,
+        experiment_prefix="Dbizi test",
+        evaluators=[similarity_score_evaluator],
+        metadata={
+            "keyword": "test",
+            "assistant_id": ASSISTANT_ID,
+            "base_url": API_BASE_URL,
+        }
+    )
+    
+    print("\n✅ Evaluation completed")
+    print(f"📊 Review the results in LangSmith")
+    return results
+
+
+if __name__ == "__main__":
+    run_evaluation()

--- a/scripts/langsmith/evaluate_assistant.py
+++ b/scripts/langsmith/evaluate_assistant.py
@@ -19,6 +19,7 @@ API_BASE_URL = os.getenv("API_BASE_URL")
 JWT_TOKEN = os.getenv("JWT_TOKEN")
 ASSISTANT_ID = int(os.getenv("ASSISTANT_ID"))
 DATASET_NAME = os.getenv("DATASET_NAME")
+EVALUATOR_MODEL = os.getenv("EVALUATOR_MODEL", "gpt-4.1")
 
 # Initialize OpenAI client for the evaluator
 openai_client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
@@ -133,9 +134,9 @@ You are assessing a similarity between the reference and the submission output, 
 IMPORTANT: Your response MUST be in the format "Grade:X",where X is a number from 1 to 10 indicating the similarity score."""
     
     try:
-        # Call the LLM judge (gpt-4.1)
+        # Call the LLM judge
         response = openai_client.chat.completions.create(
-            model="gpt-4.1",
+            model=EVALUATOR_MODEL,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}

--- a/scripts/langsmith/evaluate_assistant.py
+++ b/scripts/langsmith/evaluate_assistant.py
@@ -9,15 +9,16 @@ from langsmith import evaluate, Client, wrappers
 from langsmith.schemas import Run, Example
 from openai import OpenAI
 
-# Load environment variables from backend
+# Load environment variables from lamb-kb-server-stable backend
 project_root = Path(__file__).parent.parent.parent
+load_dotenv(project_root / "lamb-kb-server-stable" / "backend" / ".env")
 load_dotenv(project_root / "backend" / ".env")
 
-# Configuration
-API_BASE_URL = "http://localhost:9099"
-JWT_TOKEN = "your_jwt_token_here"  # Replace with your actual JWT token
-ASSISTANT_ID = 1  # Replace with your actual assistant ID
-DATASET_NAME = "dbizi dataset"
+# Configuration - Load from environment variables
+API_BASE_URL = os.getenv("API_BASE_URL")
+JWT_TOKEN = os.getenv("JWT_TOKEN")
+ASSISTANT_ID = int(os.getenv("ASSISTANT_ID"))
+DATASET_NAME = os.getenv("DATASET_NAME")
 
 # Initialize OpenAI client for the evaluator
 openai_client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))

--- a/scripts/langsmith/evaluate_assistant.py
+++ b/scripts/langsmith/evaluate_assistant.py
@@ -111,7 +111,7 @@ def similarity_score_evaluator(run: Run, example: Example) -> dict:
     
     # Build the prompt according to LangSmith structure
     system_prompt = """You are an expert at comparing two answers.
-You are assessing a similarity between the reference and the submission output, given an input question as context."""
+You are assessing a similarity between the reference and the submission output, given an input question as context. Similarity will have a high score if the answers are very close in meaning and low score if they are very different. Both answers may contain additional information, but focus on the core answer to the question. Both answers must be in the same language as the question."""
     
     user_prompt = f"""Please grade the following example according to the above instructions:
 
@@ -129,14 +129,12 @@ You are assessing a similarity between the reference and the submission output, 
 </reference_outputs>
 </example>
 
-IMPORTANT: You must end your response with exactly this format:
-Grade:X
-where X is a number from 1 to 10 indicating the similarity score."""
+IMPORTANT: Your response MUST be in the format "Grade:X",where X is a number from 1 to 10 indicating the similarity score."""
     
     try:
-        # Call the LLM judge (gpt-4o-mini)
+        # Call the LLM judge (gpt-4.1)
         response = openai_client.chat.completions.create(
-            model="gpt-4o-mini",
+            model="gpt-4.1",
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
@@ -146,9 +144,9 @@ where X is a number from 1 to 10 indicating the similarity score."""
         
         # Get the response
         judge_response = response.choices[0].message.content
-
+        print(f"Judge response: {judge_response}")
         # Extract the numeric score in "Grade:X" format
-        score_match = re.search(r'Grade:\s*([1-9]|10)', judge_response, re.IGNORECASE)
+        score_match = re.search(r'Grade:\s*(10|[1-9])', judge_response, re.IGNORECASE)
         
         if score_match:
             score = int(score_match.group(1))


### PR DESCRIPTION
Added 2 scripts in scripts/langsmith:
-dbizi_dataset.py (creates a dataset in LangSmith with 15 questions about dbizi)
-evaluate_assistant.py (an llm-as-a-judge evaluates a given lamb assistant with the given dataset in LangSmith)

To try them, first configure these LangSmith env variables in backend/.env:
-LANGCHAIN_TRACING_V2=true
-LANGCHAIN_API_KEY=YOUR_LANGCHAIN_API_KEY
-LANGCHAIN_PROJECT=lamb-assistants
-LANGCHAIN_ENDPOINT=https://api.smith.langchain.com

And these 2 variables in evaluate_assistant.py:
-JWT_TOKEN = "your_jwt_token_here" 
-ASSISTANT_ID = 1 (this should be the id of the dbizi assistant in lamb)

Then, run the scripts:
-first, dbizi_dataset.py
-then, evaluate_assistant.py
