### PR TITLE
hot fix, not working properly docker compilation, error that in impor…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "lamb-frontend",
+    "private": true,
+    "version": "1.0.0",
+    "description": "LAMB Frontend Monorepo"
+}

--- a/frontend/packages/creator-app/src/lib/components/evaluaitor/RubricAIChat.svelte
+++ b/frontend/packages/creator-app/src/lib/components/evaluaitor/RubricAIChat.svelte
@@ -1,6 +1,6 @@
 <script>
   import { createEventDispatcher } from 'svelte';
-  import { _, locale } from '@lamb/ui/i18n';
+  import { _, locale } from '@lamb/ui';
 
   // Props
   let { rubricId, aiGenerating } = $props();

--- a/frontend/packages/creator-app/src/lib/version.js
+++ b/frontend/packages/creator-app/src/lib/version.js
@@ -3,8 +3,8 @@
 
 export const VERSION_INFO = {
   "version": "0.5",
-  "commit": "308814ad",
+  "commit": "3c966593",
   "branch": "feature/issue#277/Architecture_Activity_Module_System_Extensible_LTI_App_Framework",
-  "commitDate": "2026-03-08",
+  "commitDate": "2026-03-09",
   "buildDate": "2026-03-09"
 };

--- a/frontend/packages/module-chat/src/lib/version.js
+++ b/frontend/packages/module-chat/src/lib/version.js
@@ -3,8 +3,8 @@
 
 export const VERSION_INFO = {
   "version": "0.5",
-  "commit": "308814ad",
+  "commit": "3c966593",
   "branch": "feature/issue#277/Architecture_Activity_Module_System_Extensible_LTI_App_Framework",
-  "commitDate": "2026-03-08",
+  "commitDate": "2026-03-09",
   "buildDate": "2026-03-09"
 };


### PR DESCRIPTION
# 🔧 Hotfix: Remove legacy `svelte-app/` and fix build breakage

**Issue:** #277 — Architecture: Activity Module System

## Summary

Removes the legacy `frontend/svelte-app/` directory (superseded by the monorepo in Phase 2) and fixes the resulting build failures.

## Problem

After deleting `svelte-app/`, Docker's `frontend-build` service failed with two issues:

1. **Missing root `package.json`** — pnpm workspaces require a `package.json` at the workspace root (alongside `pnpm-workspace.yaml`). Without it, `pnpm install` fails silently.
2. **Broken i18n import in `RubricAIChat.svelte`** — The component imported `{ _, locale }` from `'$lib/i18n'`, a path that doesn't exist in `creator-app`. All sibling evaluaitor components correctly use `'@lamb/ui'`.

## Changes

| File | Change |
|---|---|
| `frontend/svelte-app/` | **Deleted** — all code was migrated to `packages/creator-app/` in Phase 2 |
| `frontend/package.json` | **New** — minimal root `package.json` for pnpm workspace (`private: true`, no deps) |
| `frontend/packages/creator-app/src/lib/components/evaluaitor/RubricAIChat.svelte` | Fixed import: `'$lib/i18n'` → `'@lamb/ui'` |

## Verification

- `module-chat` builds successfully ✅
- `creator-app` builds successfully after import fix ✅
- Docker Compose `frontend-build` service completes without errors ✅
