### PR TITLE
Feature/issue#277/phase4 lamba port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,11 @@ testing/package-lock.json
 testing/playwright/test-results/.last-run.json
 backend/static/cache
 docker-compose.yaml
+.pnpm-store/
+backend/testing/
+backend/uploads/
+frontend/packages/
+
 
 
 ./clinerules

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ config.json
 frontend/svelte-app/.svelte-kit/
 frontend/svelte-app/package-lock.json
 frontend/svelte-app/src/lib/version.js
-/frontnend/svelte-app
+/frontend/svelte-app
 /frontend/package
 /frontend/.env
 /frontend/.env.*
@@ -201,7 +201,7 @@ docker-compose.yaml
 .pnpm-store/
 backend/testing/
 backend/uploads/
-frontend/packages/
+
 
 
 #OPENCODE

--- a/Documentation/352-resilience-fixes-repro.md
+++ b/Documentation/352-resilience-fixes-repro.md
@@ -1,0 +1,415 @@
+# Frontend Resilience Phase 1 — Repro + Verification
+
+Companion document to issue **#352** ("Frontend resilience audit") and the architecture-doc section §9.6 ("Frontend Resilience Patterns").
+
+This doc documents the **5 bugs fixed in Phase 1** on branch `fix/352-frontend-resilience-phase1`. For each bug it gives:
+1. **Files changed** — exact lines
+2. **Repro before fix** — concrete steps that demonstrate the broken behavior on the original code
+3. **Verify after fix** — same steps, with the expected fixed behavior
+
+All repros assume:
+- Docker compose stack running (`docker compose up`)
+- Frontend dev server on `http://localhost:5173`
+- A browser with DevTools open (Network + Console tabs)
+- A working test account with creator role
+
+## Switching between fixed and broken code for repro
+
+```bash
+# To see the BROKEN behavior, check out the parent commit:
+git stash                                   # if you have local changes
+git checkout 4b38f05d -- <file>             # restore one file at a time
+# …reproduce…
+git checkout fix/352-frontend-resilience-phase1 -- <file>   # restore fix
+```
+
+Or, simpler, run repros on `dev` (origin tip) and verifications on `fix/352-frontend-resilience-phase1`.
+
+---
+
+## Bug H1 — `+layout.js` blanks the entire app on locale load failure
+
+**File:** `frontend/svelte-app/src/routes/+layout.js:28-33`
+**Pattern:** F (top-level `await` with no fallback)
+
+### Repro before fix (broken)
+
+Simulate locale JSON load failure, e.g. by intercepting `/locales/en.json` with the browser DevTools "Network conditions" → block-request feature, or by temporarily renaming the file:
+
+```bash
+# Method 1 — rename one of the locale JSON files to force a 404
+mv /opt/lamb/frontend/svelte-app/src/lib/locales/en.json \
+   /opt/lamb/frontend/svelte-app/src/lib/locales/en.json.bak
+```
+
+1. Reload `http://localhost:5173/`.
+2. **Expected broken behavior:** the page renders blank/white. The browser console shows an unhandled rejection from `waitLocale()`. SvelteKit's `load()` has rejected, so the entire layout failed to render.
+3. Restore: `mv …en.json.bak …en.json`.
+
+### Verify after fix
+
+With the fix in place, repeat the same steps:
+
+```bash
+mv /opt/lamb/frontend/svelte-app/src/lib/locales/en.json \
+   /opt/lamb/frontend/svelte-app/src/lib/locales/en.json.bak
+```
+
+1. Reload `http://localhost:5173/`.
+2. **Expected fixed behavior:** the page renders. The console logs `waitLocale failed, continuing with fallback`. Some labels may show their i18n key (`auth.email`) instead of translated text, but the app is usable. The user can navigate, log in, etc.
+3. Restore the locale file.
+
+---
+
+## Bug H2 — `Login.svelte` login button stuck spinning on unexpected throw
+
+**File:** `frontend/svelte-app/src/lib/components/Login.svelte:27-83`
+**Pattern:** A (loading flag without `try/finally`)
+
+The `login()` service has its own `try/catch` returning `{success:false}`, so this only triggers if a downstream call (e.g. `replaceSessionWithLoginData()`) throws unexpectedly. The fix is defense-in-depth: wrap the entire submit handler in `try/finally`.
+
+### Repro before fix (broken)
+
+Easiest synthetic repro: temporarily make `replaceSessionWithLoginData` throw.
+
+```javascript
+// Edit frontend/svelte-app/src/lib/session/sessionManager.js
+// Inside replaceSessionWithLoginData, before clearCurrentSession():
+if (browser) throw new Error('Synthetic failure for repro');
+```
+
+1. Open `http://localhost:5173/`, click login, enter valid creator credentials, click Submit.
+2. **Expected broken behavior:** spinner spins forever. Submit button stays disabled. Console shows the synthetic error. User must reload the page.
+3. Revert the synthetic throw.
+
+### Verify after fix
+
+Apply the same synthetic throw with the fix in place.
+
+1. Submit the login form with valid credentials.
+2. **Expected fixed behavior:** spinner stops, button is re-enabled, an error message is shown ("Synthetic failure for repro"). User can correct and try again — no reload required.
+3. Revert the synthetic throw.
+
+---
+
+## Bug H3 — AAC stream keeps running after navigation away
+
+**File:** `frontend/svelte-app/src/lib/services/aacService.js:111-180`
+**Companion:** `frontend/svelte-app/src/lib/components/aac/AacTerminal.svelte` (AbortController wiring + `onDestroy`)
+**Pattern:** E (timer/stream not cleaned up)
+
+### Repro before fix (broken)
+
+1. Log in. Navigate to `/agent`. Start a new AAC session with a slow-responding skill (or just any conversation that streams for several seconds).
+2. Send a message that will produce a long answer (e.g. "Explain assistant authoring step by step in detail").
+3. While the response is streaming, immediately click another nav link (e.g. `/assistants`).
+4. Open DevTools → Network → filter by `/aac/sessions/.../message/stream`.
+5. **Expected broken behavior:** the request is still pending (status: pending). Open DevTools → Performance Memory; the fetch reader keeps decoding chunks in the background. If you watch long enough, the stream eventually completes server-side and chunks keep arriving, attempting to update component state on a destroyed component (Svelte 5 may swallow these silently, but the network traffic and CPU are real).
+
+### Verify after fix
+
+Repeat the same steps.
+
+1. Send a long-streaming message.
+2. Navigate away mid-stream.
+3. **Expected fixed behavior:** the `/aac/sessions/.../message/stream` request shows status `(canceled)` in DevTools Network within ~1 frame after navigation. No further chunks arrive. No errors in console. Memory does not grow.
+
+Additional check — abort on rapid same-page resend:
+4. Stay on `/agent`. Send message A (streaming). Before A completes, send message B.
+5. **Expected fixed behavior:** request A is canceled, request B starts cleanly. (Without the fix, both run concurrently and chunks interleave into the wrong message slot.)
+
+---
+
+## Bug AacTerminal defensive try/finally on `loading`
+
+**File:** `frontend/svelte-app/src/lib/components/aac/AacTerminal.svelte` — `handleSend()` and `triggerSkillStartup()`
+**Pattern:** A (defense-in-depth)
+
+Note: the original code already reset `loading = false` after the `try/catch` block, so this is not a real bug today. The fix adds `try/finally` so any future code path that throws between `loading = true` and the reset cannot leak the flag. The mounted-check (`if (isMounted)`) prevents stale-state writes after `onDestroy`.
+
+### Verify after fix (sanity check)
+
+1. Send a message in AAC.
+2. While streaming, navigate away.
+3. Navigate back to the same session.
+4. **Expected fixed behavior:** session loads cleanly, send button is enabled, no stale "loading" state from the prior stream. (Without the mount-check, `loading = false` could fire on an unmounted instance, causing Svelte 5 dev warnings.)
+
+---
+
+## Bug H8 — `AssistantsList` retry recursion runs after unmount
+
+**File:** `frontend/svelte-app/src/lib/components/AssistantsList.svelte:138-167`
+**Pattern:** B (`await` in lifecycle without mounted-check)
+
+### Repro before fix (broken)
+
+The retry path triggers when the first `getAssistants()` call throws, then waits 1 second, then retries. To repro:
+
+1. In DevTools, set Network throttling to "Offline".
+2. Navigate to `/assistants`. The fetch fails. Component logs "Will retry loading assistants in 1 second...".
+3. **Within that 1-second window**, click another nav link (e.g. `/knowledge-bases`).
+4. Set Network throttling back to "No throttling".
+5. **Expected broken behavior:** in the console, see Svelte warnings about state updates on destroyed components, OR the next time you visit `/assistants`, briefly see the previous fetch's stale data flash before the new fetch runs. The retry call recurses on a destroyed component.
+
+### Verify after fix
+
+Repeat the same steps.
+
+1. Trigger the retry path (offline → navigate to `/assistants` → wait for fail).
+2. Navigate away within the 1-second retry window.
+3. Restore network.
+4. **Expected fixed behavior:** the retry's `setTimeout` resolves but the function bails out at the `if (!isMounted) return;` guard. No state writes on the destroyed component. No console warnings. Re-navigating to `/assistants` triggers a fresh load cleanly.
+
+---
+
+## Smoke test — full Phase 1 verification in one pass
+
+Run this end-to-end flow to confirm all five fixes are in place:
+
+```
+Step 1.  Stop docker compose.
+Step 2.  Move /opt/lamb/frontend/svelte-app/src/lib/locales/en.json to en.json.bak
+Step 3.  Start docker compose, open http://localhost:5173/
+         ✓ EXPECT: page loads (not blank). Some text in i18n keys is OK.
+Step 4.  Restore en.json.
+Step 5.  Reload. Login with valid credentials.
+         ✓ EXPECT: clean login, redirect to /assistants.
+Step 6.  In DevTools, throttle to Offline.
+Step 7.  Click /assistants in nav.
+         ✓ EXPECT: error state shown OR retry message in console.
+Step 8.  Within 1 second, click /knowledge-bases.
+Step 9.  Restore network throttling.
+         ✓ EXPECT: no Svelte warnings about destroyed-component updates.
+Step 10. Navigate to /agent. Start a new conversation.
+Step 11. Send a long-form message ("Explain in detail…").
+Step 12. While streaming, click /assistants.
+         ✓ EXPECT: in Network tab, the /aac/sessions/.../message/stream request
+                   shows (canceled) within a frame.
+Step 13. Navigate back to /agent. Resume the session.
+         ✓ EXPECT: send button is enabled. Conversation history is shown.
+                   No "loading" stuck state.
+```
+
+---
+
+## Phase 2 fixes
+
+Phase 2 added five more fixes on top of Phase 1.
+
+### Bug M1/M2/M3 — Mid-session token expiry leaves UI broken
+
+**File:** new `frontend/svelte-app/src/lib/services/apiClient.js`
+**Pattern:** D (no global 401 handler)
+
+Migrated services: `aacService.js` (incl. streaming), `authService.js` (`fetchUserProfile`, `getHelp`), `adminService.js` (all 8 functions), `AssistantForm.svelte` file upload.
+
+#### Repro before fix (broken)
+
+1. Log in normally.
+2. Open DevTools → Application → Local Storage → set `userToken` to `"invalid-token-xxx"` (or wait long enough for the OWI session to expire naturally).
+3. Click around — try /assistants, /agent, /knowledgebases.
+4. **Expected broken behavior:** APIs all return 401. Each component shows its own generic error (e.g. "HTTP 401" in AAC, "Failed to fetch" in admin, blank lists elsewhere). The user remains on the same page, sees errors, and has to **manually reload** to recover. *This is the original symptom you reported.*
+
+#### Verify after fix
+
+Repeat the same steps.
+
+1. Log in, then corrupt the token in localStorage.
+2. Click any nav link.
+3. **Expected fixed behavior:** the first 401 immediately clears the session and redirects to the login screen at `/`. The user logs in again and proceeds. No reload needed.
+
+Mid-stream test (covers M1):
+4. Log in, navigate to `/agent`, start a conversation.
+5. Open DevTools console and run: `localStorage.setItem('userToken', 'invalid-xxx')`
+6. Send a message.
+7. **Expected fixed behavior:** the stream returns 401, `apiFetch` triggers session reset and redirect. The terminal does NOT paint "HTTP 401" (the error path detects "Session expired" and exits quietly).
+
+### Bug H10 — `KnowledgeBasesList` silent empty on dual failure
+
+**File:** `frontend/svelte-app/src/lib/components/KnowledgeBasesList.svelte:93-118`
+
+#### Repro before fix (broken)
+
+1. Stop the KB Server: `docker compose stop kb`
+2. Log in. Navigate to `/knowledgebases`.
+3. **Expected broken behavior:** page shows empty list with no error indicator. User has no way to know why their KBs aren't showing.
+
+#### Verify after fix
+
+1. Stop the KB Server.
+2. Navigate to `/knowledgebases`.
+3. **Expected fixed behavior:** error banner shown (e.g. "Failed to load knowledge bases" or "server offline"). User knows to retry / contact admin.
+4. Restart KB Server: `docker compose start kb`. Reload — list populates.
+
+Partial-failure variant: if `getUserKnowledgeBases()` succeeds but `getSharedKnowledgeBases()` fails, the user sees their owned KBs (no banner; the partial result is more useful than an error).
+
+### Bug H11 — `AssistantForm` file upload — token-expiry mid-upload
+
+**File:** `frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte:760-820`
+
+#### Repro before fix (broken)
+
+1. Open assistant edit form. Open the file panel.
+2. In DevTools, corrupt `localStorage.userToken`.
+3. Click "Upload file" and select a file.
+4. **Expected broken behavior:** spinner spins, eventually shows "API error: 401 - …" but the user is still logged in (token in localStorage is now bogus). Every other action will also fail.
+
+#### Verify after fix
+
+Repeat steps.
+
+1. Corrupt token, click upload.
+2. **Expected fixed behavior:** session is cleared immediately on 401 and the user is redirected to login. No misleading "API error" banner persists in the form.
+
+### Bug H12 — `assistantStore` blank list on unexpected response shape
+
+**File:** `frontend/svelte-app/src/lib/stores/assistantStore.js:80-110`
+
+#### Repro before fix (broken)
+
+This is an edge case triggered when the backend returns something other than `{ assistants: [...] }`. Synthetic repro:
+
+```javascript
+// Edit frontend/svelte-app/src/lib/services/assistantService.js
+// Inside getAssistants(), before return:
+return { /* missing assistants key */ total_count: 0 };
+```
+
+1. Reload `/assistants`.
+2. **Expected broken behavior:** Svelte iterates `state.items` — which is now `undefined` — and the page throws or renders blank. Console shows "Cannot read property of undefined".
+
+#### Verify after fix
+
+Apply the same synthetic shape change.
+
+1. Reload `/assistants`.
+2. **Expected fixed behavior:** list shows "No assistants" cleanly. Store error stays `null`. Defensive `Array.isArray()` coerced the bad shape to `[]`.
+
+### Bug H6 — `GlobalAacTabBar` 500ms polling
+
+**Files:** `frontend/svelte-app/src/lib/stores/aacStore.svelte.js`, `GlobalAacTabBar.svelte`, `AacTabBar.svelte`, `agent/+page.svelte`, `assistants/+page.svelte`
+
+The store was migrated from Svelte 5 `$state` runes to `writable()` so cross-module reactivity works without polling.
+
+#### Repro before fix (high CPU, hard to user-perceive)
+
+1. Open `/agent`, open DevTools → Performance.
+2. Start a recording with no user interaction.
+3. **Expected broken behavior:** Performance trace shows `setInterval` callback firing every 500ms, each running a Svelte component reconciliation pass even though nothing changed. CPU non-zero at idle.
+
+#### Verify after fix
+
+1. Same recording.
+2. **Expected fixed behavior:** no periodic activity. Timer is gone from the trace. Tab bar still updates instantly when you open/close tabs from any other component (subscribe-based reactivity instead of polling).
+
+Function-level smoke test:
+3. Open assistant A, launch an AAC skill (creates a tab). Switch to a different page. Open assistant B, launch another skill (second tab).
+4. **Expected fixed behavior:** both tabs visible in the global tab bar without delay. Closing a tab from anywhere updates the bar instantly.
+
+---
+
+## Phase 3 fixes
+
+Phase 3 broadened the 401 coverage to all axios- and fetch-based services, and addressed Library Manager polling/abort + remaining mounted-checks.
+
+### Axios-based services — global 401 via shared instance
+
+**Files changed:**
+- `apiClient.js` — exports new `apiAxios` instance with request/response interceptors
+- `knowledgeBaseService.js`, `assistantService.js`, `analyticsService.js`, `libraryService.js`, `templateService.js` — all swapped `import axios from 'axios'` for the shared instance
+
+**Why this matters:** before Phase 3, every KB/assistant/analytics/library/template call still went through plain axios with no 401 handling. Token expiry while browsing any of those screens left the user with raw error banners. Now every axios call goes through the shared instance — same global session-recovery semantics as `apiFetch`.
+
+#### Repro before fix
+
+1. Log in. Navigate to `/knowledgebases`.
+2. In DevTools: `localStorage.setItem('userToken', 'invalid')`.
+3. Click any KB.
+4. **Expected broken behavior:** axios 401 surfaces as a "Failed to fetch" or "Request failed with status 401" error in the panel. User stays on the page; every subsequent action also 401s.
+
+#### Verify after fix
+
+Repeat steps. **Expected fixed behavior:** the first 401 redirects to login. No "Failed to fetch" banner persists. Same applies for `/assistants` (assistantService), `/libraries` (libraryService), the analytics dashboard, and prompt-template management.
+
+### `testService.js`, `rubricService.js`, `organizationService.js` — fetch-based migration
+
+Migrated to `apiFetch` / `apiJson` from `apiClient`. Same effect — 401 redirects to login.
+
+### Bug M4 — Library Manager rapid-switching shows stale data
+
+**File:** `frontend/svelte-app/src/lib/components/libraries/LibraryDetail.svelte:60-90`
+
+#### Repro before fix
+
+1. Open `/libraries`. Have 2+ libraries.
+2. Click library A. While it's loading (slow connection helps), click library B.
+3. **Expected broken behavior:** library A's data may briefly show after B's selection. Items list flickers. Polling may target the wrong library ID.
+
+#### Verify after fix
+
+Same steps. **Expected fixed behavior:** only B's data is shown. The earlier A fetch completes silently with no state writes (dropped via `currentLoadId` sequence check).
+
+### Bug M5 — Library item poll silently swallows errors
+
+**File:** `LibraryDetail.svelte` — `pollPendingItems()`
+
+#### Repro before fix
+
+1. Open a library with a "processing" item. Polling starts.
+2. Stop the Library Manager: `docker compose stop library-manager`.
+3. **Expected broken behavior:** poll keeps firing every 3s. Items remain "processing" forever. Console shows network errors. User has no indication anything is wrong.
+
+#### Verify after fix
+
+Same steps. **Expected fixed behavior:** after 5 consecutive failed polls (~15 seconds), polling stops and an error banner says "Lost connection while checking item status. Reload to retry."
+
+### Bug M6 — Library success-message timeout leaks on unmount
+
+**File:** `LibraryDetail.svelte` — `showSuccess()` + `onDestroy`
+
+#### Repro before fix
+
+Hard to user-perceive. Synthetic check:
+
+1. In LibraryDetail, trigger a success (e.g. upload a file). Within 4 seconds, navigate away.
+2. **Expected broken behavior (Svelte dev mode):** console warning about state update on destroyed component when the timeout fires.
+
+#### Verify after fix
+
+Same steps. **Expected fixed behavior:** no warning. Timeout is cleared in `onDestroy`. `if (isMounted)` guards the assignment.
+
+### Bug M7 — Library polling continues across `libraryId` changes
+
+**File:** `LibraryDetail.svelte` — covered together with M4 above. The `currentLoadId` sequence check + `if (!isMounted) return` in the poll loop handle both rapid switching and unmount.
+
+### Bug M12 — Assistants page overlapping detail fetches
+
+**File:** `routes/assistants/+page.svelte:277-310`
+
+#### Repro before fix
+
+1. From assistants list, click assistant A. While loading, click B. While that loads, click C.
+2. **Expected broken behavior:** the detail panel may show A's fields after C is selected. URL shows C but content is stale.
+
+#### Verify after fix
+
+Same steps. **Expected fixed behavior:** only C's data shown. Stale fetches dropped via `detailFetchSeq` sequence check.
+
+### Bug M13 — AssistantForm fetchKnowledgeBases mounted-check
+
+**File:** `AssistantForm.svelte` — added `isMounted` flag, mounted-checks in `fetchKnowledgeBases()`.
+
+### Bug L1 — `agent/history/[id]` mounted-check
+
+**File:** `routes/agent/history/[id]/+page.svelte` — added `isMounted` flag and `onDestroy`.
+
+---
+
+## What is NOT covered by Phase 1–3
+
+These remain open in #352:
+
+- **`ChatInterface.svelte`** — 6 raw `fetch()` calls, not migrated. Lower priority because the chat UI lives in a separate flow most creators don't touch frequently.
+- **L2-L8 low-severity items** — context-refresh timing asymmetry, `canvasData.content` null check, file-input DOM clear, fire-and-forget `loadSharedUsers()`, partial profile data handling.
+- **ESLint guardrail rule** for the resilience patterns (mentioned in §9.6) — manual code review for now.
+- **E2E Playwright tests** for these resilience scenarios — should be a follow-up.

--- a/Documentation/lamb_architecture_v2.md
+++ b/Documentation/lamb_architecture_v2.md
@@ -1255,6 +1255,274 @@ window.LAMB_CONFIG = {
 
 ---
 
+### 9.6 Frontend Resilience Patterns (Required)
+
+These patterns are mandatory for any new frontend code. They exist because we keep finding the same class of "frontend goes unresponsive, reload fixes it" bugs (issue #352 catalogues 38 instances). Each pattern below has a corresponding ESLint-style smell to scan for in code review.
+
+#### 9.6.1 Loading flags must use `try/finally`
+
+**Rule:** any `loading = true` (or `set(true)`) MUST have a matching reset in a `finally` block, never only in the success branch and never only in `catch`.
+
+```javascript
+// ❌ BAD — error path leaks loading=true forever
+async function submit() {
+  loading = true;
+  const result = await api.call();
+  if (result.success) { handleOk(); loading = false; }
+  else { error = result.error; }   // loading still true
+}
+
+// ❌ BAD — uncaught throw leaks loading=true forever
+async function submit() {
+  loading = true;
+  const result = await api.call();   // throws? we never reach next line
+  loading = false;
+}
+
+// ✅ GOOD — every exit path resets loading
+async function submit() {
+  loading = true;
+  error = null;
+  try {
+    const result = await api.call();
+    if (result.success) handleOk();
+    else error = result.error;
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  } finally {
+    loading = false;
+  }
+}
+```
+
+**Symptom this prevents:** spinners stuck spinning, submit buttons permanently disabled after a network blip.
+
+#### 9.6.2 `await` in `onMount` / `$effect` requires a mounted-check
+
+**Rule:** any async work started in `onMount` or `$effect` MUST check it's still mounted before writing reactive state. Use a local `cancelled` flag plus a teardown.
+
+```javascript
+// ❌ BAD — setState on destroyed component if user navigates away mid-fetch
+onMount(async () => {
+  const data = await api.get(id);
+  state = data;
+});
+
+// ✅ GOOD
+onMount(() => {
+  let cancelled = false;
+  (async () => {
+    try {
+      const data = await api.get(id);
+      if (!cancelled) state = data;
+    } catch (e) {
+      if (!cancelled) error = e.message;
+    }
+  })();
+  return () => { cancelled = true; };
+});
+```
+
+**Symptom this prevents:** stale data from a previous resource appearing after rapid navigation; console errors about updates on destroyed components.
+
+#### 9.6.3 Cancellable fetches use `AbortController`
+
+**Rule:** any fetch that depends on a prop/route param that can change MUST be abortable, and the previous fetch MUST be aborted when the dependency changes.
+
+```javascript
+// ✅ GOOD
+let abortController = null;
+
+async function loadResource(id) {
+  if (abortController) abortController.abort();
+  abortController = new AbortController();
+
+  loading = true;
+  try {
+    const data = await fetch(`/api/${id}`, { signal: abortController.signal })
+      .then(r => r.json());
+    state = data;
+  } catch (e) {
+    if (e.name === 'AbortError') return;   // expected on rapid switch
+    error = e.message;
+  } finally {
+    loading = false;
+  }
+}
+
+onDestroy(() => abortController?.abort());
+```
+
+**Symptom this prevents:** clicking through items in a list shows the wrong details because an earlier request resolved last.
+
+#### 9.6.4 401 must be handled centrally, not per call site
+
+**Rule:** all API calls go through a shared `apiFetch` wrapper that:
+1. Attaches the bearer token
+2. On 401, calls `clearCurrentSession()` from `$lib/session/sessionManager.js` and redirects to login
+3. On 403, surfaces a permission error with a redirect option
+
+Do NOT reimplement 401 handling in each service file. Do NOT silently return `{success:false}` on 401 — that lets the user keep clicking buttons that will all fail.
+
+```javascript
+// $lib/services/apiClient.js — single source of truth
+import { goto } from '$app/navigation';
+import { clearCurrentSession } from '$lib/session/sessionManager';
+
+export async function apiFetch(path, options = {}) {
+  const token = getAuthToken();
+  const res = await fetch(getApiUrl(path), {
+    ...options,
+    headers: {
+      ...(options.headers || {}),
+      'Authorization': token ? `Bearer ${token}` : ''
+    }
+  });
+
+  if (res.status === 401) {
+    clearCurrentSession();
+    await goto('/login');
+    throw new Error('Session expired');
+  }
+  return res;
+}
+```
+
+**Symptom this prevents:** "everything is broken until I reload" — the classic OWI session-expiry symptom.
+
+#### 9.6.5 Timers and streams must be cleaned up on destroy
+
+**Rule:** every `setInterval`, `setTimeout`, `EventSource`, and `fetch().body.getReader()` started in a component MUST have a matching cleanup in `onDestroy` (or returned from `onMount`).
+
+```javascript
+// ❌ BAD — timer fires after unmount
+function showSuccess() {
+  successMessage = 'Saved';
+  setTimeout(() => { successMessage = ''; }, 4000);
+}
+
+// ✅ GOOD
+let successTimer = null;
+function showSuccess() {
+  successMessage = 'Saved';
+  clearTimeout(successTimer);
+  successTimer = setTimeout(() => { successMessage = ''; }, 4000);
+}
+onDestroy(() => clearTimeout(successTimer));
+```
+
+For streaming readers, use `AbortController.signal` on the fetch and call `.abort()` from `onDestroy`. The `getReader()` loop will reject with `AbortError` on the next read, breaking cleanly.
+
+**Symptom this prevents:** memory leaks; ghost background HTTP traffic after navigation; stale toasts appearing on the wrong page.
+
+#### 9.6.6 Top-level `await` in `+layout.js` / `+layout.svelte` needs a fallback
+
+**Rule:** anything awaited in `load()` that can fail (locale JSON, runtime config fetch) MUST have a `.catch()` that allows the layout to render with a sensible fallback. A rejected `load()` blanks the page.
+
+```javascript
+// ❌ BAD — locale 404 blanks the entire app
+export const load = async () => {
+  setupI18n();
+  await waitLocale();
+  return {};
+};
+
+// ✅ GOOD
+export const load = async () => {
+  setupI18n();
+  try {
+    await waitLocale();
+  } catch (e) {
+    console.error('Locale load failed, using fallback', e);
+    // fallback locale is already set by setupI18n()
+  }
+  return {};
+};
+```
+
+#### 9.6.7 Stores holding user-scoped state must register with `sessionManager`
+
+**Rule:** any store that caches per-user data (assistants, KBs, AAC sessions, drafts, tabs) MUST expose a `reset()` method and be invoked from `resetAllUserScopedStores()` in `$lib/session/sessionManager.js`. Never hold user state in module-level variables that survive logout.
+
+```javascript
+// $lib/stores/myThing.js
+function createMyThingStore() {
+  const { subscribe, set, update } = writable(initialState);
+  return {
+    subscribe,
+    // …other methods
+    reset: () => set(initialState)   // ← required
+  };
+}
+
+// $lib/session/sessionManager.js — register here
+import { myThing } from '$lib/stores/myThing';
+export function resetAllUserScopedStores() {
+  // …
+  myThing.reset();
+}
+```
+
+**Symptom this prevents:** previous user's data appearing after re-login on the same browser.
+
+#### 9.6.8 No silent error swallowing on data fetches
+
+**Rule:** `Promise.all([call1.catch(()=>[]), call2.catch(()=>[])])` is forbidden for primary data loads. It conflates "empty result" with "request failed", so the UI shows "no items" when in reality the user should see an error and a retry option.
+
+If you genuinely want a partial-failure-tolerant fetch, surface the partial state explicitly (`{ owned: [...], shared: null, sharedError: '...' }`) so the UI can show a banner.
+
+#### 9.6.9 Polling loops check errors and unmount
+
+**Rule:** `setInterval` polls MUST:
+1. Stop on unmount (cleared from `onDestroy`)
+2. Stop on auth errors (don't keep hammering after 401)
+3. Surface non-transient errors after N retries (don't silently spin forever)
+
+```javascript
+// ✅ GOOD pattern
+let pollTimer = null;
+let pollFailures = 0;
+
+async function pollOnce() {
+  try {
+    const status = await apiFetch(`/items/${id}/status`).then(r => r.json());
+    state = status;
+    pollFailures = 0;
+  } catch (e) {
+    pollFailures += 1;
+    if (pollFailures >= 5) {
+      pollError = 'Lost connection to server';
+      stopPolling();
+    }
+  }
+}
+
+function startPolling() {
+  pollOnce();
+  pollTimer = setInterval(pollOnce, 3000);
+}
+function stopPolling() {
+  clearInterval(pollTimer);
+  pollTimer = null;
+}
+onDestroy(stopPolling);
+```
+
+#### 9.6.10 Code-review checklist (paste into PR template)
+
+For any frontend PR:
+
+- [ ] Every `loading = true` has a `finally { loading = false }` (Pattern A)
+- [ ] Every `await` in `onMount`/`$effect` has a mounted-check (Pattern B)
+- [ ] Cancellable fetches use `AbortController` and abort on dep change (Pattern C)
+- [ ] All API calls go through `apiFetch` (no direct `fetch()` to backend) (Pattern D)
+- [ ] Every `setInterval`/`setTimeout`/stream has cleanup in `onDestroy` (Pattern E)
+- [ ] No `Promise.all([call.catch(()=>[])])` for primary loads
+- [ ] User-scoped stores have `reset()` and are wired into `sessionManager`
+- [ ] Top-level `await` in layout has a `.catch()` fallback
+
+---
+
 ## 10. Development & Deployment
 
 ### 10.1 Quick Start

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,6 +91,21 @@ LAMB_KB_SERVER=http://kb:9090
 LAMB_KB_SERVER_TOKEN=0p3n-w3bu!
 
 # ============================================================================
+# LIBRARY MANAGER
+# ============================================================================
+
+# LAMB_LIBRARY_SERVER_ENABLE: Enable/disable the Library Manager integration.
+# Values: ENABLE | DISABLE (default: ENABLE)
+LAMB_LIBRARY_SERVER_ENABLE=ENABLE
+
+# Library Manager microservice URL
+# Docker Compose: http://library-manager:9091 (using service name) or http://localhost:9091
+LAMB_LIBRARY_SERVER=http://library-manager:9091
+
+# Library Manager Authentication Token
+LAMB_LIBRARY_TOKEN=change-me
+
+# ============================================================================
 # LLM CONFIGURATION
 # ============================================================================
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -11,6 +11,7 @@ def _env_bool(name: str, default: bool) -> bool:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
+
 # Server Configuration
 DEV_MODE = os.getenv('DEV_MODE', 'false').lower() == 'false'
 
@@ -20,7 +21,8 @@ DEV_MODE = os.getenv('DEV_MODE', 'false').lower() == 'false'
 # PIPELINES_HOST: Legacy variable, falls back to LAMB_WEB_HOST for backward compatibility
 LAMB_WEB_HOST = os.getenv('LAMB_WEB_HOST') or os.getenv('PIPELINES_HOST')
 if not LAMB_WEB_HOST:
-    raise ValueError("LAMB_WEB_HOST or PIPELINES_HOST environment variable is required")
+    raise ValueError(
+        "LAMB_WEB_HOST or PIPELINES_HOST environment variable is required")
 LAMB_BACKEND_HOST = os.getenv('LAMB_BACKEND_HOST')
 if not LAMB_BACKEND_HOST:
     raise ValueError("LAMB_BACKEND_HOST environment variable is required")
@@ -28,19 +30,22 @@ LAMB_HOST = LAMB_WEB_HOST  # Legacy alias for backward compatibility
 
 # Get the token from environment and strip any whitespace
 # LAMB_BEARER_TOKEN is the new variable name, PIPELINES_BEARER_TOKEN is kept for backward compatibility
-lamb_token = os.getenv('LAMB_BEARER_TOKEN') or os.getenv('PIPELINES_BEARER_TOKEN')
+lamb_token = os.getenv('LAMB_BEARER_TOKEN') or os.getenv(
+    'PIPELINES_BEARER_TOKEN')
 if not lamb_token:
-    raise ValueError("LAMB_BEARER_TOKEN or PIPELINES_BEARER_TOKEN environment variable is required")
+    raise ValueError(
+        "LAMB_BEARER_TOKEN or PIPELINES_BEARER_TOKEN environment variable is required")
 lamb_token = lamb_token.strip()
 
 LAMB_BEARER_TOKEN = lamb_token
 PIPELINES_BEARER_TOKEN = lamb_token  # Legacy alias for backward compatibility
 PIPELINES_DIR = os.getenv("PIPELINES_DIR", "./lamb_assistants")
- 
+
 API_KEY = lamb_token
 # Ollama Configuration
 
-OLLAMA_BASE_URL = os.getenv('OLLAMA_BASE_URL', 'http://host.docker.internal:11434')
+OLLAMA_BASE_URL = os.getenv(
+    'OLLAMA_BASE_URL', 'http://host.docker.internal:11434')
 
 OLLAMA_MODEL = os.getenv('OLLAMA_MODEL', 'nomic-embed-text')
 
@@ -62,16 +67,22 @@ if not OWI_BASE_URL:
 # OWI_PUBLIC_BASE_URL: Public URL for browser-facing redirects and login URLs
 # Falls back to OWI_BASE_URL if not explicitly set
 OWI_PUBLIC_BASE_URL = os.getenv('OWI_PUBLIC_BASE_URL') or OWI_BASE_URL
-CHROMA_PATH = os.path.join(OWI_PATH, "vector_db") 
+CHROMA_PATH = os.path.join(OWI_PATH, "vector_db")
 
 # Frontend Runtime Configuration
 LAMB_FRONTEND_BASE_URL = os.getenv('LAMB_FRONTEND_BASE_URL', '/creator')
-LAMB_FRONTEND_LAMB_SERVER = os.getenv('LAMB_FRONTEND_LAMB_SERVER') or LAMB_WEB_HOST or 'http://localhost:9099'
+LAMB_FRONTEND_LAMB_SERVER = os.getenv(
+    'LAMB_FRONTEND_LAMB_SERVER') or LAMB_WEB_HOST or 'http://localhost:9099'
 LAMB_FRONTEND_OPENWEBUI_SERVER = (
-    os.getenv('LAMB_FRONTEND_OPENWEBUI_SERVER') or OWI_PUBLIC_BASE_URL or 'http://localhost:8080'
+    os.getenv(
+        'LAMB_FRONTEND_OPENWEBUI_SERVER') or OWI_PUBLIC_BASE_URL or 'http://localhost:8080'
 )
 LAMB_ENABLE_OPENWEBUI = _env_bool('LAMB_ENABLE_OPENWEBUI', True)
 LAMB_ENABLE_DEBUG = _env_bool('LAMB_ENABLE_DEBUG', False)
+# Feature flag for the Library Manager microservice.
+# Enabled by default; set LAMB_LIBRARY_SERVER_ENABLE=DISABLE to turn off.
+LAMB_ENABLE_LIBRARIES = os.getenv(
+    "LAMB_LIBRARY_SERVER_ENABLE", "ENABLE").upper().strip() != "DISABLE"
 
 # Database Configuration
 LAMB_DB_PATH = os.getenv('LAMB_DB_PATH', '/data/lamb')
@@ -123,8 +134,10 @@ if not OWI_ADMIN_PASSWORD:
 # Google Gemini Image Generation Configuration
 # GEMINI_MODELS: Comma-separated list of available Gemini image generation models
 # GEMINI_DEFAULT_MODEL: Default model to use when assistant specifies an invalid model
-GEMINI_DEFAULT_MODEL = os.getenv('GEMINI_DEFAULT_MODEL', 'gemini-2.5-flash-image-preview')
-GEMINI_MODELS = os.getenv('GEMINI_MODELS', 'gemini-2.5-flash-image-preview,gemini-3-pro-image-preview')
+GEMINI_DEFAULT_MODEL = os.getenv(
+    'GEMINI_DEFAULT_MODEL', 'gemini-2.5-flash-image-preview')
+GEMINI_MODELS = os.getenv(
+    'GEMINI_MODELS', 'gemini-2.5-flash-image-preview,gemini-3-pro-image-preview')
 
 # LLM Client Pool Configuration
 # Controls shared HTTP client pools for OpenAI and Ollama connectors
@@ -137,4 +150,5 @@ OLLAMA_REQUEST_TIMEOUT = int(os.getenv('OLLAMA_REQUEST_TIMEOUT', '120'))
 required_vars = ['OWI_PATH']
 missing_vars = [var for var in required_vars if not os.getenv(var)]
 if missing_vars:
-    raise ValueError(f"Missing required environment variables: {', '.join(missing_vars)}")
+    raise ValueError(
+        f"Missing required environment variables: {', '.join(missing_vars)}")

--- a/backend/creator_interface/library_manager_client.py
+++ b/backend/creator_interface/library_manager_client.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 LAMB_LIBRARY_SERVER = os.getenv("LAMB_LIBRARY_SERVER", "")
 LAMB_LIBRARY_TOKEN = os.getenv("LAMB_LIBRARY_TOKEN", "")
+LAMB_LIBRARY_SERVER_ENABLE = os.getenv(
+    "LAMB_LIBRARY_SERVER_ENABLE", "ENABLE").upper().strip()
 
 
 class LibraryManagerClient:
@@ -40,7 +42,14 @@ class LibraryManagerClient:
 
         Raises:
             ValueError: If no Library Manager is configured.
+            HTTPException(503): If Library Manager is disabled via env var.
         """
+        if LAMB_LIBRARY_SERVER_ENABLE == "DISABLE":
+            raise HTTPException(
+                status_code=503,
+                detail="Library Manager is disabled (LAMB_LIBRARY_SERVER_ENABLE=DISABLE)",
+            )
+
         user_email = creator_user.get("email")
         if user_email:
             try:
@@ -54,10 +63,12 @@ class LibraryManagerClient:
                         "external_keys": lib_config.get("external_service_keys", {}),
                     }
             except Exception as e:
-                logger.warning(f"Error resolving library config for {user_email}: {e}")
+                logger.warning(
+                    f"Error resolving library config for {user_email}: {e}")
 
         if not self.global_server_url:
-            raise ValueError("Library Manager not configured (set LAMB_LIBRARY_SERVER)")
+            raise ValueError(
+                "Library Manager not configured (set LAMB_LIBRARY_SERVER)")
         return {
             "url": self.global_server_url,
             "token": self.global_token,

--- a/backend/docker-entrypoint.py
+++ b/backend/docker-entrypoint.py
@@ -21,7 +21,8 @@ def replace_bool(text: str, key: str, value: bool) -> tuple[str, int]:
 
 
 def patch_frontend_config() -> None:
-    frontend_build_path = os.getenv("LAMB_FRONTEND_BUILD_PATH", "/app/frontend/build")
+    frontend_build_path = os.getenv(
+        "LAMB_FRONTEND_BUILD_PATH", "/app/frontend/build")
     config_js_path = Path(frontend_build_path) / "config.js"
     config_js_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -30,6 +31,7 @@ def patch_frontend_config() -> None:
     openwebui_server = config.LAMB_FRONTEND_OPENWEBUI_SERVER
     enable_openwebui = config.LAMB_ENABLE_OPENWEBUI
     enable_debug = config.LAMB_ENABLE_DEBUG
+    enable_libraries = config.LAMB_ENABLE_LIBRARIES
 
     if not config_js_path.exists():
         config_payload = {
@@ -42,9 +44,11 @@ def patch_frontend_config() -> None:
             "features": {
                 "enableOpenWebUi": enable_openwebui,
                 "enableDebugMode": enable_debug,
+                "enableLibraries": enable_libraries,
             },
         }
-        config_js_path.write_text("window.LAMB_CONFIG = " + json.dumps(config_payload, indent=2) + ";\n", encoding="utf-8")
+        config_js_path.write_text(
+            "window.LAMB_CONFIG = " + json.dumps(config_payload, indent=2) + ";\n", encoding="utf-8")
         return
 
     text = config_js_path.read_text(encoding="utf-8")
@@ -54,6 +58,7 @@ def patch_frontend_config() -> None:
         ("openWebUiServer", openwebui_server, replace_string),
         ("enableOpenWebUi", enable_openwebui, replace_bool),
         ("enableDebugMode", enable_debug, replace_bool),
+        ("enableLibraries", enable_libraries, replace_bool),
     ]
 
     for key, value, replacer in updates:

--- a/frontend/MERGE_DEV_TO_PHASE4.md
+++ b/frontend/MERGE_DEV_TO_PHASE4.md
@@ -60,9 +60,51 @@ This was a reference template for `window.LAMB_CONFIG`. The actual config is gen
    - module-file-eval: 4 calls with raw `fetch()` with manual auth headers
    - Requires `apiClient` to be in `@lamb/ui` first (see #2)
 ### Low Priority
+
 6. **Document `window.LAMB_CONFIG` structure**
    - `config.js.sample` was deleted during this merge
    - Consider adding a proper documentation page or keeping a reference in `docs/`
+
+7. **Move `getConfig()` to `@lamb/ui` (fix hardcoded workaround in Nav.svelte)**
+   - **Current workaround:** `Nav.svelte` has a hardcoded `const getConfig = () => window.LAMB_CONFIG || { features: {} };` because `config.js` only exists in `creator-app` and `@lamb/ui` cannot import from it (circular dependency).
+   - **Proper fix:** Create `@lamb/ui/src/lib/config.js` with `getConfig()` (just reads `window.LAMB_CONFIG`). Keep `getApiUrl()` and `getLambApiUrl()` in `creator-app/src/lib/config.js` since those are app-specific. Update `Nav.svelte` to import `getConfig` from `@lamb/ui`.
+
+8. **Migrate 4 files from `marked` to `renderMarkdownSafe` from `@lamb/ui`**
+   - **Current state:** 4 files in `creator-app` import `marked` directly and use `{@html marked(...)}` without sanitization (XSS risk):
+     - `routes/+page.svelte` (line 9)
+     - `lib/components/ChatInterface.svelte` (line 4)
+     - `routes/agent/history/[id]/+page.svelte` (line 8)
+     - `lib/components/aac/AacTerminal.svelte` (line 5)
+   - **Proper fix:** Replace `import { marked } from 'marked'` + `{@html marked(text)}` with `import { renderMarkdownSafe } from '@lamb/ui'` + `{@html renderMarkdownSafe(text)}`. This eliminates the need for `marked` as a direct dependency in `creator-app` and ensures all markdown rendering is sanitized.
+
+9. **Fix `@lamb/ui/i18n` subpath imports in Pagination.svelte and RubricMetadataForm.svelte**
+   - **Risk:** Compilation failure if Vite/SvelteKit doesn't resolve subpath exports correctly
+   - **Files:** `lib/components/common/Pagination.svelte`, `lib/components/evaluaitor/RubricMetadataForm.svelte`
+   - **Current:** `import { _, locale } from '@lamb/ui/i18n';`
+   - **Fix:** Change to `import { _, locale } from '@lamb/ui';` for consistency and reliability
+
+10. **Remove dead imports in `+page.svelte` (root)**
+    - **Risk:** None (dead code), but adds confusion and unnecessary dependencies
+    - **Files:** `routes/+page.svelte`
+    - **Remove:** `import { marked } from 'marked';` (line 9, unused — replaced by `renderMarkdownSafe`)
+    - **Remove:** `import { getApiUrl } from '$lib/config';` (line 10, unused — `apiFetch` resolves URLs internally)
+
+11. **Add sanitization to `module-file-eval` markdown rendering**
+    - **Risk:** XSS if AI-generated content contains malicious payloads
+    - **File:** `module-file-eval/src/routes/grading/+page.svelte`
+    - **Current:** Uses `{@html marked.parse(md)}` without DOMPurify sanitization
+    - **Fix:** Import and use `renderMarkdownSafe` from `@lamb/ui` (once available as a shared export)
+
+12. **Migrate `createEventDispatcher` to Svelte 5 callback props (~15 components)**
+    - **Risk:** Low — Svelte 5 has backwards compat, but deprecated and generates warnings
+    - **Affected:** `Login.svelte`, `Signup.svelte`, `Pagination.svelte`, and ~12 more components
+    - **Fix:** Replace `dispatch('event-name')` + `on:event-name` with callback props (`oneventname={...}`)
+
+13. **Review `hooks.server.js` i18n `locale.set()` in SSR context**
+    - **Risk:** Low — `svelte-i18n` handles this internally, but fragile if `setupI18n()` hasn't run yet
+    - **File:** `creator-app/src/hooks.server.js`
+    - **Current:** Imports `locale` from `@lamb/ui` and calls `locale.set(lang)` in server hooks
+    - **Fix:** If issues arise, move i18n setup logic to `+layout.js` where it's guaranteed to run after `setupI18n()`
 ---
 ## Files affected by this merge
 ### Auto-merged (no conflicts)
@@ -106,7 +148,7 @@ This was a reference template for `window.LAMB_CONFIG`. The actual config is gen
 - `+layout.js` — accepted dev (`try/catch` around `waitLocale()`)
 - `+page.svelte` — merged: `@lamb/ui` imports + `apiFetch`/`sanitize` from dev
 - `org-admin/+page.svelte` — merged: `apiAxios` from dev + `@lamb/ui` imports
-- `Nav.svelte` — accepted HEAD (relative paths correct for `@lamb/ui`) + added `getConfig`
+- `Nav.svelte` — accepted HEAD (relative paths correct for `@lamb/ui`). Added `getConfig` as hardcoded `window.LAMB_CONFIG` read (TODO #7 to move to `@lamb/ui` properly)
 - `userStore.js` — merged: `authService` from HEAD + validation from dev
 ### Deleted
 - `frontend/svelte-app/package.json`

--- a/frontend/packages/creator-app/src/lib/stores/assistantStore.js
+++ b/frontend/packages/creator-app/src/lib/stores/assistantStore.js
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { getAssistants } from '$lib/services/assistantService'; // We'll port this service next
-import { user } from './userStore';
+import { user } from '@lamb/ui';
 
 /**
  * @typedef {Object} Assistant
@@ -62,7 +62,7 @@ const createAssistantsStore = () => {
     subscribe,
     set,     // Expose set if needed directly
     update,  // Expose update if needed directly
-    
+
     /**
      * Load assistants from the backend
      * @returns {Promise<void>}
@@ -70,14 +70,14 @@ const createAssistantsStore = () => {
     loadAssistants: async () => {
       // Only run in browser
       if (!browser) return;
-      
+
       // Update store to loading state
       update(state => ({
         ...state,
         loading: true,
         error: null
       }));
-      
+
       try {
         // Fetch fresh data from the backend
         // getAssistants returns an object: { assistants: Assistant[], total_count: number }
@@ -111,14 +111,14 @@ const createAssistantsStore = () => {
         }));
       }
     },
-    
+
     /**
      * Reset the store to its initial state
      */
     reset: () => {
       set(initialState); // Reset to initial state
     },
-    
+
     /**
      * Clean up any subscriptions
      */

--- a/frontend/packages/creator-app/src/routes/+layout.js
+++ b/frontend/packages/creator-app/src/routes/+layout.js
@@ -1,7 +1,5 @@
 import { browser } from '$app/environment';
-import '$lib/i18n'; // Import to initialize. Important for SSR!
-import { locale, waitLocale } from 'svelte-i18n';
-import { setupI18n, setLocale, supportedLocales, fallbackLocale } from '$lib/i18n';
+import { locale, waitLocale, setupI18n, setLocale, supportedLocales, fallbackLocale } from '@lamb/ui';
 
 /** @type {import('./$types').LayoutLoad} */
 export const load = async () => {

--- a/frontend/packages/creator-app/src/routes/+page.svelte
+++ b/frontend/packages/creator-app/src/routes/+page.svelte
@@ -11,8 +11,8 @@
 	import { _, locale } from '@lamb/ui';
 	import { getMyProfile } from '$lib/services/adminService';
 	import { apiFetch } from '$lib/services/apiClient';
-	import { renderMarkdownSafe } from '$lib/utils/sanitize';
-
+	import { renderMarkdownSafe } from '@lamb/ui';
+	
 	// Track mount status so async fetches that resolve after the user
 	// navigates away don't write state to a destroyed component. Also tag
 	// each loadNews() invocation so a slow request from a previous locale

--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -33,7 +33,9 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "svelte-i18n": "^4.0.1"
+    "svelte-i18n": "^4.0.1",
+    "dompurify": "^3.4.1",
+    "marked": "^15.0.12"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/frontend/packages/ui/src/lib/components/Nav.svelte
+++ b/frontend/packages/ui/src/lib/components/Nav.svelte
@@ -4,11 +4,14 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { base } from '$app/paths';
-  import { locale, _ } from '$lib/i18n';
-  import LanguageSelector from '$lib/components/LanguageSelector.svelte';
-  import { VERSION_INFO } from '$lib/version.js';
-  import { getConfig } from '../config.js'; 
-  
+  import { locale, _ } from '../i18n/index.js';
+  import LanguageSelector from '../components/LanguageSelector.svelte';
+  import { VERSION_INFO } from '../version.js';
+  // TODO: Move getConfig to @lamb/ui so it's shared across all modules.
+  // Currently config.js only exists in creator-app, but Nav.svelte needs
+  // getConfig() for feature flags. Hardcoded here as a temporary workaround.
+  const getConfig = () => window.LAMB_CONFIG || { features: {} };
+
   // Format version display
   let versionDisplay = `v${VERSION_INFO.version}`;
   

--- a/frontend/packages/ui/src/lib/index.js
+++ b/frontend/packages/ui/src/lib/index.js
@@ -3,3 +3,4 @@ export { authService, configService } from './services/index.js';
 export { user, user as userStore, configStore } from './stores/index.js';
 export { setupI18n, initI18n, setLocale, locale, _, waitLocale, fallbackLocale, supportedLocales } from './i18n/index.js';
 export { VERSION_INFO } from './version.js';
+export { renderMarkdownSafe, sanitizeHtml } from './utils/sanitize.js';

--- a/frontend/svelte-app/package.json
+++ b/frontend/svelte-app/package.json
@@ -48,6 +48,7 @@
 		"@ai-sdk/svelte": "^2.0.0",
 		"ai": "^4.3.7",
 		"axios": "^1.8.1",
+		"dompurify": "^3.4.1",
 		"flowbite-svelte": "^0.48.6",
 		"flowbite-svelte-icons": "^2.1.1",
 		"marked": "^15.0.12",

--- a/frontend/svelte-app/src/lib/components/AssistantsList.svelte
+++ b/frontend/svelte-app/src/lib/components/AssistantsList.svelte
@@ -94,6 +94,10 @@
   // Lifecycle and Data Loading
   let localeUnsubscribe = () => {};
   let userUnsubscribe = () => {};
+  // Track mount status so the retry recursion in loadAllAssistants does not
+  // resume after the component has been destroyed (e.g. logout, route change
+  // mid-retry). Without this, setState fires on a destroyed component. (#352, H8)
+  let isMounted = true;
 
   onMount(() => {
     localeUnsubscribe = locale.subscribe(value => {
@@ -128,6 +132,7 @@
     }
     
     return () => {
+      isMounted = false;
       localeUnsubscribe();
       if (userUnsubscribe) userUnsubscribe();
     };
@@ -136,31 +141,35 @@
   // Load all assistants (with high limit for client-side processing)
   // retryAttempt tracks whether we've already retried (to avoid infinite loops)
   async function loadAllAssistants(retryAttempt = false) {
+    if (!isMounted) return;
     loading = true;
     error = null;
     try {
       console.log(showShared ? 'Fetching shared assistants...' : 'Fetching all assistants...');
-      const response = showShared 
-        ? await getSharedAssistants() 
+      const response = showShared
+        ? await getSharedAssistants()
         : await getAssistants(100, 0); // Backend max is 100 items
       console.log('Received assistants:', response);
-      
+
+      if (!isMounted) return;
       allAssistants = response.assistants || [];
       applyFiltersAndPagination();
     } catch (err) {
       console.error('Error loading assistants:', err);
-      if (!retryAttempt) {
+      if (!retryAttempt && isMounted) {
         console.log('Will retry loading assistants in 1 second...');
         loading = true;
         await new Promise(resolve => setTimeout(resolve, 1000));
+        if (!isMounted) return; // Don't recurse if unmounted while waiting
         return loadAllAssistants(true);
       }
+      if (!isMounted) return;
       error = err instanceof Error ? err.message : String(err);
       allAssistants = [];
       displayAssistants = [];
       totalItems = 0;
     } finally {
-      loading = false;
+      if (isMounted) loading = false;
     }
   }
   

--- a/frontend/svelte-app/src/lib/components/ChatInterface.svelte
+++ b/frontend/svelte-app/src/lib/components/ChatInterface.svelte
@@ -1,8 +1,32 @@
 <script>
     import { writable } from 'svelte/store';
-    import { onMount } from 'svelte';
+    import { onMount, onDestroy } from 'svelte';
     import { marked } from 'marked';
     import ConfirmationModal from '$lib/components/modals/ConfirmationModal.svelte';
+    import { apiFetch } from '$lib/services/apiClient';
+
+    // Track mount status so async fetches that resolve after the user
+    // navigates away don't write state to a destroyed component, and so
+    // the streaming completion can be aborted on unmount. (#353, H1 + H4)
+    let isMounted = true;
+    /** @type {AbortController|null} */
+    let streamAbort = null;
+    onDestroy(() => {
+        isMounted = false;
+        streamAbort?.abort();
+        streamAbort = null;
+    });
+
+    /**
+     * Treat a "Session expired" error from apiFetch as a no-op for UI
+     * purposes — the wrapper is already redirecting to login, so painting
+     * a duplicate banner adds noise.
+     * @param {unknown} err
+     * @returns {boolean}
+     */
+    function isSessionExpired(err) {
+        return err instanceof Error && err.message.startsWith('Session expired');
+    }
 
     // Configure marked to preserve line breaks (converts \n to <br>)
     marked.setOptions({
@@ -129,32 +153,31 @@
      * Fetch chat list for current assistant
      */
     async function fetchChatList() {
-        if (!apiUrl || !userToken || !assistantId) return;
-        
+        if (!assistantId) return;
+
         isLoadingChats = true;
         logWithTime(`Fetching chat list for assistant ${assistantId}`);
-        
+
         try {
-            const response = await fetch(
-                `${apiUrl}/creator/chats?assistant_id=${assistantId}&per_page=50`,
-                {
-                    headers: { 'Authorization': `Bearer ${userToken}` }
-                }
-            );
-            
+            const response = await apiFetch(`/creator/chats?assistant_id=${assistantId}&per_page=50`);
+
+            if (!isMounted) return;
             if (!response.ok) {
                 throw new Error(`Failed to fetch chats: ${response.status}`);
             }
-            
+
             const data = await response.json();
+            if (!isMounted) return;
             chatList = data.chats || [];
             logWithTime(`Loaded ${chatList.length} chats`);
-            
+
         } catch (error) {
+            if (!isMounted) return;
+            if (isSessionExpired(error)) return;
             console.error('Error fetching chat list:', error);
             chatList = [];
         } finally {
-            isLoadingChats = false;
+            if (isMounted) isLoadingChats = false;
         }
     }
 
@@ -163,41 +186,38 @@
      * @param {string} chatId
      */
     async function loadChat(chatId) {
-        if (!apiUrl || !userToken) return;
-        
         logWithTime(`Loading chat ${chatId}`);
         isLoading = true;
-        
+
         try {
-            const response = await fetch(
-                `${apiUrl}/creator/chats/${chatId}`,
-                {
-                    headers: { 'Authorization': `Bearer ${userToken}` }
-                }
-            );
-            
+            const response = await apiFetch(`/creator/chats/${chatId}`);
+
+            if (!isMounted) return;
             if (!response.ok) {
                 throw new Error(`Failed to load chat: ${response.status}`);
             }
-            
+
             const data = await response.json();
-            
+            if (!isMounted) return;
+
             // Convert messages from response to our format
             messages = (data.messages || []).map((msg, idx) => ({
                 id: msg.id || `msg-${idx}`,
                 role: msg.role,
                 content: msg.content
             }));
-            
+
             currentChatId = data.id;
             currentChatTitle = data.title;
-            
+
             logWithTime(`Loaded chat with ${messages.length} messages`);
-            
+
         } catch (error) {
+            if (!isMounted) return;
+            if (isSessionExpired(error)) return;
             console.error('Error loading chat:', error);
         } finally {
-            isLoading = false;
+            if (isMounted) isLoading = false;
         }
     }
 
@@ -225,30 +245,27 @@
         logWithTime(`Updating chat title to: ${newTitle}`);
         
         try {
-            const response = await fetch(
-                `${apiUrl}/creator/chats/${currentChatId}`,
-                {
-                    method: 'PUT',
-                    headers: {
-                        'Authorization': `Bearer ${userToken}`,
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({ title: newTitle })
-                }
-            );
-            
+            const response = await apiFetch(`/creator/chats/${currentChatId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title: newTitle })
+            });
+
+            if (!isMounted) return;
             if (response.ok) {
                 currentChatTitle = newTitle;
                 // Update in chat list
-                chatList = chatList.map(c => 
+                chatList = chatList.map(c =>
                     c.id === currentChatId ? { ...c, title: newTitle } : c
                 );
                 logWithTime('Title updated successfully');
             }
         } catch (error) {
+            if (!isMounted) return;
+            if (isSessionExpired(error)) return;
             console.error('Error updating title:', error);
         } finally {
-            isEditingTitle = false;
+            if (isMounted) isEditingTitle = false;
         }
     }
 
@@ -272,14 +289,11 @@
         logWithTime(`Deleting chat ${deletingChatId}`);
         
         try {
-            const response = await fetch(
-                `${apiUrl}/creator/chats/${deletingChatId}`,
-                {
-                    method: 'DELETE',
-                    headers: { 'Authorization': `Bearer ${userToken}` }
-                }
-            );
-            
+            const response = await apiFetch(`/creator/chats/${deletingChatId}`, {
+                method: 'DELETE'
+            });
+
+            if (!isMounted) return;
             if (response.ok) {
                 chatList = chatList.filter(c => c.id !== deletingChatId);
                 if (currentChatId === deletingChatId) {
@@ -290,9 +304,11 @@
                 chatToDeleteId = null;
             }
         } catch (error) {
+            if (!isMounted) return;
+            if (isSessionExpired(error)) return;
             console.error('Error deleting chat:', error);
         } finally {
-            isDeletingChat = false;
+            if (isMounted) isDeletingChat = false;
         }
     }
     
@@ -308,21 +324,15 @@
     // --- API Calls ---
     /** Fetches available models */
     async function fetchModels() {
-        if (!apiUrl || !userToken) {
-            modelsError = 'API URL or user token is not configured.';
-            console.error(modelsError);
-            return;
-        }
         isLoadingModels = true;
         modelsError = null;
-        logWithTime(`Fetching models from ${apiUrl}/creator/models`);
+        logWithTime('Fetching models from /creator/models');
         try {
-            const response = await fetch(`${apiUrl}/creator/models`, {
-                method: 'GET',
-                headers: { 'Authorization': `Bearer ${userToken}` }
-            });
+            const response = await apiFetch('/creator/models', { method: 'GET' });
+            if (!isMounted) return;
             if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
             const data = await response.json();
+            if (!isMounted) return;
             if (data.data && Array.isArray(data.data)) {
                 const modelIds = data.data
                     .map(/** @param {{ id: string }} model */ (model) => model.id)
@@ -342,16 +352,18 @@
                 throw new Error('Invalid model data format');
             }
         } catch (/** @type {unknown} */ error) {
+            if (!isMounted) return;
+            if (isSessionExpired(error)) return;
             const errorMessage = error instanceof Error ? error.message : 'Failed to load models';
             modelsError = errorMessage;
             console.error('Error fetching models:', error);
-            models = ['gpt-3.5-turbo', 'gpt-4']; 
+            models = ['gpt-3.5-turbo', 'gpt-4'];
             if (!selectedModel || !models.includes(selectedModel)) {
                 selectedModel = models[0];
             }
             logWithTime(`Using fallback models due to error. Selected: ${selectedModel}`);
         } finally {
-            isLoadingModels = false;
+            if (isMounted) isLoadingModels = false;
         }
     }
 
@@ -359,11 +371,17 @@
      * Sends messages to the chat API and handles streaming response.
      */
     async function handleSubmit() {
-        if (!input.trim() || isLoading || !apiUrl || !userToken) return;
+        if (!input.trim() || isLoading) return;
 
         logWithTime(`Submitting message with model: ${selectedModel}`);
         isLoading = true;
         isStreaming = true;
+
+        // Cancel any previous in-flight stream so navigation away or rapid
+        // resends don't leave the previous fetch + reader running. (#353, H1)
+        streamAbort?.abort();
+        streamAbort = new AbortController();
+        const signal = streamAbort.signal;
 
         /** @type {Message} */
         const newUserMessage = { id: Date.now().toString(), role: 'user', content: input };
@@ -392,19 +410,14 @@
             if (!assistantId) {
                 throw new Error('Assistant ID is required for chat');
             }
-            if (!userToken) {
-                throw new Error('User authentication token is required');
-            }
-            
-            const endpoint = `${apiUrl}/creator/assistant/${assistantId}/chat/completions`;
+
+            const endpoint = `/creator/assistant/${assistantId}/chat/completions`;
             logWithTime(`Sending request to ${endpoint}`);
-            const response = await fetch(endpoint, {
+            const response = await apiFetch(endpoint, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${userToken}`
-                },
-                body: JSON.stringify(payload)
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+                signal,
             });
 
             if (!response.ok) {
@@ -435,6 +448,10 @@
                 logWithTime('Starting stream processing');
 
                 while (true) {
+                    if (signal.aborted) {
+                        try { await reader.cancel(); } catch (_) { /* noop */ }
+                        return;
+                    }
                     const { done, value } = await reader.read();
                     if (done) {
                         logWithTime('Stream finished.');
@@ -522,16 +539,25 @@
             fetchChatList();
 
         } catch (/** @type {any} */ error) {
+            // AbortError on unmount or rapid-resend is expected; do not paint
+            // an error message on the (possibly already-replaced) assistant slot.
+            if (error?.name === 'AbortError') return;
+            // Session-expired errors from apiFetch are already redirecting.
+            if (isSessionExpired(error)) return;
             logWithTime(`Error during chat submission: ${error.message}`);
             console.error('Chat error:', error);
-            messages = messages.map(msg => 
-                msg.id === assistantMessageId 
-                ? { ...msg, content: `Error: ${error.message}` } 
-                : msg
-            );
+            if (isMounted) {
+                messages = messages.map(msg =>
+                    msg.id === assistantMessageId
+                    ? { ...msg, content: `Error: ${error.message}` }
+                    : msg
+                );
+            }
         } finally {
-            isLoading = false;
-            isStreaming = false;
+            if (isMounted) {
+                isLoading = false;
+                isStreaming = false;
+            }
             logWithTime('Chat submission finished.');
         }
     }
@@ -549,6 +575,8 @@
     // --- Lifecycle & Effects ---
     onMount(() => {
         logWithTime("ChatInterface mounted.");
+        // fetchModels and fetchChatList are mounted-aware via the isMounted
+        // flag at the top of the script; no extra guard needed here. (#353, H4)
         fetchModels();
         fetchChatList();
     });

--- a/frontend/svelte-app/src/lib/components/ChatInterface.svelte
+++ b/frontend/svelte-app/src/lib/components/ChatInterface.svelte
@@ -159,7 +159,7 @@
         logWithTime(`Fetching chat list for assistant ${assistantId}`);
 
         try {
-            const response = await apiFetch(`/creator/chats?assistant_id=${assistantId}&per_page=50`);
+            const response = await apiFetch(`/chats?assistant_id=${assistantId}&per_page=50`);
 
             if (!isMounted) return;
             if (!response.ok) {
@@ -190,7 +190,7 @@
         isLoading = true;
 
         try {
-            const response = await apiFetch(`/creator/chats/${chatId}`);
+            const response = await apiFetch(`/chats/${chatId}`);
 
             if (!isMounted) return;
             if (!response.ok) {
@@ -245,7 +245,7 @@
         logWithTime(`Updating chat title to: ${newTitle}`);
         
         try {
-            const response = await apiFetch(`/creator/chats/${currentChatId}`, {
+            const response = await apiFetch(`/chats/${currentChatId}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ title: newTitle })
@@ -289,7 +289,7 @@
         logWithTime(`Deleting chat ${deletingChatId}`);
         
         try {
-            const response = await apiFetch(`/creator/chats/${deletingChatId}`, {
+            const response = await apiFetch(`/chats/${deletingChatId}`, {
                 method: 'DELETE'
             });
 
@@ -326,9 +326,9 @@
     async function fetchModels() {
         isLoadingModels = true;
         modelsError = null;
-        logWithTime('Fetching models from /creator/models');
+        logWithTime('Fetching models from /creator/models');  // apiFetch prepends /creator
         try {
-            const response = await apiFetch('/creator/models', { method: 'GET' });
+            const response = await apiFetch('/models', { method: 'GET' });
             if (!isMounted) return;
             if (!response.ok) throw new Error(`Failed to fetch models: ${response.status}`);
             const data = await response.json();
@@ -411,7 +411,7 @@
                 throw new Error('Assistant ID is required for chat');
             }
 
-            const endpoint = `/creator/assistant/${assistantId}/chat/completions`;
+            const endpoint = `/assistant/${assistantId}/chat/completions`;
             logWithTime(`Sending request to ${endpoint}`);
             const response = await apiFetch(endpoint, {
                 method: 'POST',

--- a/frontend/svelte-app/src/lib/components/KnowledgeBasesList.svelte
+++ b/frontend/svelte-app/src/lib/components/KnowledgeBasesList.svelte
@@ -89,29 +89,43 @@
                 return;
             }
             
-            // Fetch owned and shared KBs separately
-            const [ownedData, sharedData] = await Promise.all([
-                getUserKnowledgeBases().catch(err => {
-                    console.warn('Error fetching owned KBs:', err);
-                    return [];
-                }),
-                getSharedKnowledgeBases().catch(err => {
-                    console.warn('Error fetching shared KBs:', err);
-                    return [];
-                })
+            // Fetch owned and shared KBs separately. Track errors per side
+            // so the UI can distinguish "you really have no KBs" from "the
+            // request failed". Previously both errors were swallowed and the
+            // user saw an empty list with no indication anything went wrong
+            // (#352, H10).
+            const [ownedResult, sharedResult] = await Promise.allSettled([
+                getUserKnowledgeBases(),
+                getSharedKnowledgeBases(),
             ]);
-            
-            ownedKnowledgeBases = ownedData || [];
-            sharedKnowledgeBases = sharedData || [];
-            
-            // Combine for allKnowledgeBases (for backward compatibility if needed)
+
+            ownedKnowledgeBases = ownedResult.status === 'fulfilled' ? (ownedResult.value || []) : [];
+            sharedKnowledgeBases = sharedResult.status === 'fulfilled' ? (sharedResult.value || []) : [];
+
+            // If both halves failed, surface the error so the user knows
+            // to retry or check connectivity. If only one failed, log it
+            // and keep the partial list visible.
+            if (ownedResult.status === 'rejected' && sharedResult.status === 'rejected') {
+                const ownedErr = ownedResult.reason;
+                error = ownedErr instanceof Error ? ownedErr.message : 'Failed to load knowledge bases';
+                if (ownedErr instanceof Error && ownedErr.message.includes('server offline')) {
+                    serverOffline = true;
+                }
+            } else {
+                if (ownedResult.status === 'rejected') {
+                    console.warn('Error fetching owned KBs:', ownedResult.reason);
+                }
+                if (sharedResult.status === 'rejected') {
+                    console.warn('Error fetching shared KBs:', sharedResult.reason);
+                }
+            }
+
             allKnowledgeBases = [...ownedKnowledgeBases, ...sharedKnowledgeBases];
-            
             console.log(`Owned: ${ownedKnowledgeBases.length}, Shared: ${sharedKnowledgeBases.length}`);
-            
+
             // Apply filters and pagination after data is loaded
             applyFiltersAndPagination();
-            
+
         } catch (/** @type {unknown} */ err) {
             console.error('Error loading knowledge bases:', err);
             error = err instanceof Error ? err.message : 'Failed to load knowledge bases';

--- a/frontend/svelte-app/src/lib/components/Login.svelte
+++ b/frontend/svelte-app/src/lib/components/Login.svelte
@@ -28,51 +28,58 @@
     loading = true;
     message = '';
     success = false;
-    
-    const result = await login(email, password);
-    
-    console.log('Login result:', result);
-    console.log('User type:', result.data?.user_type);
-    
-    // Check the success flag and nested data object
-    if (result.success && result.data) { 
-      // Check if user is an end_user and redirect to OWI
-      if (result.data.user_type === 'end_user') {
-        console.log('End user detected! Redirecting to OWI...');
-        success = true;
-        message = 'Redirecting to Open WebUI...';
-        
-        // Redirect to OWI with the launch URL
-        if (result.data.launch_url) {
-          console.log('Redirecting to:', result.data.launch_url);
-          window.location.href = result.data.launch_url;
-        } else {
-          // Fallback: show error if launch_url is missing
-          console.error('No launch_url in response!');
-          success = false;
-          message = 'Unable to redirect to Open WebUI. Please contact your administrator.';
+
+    // Wrap in try/finally so any unexpected throw still resets the loading
+    // flag — otherwise the submit button stays disabled forever. (#352)
+    try {
+      const result = await login(email, password);
+
+      console.log('Login result:', result);
+      console.log('User type:', result.data?.user_type);
+
+      // Check the success flag and nested data object
+      if (result.success && result.data) {
+        // Check if user is an end_user and redirect to OWI
+        if (result.data.user_type === 'end_user') {
+          console.log('End user detected! Redirecting to OWI...');
+          success = true;
+          message = 'Redirecting to Open WebUI...';
+
+          // Redirect to OWI with the launch URL
+          if (result.data.launch_url) {
+            console.log('Redirecting to:', result.data.launch_url);
+            window.location.href = result.data.launch_url;
+          } else {
+            // Fallback: show error if launch_url is missing
+            console.error('No launch_url in response!');
+            success = false;
+            message = 'Unable to redirect to Open WebUI. Please contact your administrator.';
+          }
+          return;
         }
-        loading = false;
-        return;
+        console.log('Creator user detected, continuing to creator interface');
+
+        // For creator users, continue with normal login
+        replaceSessionWithLoginData(result.data);
+
+        success = true;
+        message = 'Login successful!'; // Use a generic message or i18n key
+
+        setTimeout(() => {
+          goto(base + '/', { replaceState: true });
+        }, 1000);
+      } else {
+        // Handle login failure
+        success = false;
+        message = result.error || 'Login failed. Please check credentials.';
       }
-      console.log('Creator user detected, continuing to creator interface');
-      
-      // For creator users, continue with normal login
-      replaceSessionWithLoginData(result.data); 
-      
-      success = true;
-      message = 'Login successful!'; // Use a generic message or i18n key
-      
-      setTimeout(() => {
-        goto(base + '/', { replaceState: true });
-      }, 1000);
-    } else {
-      // Handle login failure
+    } catch (err) {
       success = false;
-      message = result.error || 'Login failed. Please check credentials.'; // Provide a clearer default error
+      message = err instanceof Error ? err.message : 'Login failed unexpectedly.';
+      console.error('Unexpected login error:', err);
+    } finally {
+      loading = false;
     }
-    
-    loading = false;
   }
   
   // Show signup form

--- a/frontend/svelte-app/src/lib/components/Nav.svelte
+++ b/frontend/svelte-app/src/lib/components/Nav.svelte
@@ -7,9 +7,13 @@
   import { locale, _ } from '$lib/i18n';
   import LanguageSelector from '$lib/components/LanguageSelector.svelte';
   import { VERSION_INFO } from '$lib/version.js';
+  import { getConfig } from '$lib/config.js';
   
   // Format version display
   let versionDisplay = `v${VERSION_INFO.version}`;
+  
+  // Feature flags
+  let librariesEnabled = $derived(getConfig().features.enableLibraries ?? true);
   
   // Default text for when i18n isn't loaded yet
   let localeLoaded = $state(false);
@@ -129,7 +133,7 @@
             <button
               type="button"
               onclick={() => toolsMenuOpen = !toolsMenuOpen}
-              class="inline-flex items-center h-full px-2 py-4 border-b-2 text-sm font-medium cursor-pointer select-none whitespace-nowrap {($page.url.pathname.startsWith(base + '/knowledgebases') || $page.url.pathname.startsWith(base + '/libraries') || $page.url.pathname.startsWith(base + '/evaluaitor')) ? 'border-[#2271b3] text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'} {!$user.isLoggedIn ? 'opacity-50 pointer-events-none' : ''}"
+              class="inline-flex items-center h-full px-2 py-4 border-b-2 text-sm font-medium cursor-pointer select-none whitespace-nowrap {($page.url.pathname.startsWith(base + '/knowledgebases') || (librariesEnabled && $page.url.pathname.startsWith(base + '/libraries')) || $page.url.pathname.startsWith(base + '/evaluaitor')) ? 'border-[#2271b3] text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'} {!$user.isLoggedIn ? 'opacity-50 pointer-events-none' : ''}"
               aria-disabled={!$user.isLoggedIn}
               aria-expanded={toolsMenuOpen}
               aria-haspopup="true"
@@ -150,13 +154,15 @@
                   >
                     {localeLoaded ? $_('knowledgeBases.title') : 'Knowledge Bases'}
                   </a>
-                  <a
-                    href="{base}/libraries"
-                    onclick={() => toolsMenuOpen = false}
-                    class="block px-4 py-3 text-sm font-medium text-gray-700 hover:text-[#2271b3] hover:bg-gray-50 transition-colors duration-150 {$page.url.pathname.startsWith(base + '/libraries') ? 'bg-blue-50 text-[#2271b3]' : ''}"
-                  >
-                    {localeLoaded ? $_('libraries.title', { default: 'Libraries' }) : 'Libraries'}
-                  </a>
+                  {#if librariesEnabled}
+                    <a
+                      href="{base}/libraries"
+                      onclick={() => toolsMenuOpen = false}
+                      class="block px-4 py-3 text-sm font-medium text-gray-700 hover:text-[#2271b3] hover:bg-gray-50 transition-colors duration-150 {$page.url.pathname.startsWith(base + '/libraries') ? 'bg-blue-50 text-[#2271b3]' : ''}"
+                    >
+                      {localeLoaded ? $_('libraries.title', { default: 'Libraries' }) : 'Libraries'}
+                    </a>
+                  {/if}
                   <a
                     href="{base}/evaluaitor"
                     onclick={() => toolsMenuOpen = false}
@@ -196,4 +202,4 @@
       
     </div>
   </div>
-</nav> 
+</nav>

--- a/frontend/svelte-app/src/lib/components/PublishModal.svelte
+++ b/frontend/svelte-app/src/lib/components/PublishModal.svelte
@@ -2,13 +2,19 @@
     import { publishModalOpen, selectedAssistant, publishingStatus, resetPublishingStatus } from '$lib/stores/assistantPublish';
     import { publishAssistant } from '$lib/services/assistantService'; // Import service function
     import { _, locale } from '$lib/i18n'; // Import i18n
-    import { createEventDispatcher, onMount } from 'svelte'; // For dispatching event and onMount
+    import { createEventDispatcher, onMount, onDestroy } from 'svelte';
 
     let localeLoaded = $state(false);
     let form = $state(); // Use $state for form ref
     let groupName = $state('');
     let oauthConsumerName = $state('');
-    
+
+    // Track the post-success close timer so we can clear it if the user
+    // closes the modal manually within the 1.5s window — otherwise the
+    // timeout fires handleClose() on a destroyed component. (#353, H3)
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    let closeTimer = null;
+
     const dispatch = createEventDispatcher();
 
     // Check locale loaded state
@@ -17,6 +23,10 @@
             if (value) localeLoaded = true;
         });
         return unsubscribe;
+    });
+
+    onDestroy(() => {
+        if (closeTimer) clearTimeout(closeTimer);
     });
 
     // Derive from selectedAssistant store
@@ -31,6 +41,7 @@
     });
 
     function handleClose() {
+        if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
         $publishModalOpen = false;
         resetPublishingStatus(); // Reset status on close
     }
@@ -50,8 +61,10 @@
             
             // Dispatch event with ID
             dispatch('assistantPublished', { assistantId: $selectedAssistant.id });
-            
-            setTimeout(() => {
+
+            if (closeTimer) clearTimeout(closeTimer);
+            closeTimer = setTimeout(() => {
+                closeTimer = null;
                 handleClose();
             }, 1500);
         } catch (error) {

--- a/frontend/svelte-app/src/lib/components/Signup.svelte
+++ b/frontend/svelte-app/src/lib/components/Signup.svelte
@@ -2,11 +2,11 @@
   import { createEventDispatcher } from 'svelte';
   import { signup } from '$lib/services/authService';
   import { _ , locale } from '$lib/i18n';
-  import { onMount } from 'svelte';
-  
+  import { onMount, onDestroy } from 'svelte';
+
   // Event dispatcher for component events
   const dispatch = createEventDispatcher();
-  
+
   // Form state using $state
   let name = $state('');
   let email = $state('');
@@ -15,33 +15,48 @@
   let message = $state('');
   let success = $state(false);
   let loading = $state(false);
-  
+
   let localeLoaded = $state(false);
+  /** @type {ReturnType<typeof setTimeout>|null} */
+  let showLoginTimer = null;
   onMount(() => {
       const unsub = locale.subscribe(v => localeLoaded = !!v);
       return unsub;
   });
-  
+  onDestroy(() => {
+    // Clear the post-success timer so it doesn't fire on a destroyed component (#353, H3-adjacent).
+    if (showLoginTimer) clearTimeout(showLoginTimer);
+  });
+
   // Handle form submission
   async function submitSignup() {
     loading = true;
     message = '';
     success = false;
-    
-    const result = await signup(name, email, password, secretKey);
-    
-    if (result.success) {
-      success = true;
-      message = result.message || 'Signup successful!';
-      setTimeout(() => {
-        dispatch('show-login');
-      }, 1500);
-    } else {
+
+    // Wrap in try/catch/finally so an unexpected throw still resets loading,
+    // mirroring the Login.svelte fix from #352. (#353, H2)
+    try {
+      const result = await signup(name, email, password, secretKey);
+
+      if (result.success) {
+        success = true;
+        message = result.message || 'Signup successful!';
+        if (showLoginTimer) clearTimeout(showLoginTimer);
+        showLoginTimer = setTimeout(() => {
+          dispatch('show-login');
+        }, 1500);
+      } else {
+        success = false;
+        message = result.error || 'Error signing up';
+      }
+    } catch (err) {
       success = false;
-      message = result.error || 'Error signing up';
+      message = err instanceof Error ? err.message : 'Signup failed unexpectedly.';
+      console.error('Unexpected signup error:', err);
+    } finally {
+      loading = false;
     }
-    
-    loading = false;
   }
   
   // Show login form

--- a/frontend/svelte-app/src/lib/components/aac/AacTabBar.svelte
+++ b/frontend/svelte-app/src/lib/components/aac/AacTabBar.svelte
@@ -1,11 +1,9 @@
 <script>
-	import { getOpenTabs, getActiveTabId, setActiveTab, closeTab } from '$lib/stores/aacStore.svelte';
+	import { openTabs, activeTabId, setActiveTab, closeTab } from '$lib/stores/aacStore.svelte';
+	import { get } from 'svelte/store';
 
 	/** @type {{ onTabChange?: (id: string|null) => void, onBackToMain?: () => void }} */
 	let { onTabChange = () => {}, onBackToMain = () => {} } = $props();
-
-	let tabs = $derived(getOpenTabs());
-	let activeId = $derived(getActiveTabId());
 
 	function handleTabClick(id) {
 		setActiveTab(id);
@@ -15,7 +13,7 @@
 	function handleClose(e, id) {
 		e.stopPropagation();
 		closeTab(id);
-		onTabChange(getActiveTabId());
+		onTabChange(get(activeTabId));
 	}
 
 	function handleBack() {
@@ -23,31 +21,31 @@
 	}
 </script>
 
-{#if tabs.length > 0}
+{#if $openTabs.length > 0}
 	<div class="flex items-center border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 overflow-x-auto">
 		<!-- Main view tab -->
 		<button
 			onclick={handleBack}
 			class="px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 transition-colors"
-			class:border-blue-500={!activeId}
-			class:text-blue-600={!activeId}
-			class:border-transparent={activeId}
-			class:text-gray-500={activeId}
-			class:hover:text-gray-700={activeId}
+			class:border-blue-500={!$activeTabId}
+			class:text-blue-600={!$activeTabId}
+			class:border-transparent={$activeTabId}
+			class:text-gray-500={$activeTabId}
+			class:hover:text-gray-700={$activeTabId}
 		>
 			📋 Assistant
 		</button>
 
 		<!-- Session tabs -->
-		{#each tabs as tab}
+		{#each $openTabs as tab}
 			<button
 				onclick={() => handleTabClick(tab.id)}
 				class="group flex items-center gap-1.5 px-3 py-2 text-sm whitespace-nowrap border-b-2 transition-colors"
-				class:border-blue-500={activeId === tab.id}
-				class:text-blue-600={activeId === tab.id}
-				class:border-transparent={activeId !== tab.id}
-				class:text-gray-500={activeId !== tab.id}
-				class:hover:text-gray-700={activeId !== tab.id}
+				class:border-blue-500={$activeTabId === tab.id}
+				class:text-blue-600={$activeTabId === tab.id}
+				class:border-transparent={$activeTabId !== tab.id}
+				class:text-gray-500={$activeTabId !== tab.id}
+				class:hover:text-gray-700={$activeTabId !== tab.id}
 			>
 				<span>🤖</span>
 				<span class="max-w-[150px] truncate">{tab.title || 'Session'}</span>

--- a/frontend/svelte-app/src/lib/components/aac/AacTerminal.svelte
+++ b/frontend/svelte-app/src/lib/components/aac/AacTerminal.svelte
@@ -1,8 +1,14 @@
 <script>
-	import { onMount, tick } from 'svelte';
+	import { onMount, onDestroy, tick } from 'svelte';
 	import { sendMessageStream, getSession, sendMessage } from '$lib/services/aacService';
 	import { recordTabActivity } from '$lib/stores/aacStore.svelte';
 	import { marked } from 'marked';
+
+	// Abort any in-flight stream when the component unmounts so the fetch
+	// and getReader() loop stop running in the background (#352, H3).
+	/** @type {AbortController|null} */
+	let streamAbort = null;
+	let isMounted = true;
 
 	/** @type {{ sessionId: string, firstMessage?: string, resumed?: boolean, skillStartup?: boolean }} */
 	let { sessionId, firstMessage = '', resumed = false, skillStartup = false } = $props();
@@ -83,9 +89,12 @@
 		} else if (firstMessage) {
 			messages = [{ role: 'assistant', content: firstMessage }];
 		} else if (resumed) {
-			// Resumed session — load history, hide internal [System:...] messages
+			// Resumed session — load history, hide internal [System:...] messages.
+			// Skip writes if the user navigated away while getSession was in flight
+			// (rapid tab switching destroys this component before resolution). (#352, H5)
 			try {
 				const session = await getSession(sessionId);
+				if (!isMounted) return;
 				const conv = (session.conversation || []).filter(
 					m => (m.role === 'user' && !(m.content || '').startsWith('[System:'))
 					  || (m.role === 'assistant' && m.content && !m.tool_calls)
@@ -95,10 +104,13 @@
 					resumeNotice = true;
 				}
 			} catch (e) {
+				if (!isMounted) return;
+				if (e instanceof Error && e.message.startsWith('Session expired')) return;
 				messages = [{ role: 'system', content: `Error loading session: ${e.message}` }];
 			}
 		}
 
+		if (!isMounted) return;
 		await tick();
 		scrollToBottom();
 		inputEl?.focus();
@@ -112,6 +124,8 @@
 		messages = [...messages, { role: 'assistant', content: '' }];
 		await tick();
 
+		streamAbort?.abort();
+		streamAbort = new AbortController();
 		try {
 			await sendMessageStream(
 				sessionId,
@@ -131,13 +145,19 @@
 					else if (status.status === 'responding') statusText = '';
 					scrollToBottom();
 				},
+				streamAbort.signal,
 			);
 		} catch (e) {
-			messages[streamIdx] = { role: 'system', content: `Error: ${e.message}` };
-			messages = messages;
+			if (isMounted && e?.name !== 'AbortError') {
+				messages[streamIdx] = { role: 'system', content: `Error: ${e.message}` };
+				messages = messages;
+			}
+		} finally {
+			// Defensive: guarantee loading flag is cleared even if anything
+			// above throws unexpectedly. (#352, Pattern A)
+			if (isMounted) loading = false;
 		}
-
-		loading = false;
+		if (!isMounted) return;
 		await tick();
 		scrollToBottom();
 		inputEl?.focus();
@@ -169,6 +189,8 @@
 		await tick();
 		scrollToBottom();
 
+		streamAbort?.abort();
+		streamAbort = new AbortController();
 		try {
 			await sendMessageStream(
 				sessionId,
@@ -200,17 +222,30 @@
 					}
 					scrollToBottom();
 				},
+				streamAbort.signal,
 			);
 		} catch (e) {
-			messages[streamIdx] = { role: 'system', content: `Error: ${e.message}` };
-			messages = messages;
+			if (isMounted && e?.name !== 'AbortError') {
+				messages[streamIdx] = { role: 'system', content: `Error: ${e.message}` };
+				messages = messages;
+			}
+		} finally {
+			// Defensive: guarantee loading flag is cleared on every exit
+			// path so the send button never gets stuck disabled. (#352, Pattern A)
+			if (isMounted) loading = false;
 		}
 
-		loading = false;
+		if (!isMounted) return;
 		await tick();
 		scrollToBottom();
 		inputEl?.focus();
 	}
+
+	onDestroy(() => {
+		isMounted = false;
+		streamAbort?.abort();
+		streamAbort = null;
+	});
 
 	function handleKeydown(e) {
 		if (e.key === 'Enter' && !e.shiftKey) {

--- a/frontend/svelte-app/src/lib/components/aac/GlobalAacTabBar.svelte
+++ b/frontend/svelte-app/src/lib/components/aac/GlobalAacTabBar.svelte
@@ -1,27 +1,14 @@
 <script>
-    import { onMount } from 'svelte';
-    import { getOpenTabs, getActiveTabId, setActiveTab, closeTab } from '$lib/stores/aacStore.svelte';
+    import { openTabs, activeTabId, setActiveTab, closeTab } from '$lib/stores/aacStore.svelte';
     import { deleteSession } from '$lib/services/aacService';
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
     import { _ } from '$lib/i18n';
 
-    /** @type {Array<{id: string, title: string, assistantId: number|null, skill: string|null}>} */
-    let tabs = $state([]);
-    /** @type {string|null} */
-    let activeId = $state(null);
-
-    // Poll the store periodically since cross-module $state reactivity
-    // doesn't work reliably in Svelte 5 built mode
-    onMount(() => {
-        function sync() {
-            tabs = [...getOpenTabs()];
-            activeId = getActiveTabId();
-        }
-        sync();
-        const interval = setInterval(sync, 500);
-        return () => clearInterval(interval);
-    });
+    // Subscribe directly to the writable stores via the `$` auto-subscription.
+    // Previously this component polled getOpenTabs() every 500ms because cross-
+    // module $state reactivity didn't propagate in built mode — fixed at the
+    // store level by switching to writable() (#352, H6).
 
     const skillIcons = {
         'about-lamb': '🤖',
@@ -38,7 +25,6 @@
 
     async function switchToTab(id) {
         setActiveTab(id);
-        activeId = id;
         if (!$page.url.pathname.startsWith('/agent') || $page.url.pathname.includes('/history')) {
             await goto(`/agent?session=${id}`);
         }
@@ -46,15 +32,16 @@
 
     async function closeSessionTab(e, id) {
         e.stopPropagation();
+        const wasActive = $activeTabId === id;
         try {
             await deleteSession(id);
         } catch (_) { /* might already be archived */ }
         closeTab(id);
-        tabs = [...getOpenTabs()];
-        activeId = getActiveTabId();
-        if (id === activeId && $page.url.pathname.startsWith('/agent')) {
-            if (tabs.length > 0) {
-                await goto(`/agent?session=${tabs[tabs.length - 1].id}`);
+        // No manual refresh needed — the store update propagates automatically.
+        if (wasActive && $page.url.pathname.startsWith('/agent')) {
+            const remaining = $openTabs;
+            if (remaining.length > 0) {
+                await goto(`/agent?session=${remaining[remaining.length - 1].id}`);
             } else {
                 await goto('/agent/history');
             }
@@ -62,15 +49,15 @@
     }
 </script>
 
-{#if tabs.length > 0}
+{#if $openTabs.length > 0}
     <div class="bg-white border-b border-gray-200 px-4 sm:px-6 lg:px-8">
         <div class="max-w-7xl mx-auto flex items-center gap-1 overflow-x-auto py-1">
-            {#each tabs as tab}
+            {#each $openTabs as tab}
                 <button
                     onclick={() => switchToTab(tab.id)}
                     class="group flex items-center gap-1.5 px-3 py-1.5 rounded-t-md text-sm whitespace-nowrap
                            transition-colors border border-b-0
-                           {activeId === tab.id && !$page.url.pathname.includes('/history')
+                           {$activeTabId === tab.id && !$page.url.pathname.includes('/history')
                              ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
                              : 'border-transparent text-gray-500 hover:text-gray-700 hover:bg-gray-50'}"
                 >

--- a/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
@@ -801,7 +801,7 @@
 			// Route through apiFetch so an expired token triggers global session
 			// recovery, and so the response goes through one well-tested code path.
 			// (#352, H11 + M3)
-			const response = await apiFetch('/creator/files/upload', {
+			const response = await apiFetch('/files/upload', {
 				method: 'POST',
 				body: formData,
 			});

--- a/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
@@ -11,8 +11,9 @@
 	import { goto } from '$app/navigation'; // Import for redirect
 	import { base } from '$app/paths'; // Import base path
 	import { createEventDispatcher } from 'svelte'; // Import event dispatcher
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { getSystemCapabilities } from '$lib/services/assistantService'; // Import service
+	import { apiFetch } from '$lib/services/apiClient';
 	import { locale } from '$lib/i18n';
 	import TemplateSelectModal from '$lib/components/modals/TemplateSelectModal.svelte'; // Import template modal
 	import { openTemplateSelectModal } from '$lib/stores/templateStore'; // Import template store function
@@ -20,6 +21,11 @@
 	import { getAssistantMetadataObject } from '$lib/utils/assistantData';
 
 	const dispatch = createEventDispatcher(); // For dispatching success event
+
+	// Track mount status so async fetches that resolve after the user
+	// navigates away don't write state to a destroyed component. (#352, M13)
+	let isMounted = true;
+	onDestroy(() => { isMounted = false; });
 
 	// --- Props --- 
 	// Use $props for Svelte 5 runes mode
@@ -654,22 +660,28 @@
 					return [];
 				})
 			]);
-			
+
+			if (!isMounted) return; // user navigated away while fetching (#352, M13)
+
 			// Sort each separately
 			owned.sort((a, b) => a.name.localeCompare(b.name));
 			shared.sort((a, b) => a.name.localeCompare(b.name));
-			
+
 			ownedKnowledgeBases = owned;
 			sharedKnowledgeBases = shared;
 		} catch (err) {
+			if (!isMounted) return;
+			if (err instanceof Error && err.message.startsWith('Session expired')) return;
 			console.error('Error fetching knowledge bases:', err);
 			knowledgeBaseError = err instanceof Error ? err.message : 'Failed to load knowledge bases';
 			ownedKnowledgeBases = [];
 			sharedKnowledgeBases = [];
 		} finally {
-			loadingKnowledgeBases = false;
-			kbFetchAttempted = true; // Mark fetch as attempted
-			console.log(`KB Fetch complete (Attempted: ${kbFetchAttempted}, Error: '${knowledgeBaseError}', Owned: ${ownedKnowledgeBases.length}, Shared: ${sharedKnowledgeBases.length})`);
+			if (isMounted) {
+				loadingKnowledgeBases = false;
+				kbFetchAttempted = true;
+				console.log(`KB Fetch complete (Attempted: ${kbFetchAttempted}, Error: '${knowledgeBaseError}', Owned: ${ownedKnowledgeBases.length}, Shared: ${sharedKnowledgeBases.length})`);
+			}
 		}
 	}
 
@@ -781,32 +793,17 @@
 		fileUploadLoading = true;
 		fileUploadError = '';
 
+		// Create FormData object
+		const formData = new FormData();
+		formData.append('file', file);
+
 		try {
-			const token = getAuthToken();
-			if (!token) {
-				throw new Error('Authentication token not found');
-			}
-
-			// Get the lamb server URL
-			const lambServerUrl = window.LAMB_CONFIG?.api?.lambServer;
-			if (!lambServerUrl) {
-				throw new Error('LAMB server URL not configured');
-			}
-
-			// Create FormData object
-			const formData = new FormData();
-			formData.append('file', file);
-
-			// Call the files/upload endpoint
-			const endpointPath = '/creator/files/upload';
-			const apiUrl = `${lambServerUrl.replace(/\/$/, '')}${endpointPath}`;
-			
-			const response = await fetch(apiUrl, {
+			// Route through apiFetch so an expired token triggers global session
+			// recovery, and so the response goes through one well-tested code path.
+			// (#352, H11 + M3)
+			const response = await apiFetch('/creator/files/upload', {
 				method: 'POST',
-				headers: {
-					'Authorization': `Bearer ${token}`
-				},
-				body: formData
+				body: formData,
 			});
 
 			if (!response.ok) {
@@ -816,18 +813,22 @@
 
 			const data = await response.json();
 			console.log('File uploaded successfully:', data);
-			
+
 			// Refresh the file list
 			await fetchUserFiles();
-			
+
 			// Auto-select the newly uploaded file
 			if (data.path) {
 				selectedFilePath = data.path;
 			}
-			
-			// Clear the file input
+
+			// Clear the file input (both the selected file state and the DOM
+			// element) so re-selecting the same file fires onchange again.
 			input.value = '';
 		} catch (err) {
+			// 'Session expired' was thrown by apiFetch and a redirect is already
+			// in flight — don't paint a duplicate banner.
+			if (err instanceof Error && err.message.startsWith('Session expired')) return;
 			console.error('Error uploading file:', err);
 			fileUploadError = err instanceof Error ? err.message : 'Failed to upload file';
 		} finally {

--- a/frontend/svelte-app/src/lib/components/evaluaitor/RubricsList.svelte
+++ b/frontend/svelte-app/src/lib/components/evaluaitor/RubricsList.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { createEventDispatcher } from 'svelte';
   import { _, locale } from '$lib/i18n';
@@ -46,30 +46,45 @@
   let totalPages = $state(1);
   let totalItems = $state(0);
 
+  // Tag every load so a slow earlier fetch (e.g. 'my-rubrics') resolving
+  // after a tab switch can't overwrite the now-current 'templates' list.
+  // Also gate writes behind isMounted so unmount mid-fetch is safe. (#353, M3)
+  let isMounted = true;
+  let loadSeq = 0;
+  onDestroy(() => { isMounted = false; });
+
   // Load all rubrics based on active tab
   async function loadRubrics() {
+    const mySeq = ++loadSeq;
     loading = true;
     error = null;
 
     try {
       // Fetch all rubrics (backend max is 100 items)
       let response;
-      
-      if (activeTab === 'my-rubrics') {
+      const tabAtRequest = activeTab;
+      if (tabAtRequest === 'my-rubrics') {
         response = await fetchRubrics(100, 0, {});
       } else {
         response = await fetchPublicRubrics(100, 0, {});
       }
-      
+
+      if (!isMounted || mySeq !== loadSeq) return;
+      // The active tab might have changed AGAIN while we awaited; only commit
+      // if the request matches the current tab.
+      if (tabAtRequest !== activeTab) return;
+
       allRubrics = response.rubrics || [];
       applyFiltersAndPagination();
     } catch (err) {
+      if (!isMounted || mySeq !== loadSeq) return;
+      if (err instanceof Error && err.message.startsWith('Session expired')) return;
       error = err.message || `Failed to load ${activeTab === 'my-rubrics' ? 'rubrics' : 'templates'}`;
       console.error(`Error loading ${activeTab}:`, err);
       allRubrics = [];
       displayRubrics = [];
     } finally {
-      loading = false;
+      if (isMounted && mySeq === loadSeq) loading = false;
     }
   }
   

--- a/frontend/svelte-app/src/lib/components/libraries/LibraryDetail.svelte
+++ b/frontend/svelte-app/src/lib/components/libraries/LibraryDetail.svelte
@@ -4,7 +4,7 @@
   Receives libraryId as a prop from the page.
 -->
 <script>
-    import { onMount } from 'svelte';
+    import { onMount, onDestroy } from 'svelte';
     import {
         getLibrary, getItems, uploadFile, deleteItem,
         getItemStatus, exportLibrary, toggleSharing,
@@ -33,6 +33,7 @@
     // Polling
     let pendingItemIds = $state(new Set());
     let pollInterval = $state(null);
+    let pollFailures = 0;
 
     // Delete item modal
     let showDeleteItemModal = $state(false);
@@ -44,10 +45,27 @@
 
     let isOwner = $derived(library?.is_owner ?? false);
 
+    // --- Resilience plumbing (#352, M4-M7) ---
+    // - isMounted prevents setState writes after the user navigates away
+    // - currentLoadId tags every loadData() invocation so a stale fetch that
+    //   resolves AFTER a newer one cannot overwrite current state
+    // - successTimer is tracked so we can clear it on unmount
+    let isMounted = true;
+    let currentLoadId = 0;
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    let successTimer = null;
+
     onMount(() => {
         return () => {
+            // Legacy return-from-onMount cleanup; full cleanup is in onDestroy.
             if (pollInterval) clearInterval(pollInterval);
         };
+    });
+
+    onDestroy(() => {
+        isMounted = false;
+        if (pollInterval) clearInterval(pollInterval);
+        if (successTimer) clearTimeout(successTimer);
     });
 
     $effect(() => {
@@ -58,6 +76,11 @@
     });
 
     async function loadData() {
+        // Tag this run; if a newer call starts before we finish, our writes
+        // are dropped on resolution to prevent stale data from clobbering
+        // the current view (#352, M4).
+        const myLoadId = ++currentLoadId;
+
         if (pollInterval) { clearInterval(pollInterval); pollInterval = null; }
         loading = true;
         error = '';
@@ -66,20 +89,25 @@
                 getLibrary(libraryId),
                 getItems(libraryId, { limit: 100 }),
             ]);
+            if (!isMounted || myLoadId !== currentLoadId) return;
             library = lib;
             items = itemsData.items || [];
             totalItems = itemsData.total || items.length;
             startPollingIfNeeded();
         } catch (/** @type {unknown} */ err) {
+            if (!isMounted || myLoadId !== currentLoadId) return;
+            // Session-expired errors are already redirecting elsewhere.
+            if (err instanceof Error && err.message.startsWith('Session expired')) return;
             console.error('Error loading library:', err);
             error = err instanceof Error ? err.message : 'Failed to load library';
         } finally {
-            loading = false;
+            if (isMounted && myLoadId === currentLoadId) loading = false;
         }
     }
 
     function startPollingIfNeeded() {
         if (pollInterval) clearInterval(pollInterval);
+        pollFailures = 0;
         const pending = items.filter(i => i.status === 'processing' || i.status === 'pending');
         if (pending.length === 0) return;
         pendingItemIds = new Set(pending.map(i => i.id));
@@ -87,14 +115,17 @@
     }
 
     async function pollPendingItems() {
+        if (!isMounted) return;
         if (pendingItemIds.size === 0) {
             clearInterval(pollInterval);
             pollInterval = null;
             return;
         }
+        let sawError = false;
         for (const itemId of [...pendingItemIds]) {
             try {
                 const status = await getItemStatus(libraryId, itemId);
+                if (!isMounted) return;
                 if (status.status === 'ready' || status.status === 'failed') {
                     pendingItemIds.delete(itemId);
                     pendingItemIds = new Set(pendingItemIds);
@@ -104,9 +135,30 @@
                         items = [...items];
                     }
                 }
-            } catch {
-                // Ignore individual poll errors
+            } catch (e) {
+                // Session-expired aborts the whole poll loop — stop polling so
+                // we don't keep hammering after the redirect kicks in.
+                if (e instanceof Error && e.message.startsWith('Session expired')) {
+                    clearInterval(pollInterval);
+                    pollInterval = null;
+                    return;
+                }
+                sawError = true;
             }
+        }
+        if (sawError) {
+            // After 5 consecutive cycles where every probe errored, stop and
+            // surface a banner. Previously errors were silently swallowed and
+            // items appeared "processing" forever (#352, M5).
+            pollFailures += 1;
+            if (pollFailures >= 5) {
+                clearInterval(pollInterval);
+                pollInterval = null;
+                error = 'Lost connection while checking item status. Reload to retry.';
+                return;
+            }
+        } else {
+            pollFailures = 0;
         }
         if (pendingItemIds.size === 0 && pollInterval) {
             clearInterval(pollInterval);
@@ -116,7 +168,13 @@
 
     function showSuccess(msg) {
         successMessage = msg;
-        setTimeout(() => { successMessage = ''; }, 4000);
+        // Clear any previous pending timer so rapid successes don't accumulate
+        // and so unmount doesn't fire setState on a destroyed component (#352, M6).
+        if (successTimer) clearTimeout(successTimer);
+        successTimer = setTimeout(() => {
+            if (isMounted) successMessage = '';
+            successTimer = null;
+        }, 4000);
     }
 
     const SIMPLE_IMPORT_EXTENSIONS = new Set(['txt', 'md', 'html', 'htm']);

--- a/frontend/svelte-app/src/lib/components/modals/CreateLibraryModal.svelte
+++ b/frontend/svelte-app/src/lib/components/modals/CreateLibraryModal.svelte
@@ -94,13 +94,18 @@
         role="dialog"
         aria-modal="true"
         aria-labelledby="create-library-title"
+        tabindex="-1"
         onclick={handleBackdropClick}
         onkeydown={handleKeydown}
     >
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <!-- Inner panel: presentational only — clicks are stopped to keep the
+             backdrop from closing the modal, but it has no semantic interaction
+             of its own (the backdrop and form inputs handle keyboard / aria). -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
             class="bg-white rounded-lg shadow-xl w-full max-w-md mx-4"
+            role="presentation"
             onclick={stopPropagation}
         >
             <div class="px-6 py-4 border-b border-gray-200">

--- a/frontend/svelte-app/src/lib/components/modals/ImportModal.svelte
+++ b/frontend/svelte-app/src/lib/components/modals/ImportModal.svelte
@@ -143,12 +143,14 @@
         role="dialog"
         aria-modal="true"
         aria-labelledby="import-modal-title"
+        tabindex="-1"
         onclick={handleBackdropClick}
         onkeydown={handleKeydown}
     >
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <!-- Inner panel: presentational only — see CreateLibraryModal for context. -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <div class="bg-white rounded-lg shadow-xl w-full max-w-lg mx-4" onclick={stopPropagation}>
+        <div class="bg-white rounded-lg shadow-xl w-full max-w-lg mx-4" role="presentation" onclick={stopPropagation}>
             <div class="px-6 py-4 border-b border-gray-200">
                 <h2 id="import-modal-title" class="text-lg font-semibold text-gray-900">
                     {$_('libraries.importModal.title', { default: 'Import Content' })}
@@ -160,10 +162,10 @@
                     <div class="p-3 text-sm text-red-700 bg-red-50 rounded-md" role="alert">{error}</div>
                 {/if}
 
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-2">
+                <fieldset>
+                    <legend class="block text-sm font-medium text-gray-700 mb-2">
                         {$_('libraries.importModal.typeLabel', { default: 'Import type' })}
-                    </label>
+                    </legend>
                     <div class="flex gap-2">
                         {#each [
                             { value: 'url', label: $_('libraries.importModal.typeUrl', { default: 'URL' }) },
@@ -179,7 +181,7 @@
                             </button>
                         {/each}
                     </div>
-                </div>
+                </fieldset>
 
                 {#if importType === 'url'}
                     <div>

--- a/frontend/svelte-app/src/lib/components/modals/TemplateSelectModal.svelte
+++ b/frontend/svelte-app/src/lib/components/modals/TemplateSelectModal.svelte
@@ -24,11 +24,19 @@
   /** @type {any | null} */
   let selectedTemplate = $state(null);
   
-  // Load templates when modal opens
+  // Load templates when modal opens. Dedupe across re-runs of the effect so
+  // the same open state doesn't keep firing fetches if other reactive deps
+  // change while the modal is open. The store-level sequence guards already
+  // protect against in-flight races, but skipping the duplicate work here
+  // saves bandwidth. (#353, M3)
+  let lastLoadedOpen = false;
   $effect(() => {
-    if ($templateSelectModalOpen) {
+    if ($templateSelectModalOpen && !lastLoadedOpen) {
+      lastLoadedOpen = true;
       loadUserTemplates();
       loadSharedTemplates();
+    } else if (!$templateSelectModalOpen) {
+      lastLoadedOpen = false;
     }
   });
   

--- a/frontend/svelte-app/src/lib/config.js
+++ b/frontend/svelte-app/src/lib/config.js
@@ -2,20 +2,21 @@ import { browser } from '$app/environment';
 
 // Default config structure (adjust as needed based on actual config.js)
 const defaultConfig = {
-    api: {
-        baseUrl: '/creator', // Default or fallback base URL
-        lambServer: 'http://localhost:9099', // Default LAMB server URL
-        // Note: lambApiKey removed for security - now using user authentication
-    },
-    // Static assets configuration
-    assets: {
-        path: '/static'
-    },
-    // Feature flags
-    features: {
-        enableOpenWebUi: true,
-        enableDebugMode: true
-    }
+	api: {
+		baseUrl: '/creator', // Default or fallback base URL
+		lambServer: 'http://localhost:9099' // Default LAMB server URL
+		// Note: lambApiKey removed for security - now using user authentication
+	},
+	// Static assets configuration
+	assets: {
+		path: '/static'
+	},
+	// Feature flags
+	features: {
+		enableOpenWebUi: true,
+		enableDebugMode: true,
+		enableLibraries: true
+	}
 };
 
 /**
@@ -23,11 +24,11 @@ const defaultConfig = {
  * @returns {typeof defaultConfig} The configuration object.
  */
 export function getConfig() {
-    if (browser && window.LAMB_CONFIG) {
-        return window.LAMB_CONFIG;
-    }
-    console.warn('LAMB_CONFIG not found on window, using default.');
-    return defaultConfig;
+	if (browser && window.LAMB_CONFIG) {
+		return window.LAMB_CONFIG;
+	}
+	console.warn('LAMB_CONFIG not found on window, using default.');
+	return defaultConfig;
 }
 
 /**
@@ -36,10 +37,10 @@ export function getConfig() {
  * @returns {string} The full API URL.
  */
 export function getApiUrl(endpoint) {
-    const config = getConfig();
-    const base = config?.api?.baseUrl || defaultConfig.api.baseUrl;
-    // Ensure no double slashes
-    return `${base.replace(/\/$/, '')}/${endpoint.replace(/^\//, '')}`;
+	const config = getConfig();
+	const base = config?.api?.baseUrl || defaultConfig.api.baseUrl;
+	// Ensure no double slashes
+	return `${base.replace(/\/$/, '')}/${endpoint.replace(/^\//, '')}`;
 }
 
 /**
@@ -50,13 +51,13 @@ export function getApiUrl(endpoint) {
  * @returns {string} The full API URL using lambServer config.
  */
 export function getLambApiUrl(endpoint) {
-    const config = getConfig();
-    const baseUrl = config?.api?.lambServer || defaultConfig.api.lambServer;
-    // Ensure no double slashes
-    const cleanBase = baseUrl.replace(/\/$/, '');
-    const cleanEndpoint = endpoint.replace(/^\//, '');
-    return `${cleanBase}/${cleanEndpoint}`;
+	const config = getConfig();
+	const baseUrl = config?.api?.lambServer || defaultConfig.api.lambServer;
+	// Ensure no double slashes
+	const cleanBase = baseUrl.replace(/\/$/, '');
+	const cleanEndpoint = endpoint.replace(/^\//, '');
+	return `${cleanBase}/${cleanEndpoint}`;
 }
 
 // You might export other config values if needed
-// export const API_CONFIG = getConfig().api; 
+// export const API_CONFIG = getConfig().api;

--- a/frontend/svelte-app/src/lib/services/aacService.js
+++ b/frontend/svelte-app/src/lib/services/aacService.js
@@ -1,5 +1,4 @@
-import { getApiUrl } from '$lib/config';
-import { browser } from '$app/environment';
+import { apiFetch, apiJson } from '$lib/services/apiClient';
 
 /**
  * @typedef {Object} AacSession
@@ -14,45 +13,12 @@ import { browser } from '$app/environment';
  * @property {string} [first_message]
  */
 
-/** @returns {string} */
-function getToken() {
-	if (!browser) return '';
-	return localStorage.getItem('userToken') || '';
-}
-
-/** @param {string} endpoint @param {Object} [options] */
-async function apiFetch(endpoint, options = {}) {
-	const token = getToken();
-	if (!token) throw new Error('Not authenticated');
-
-	const url = getApiUrl(endpoint);
-	const res = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'Content-Type': 'application/json',
-			...options.headers,
-		},
-		...options,
-	});
-
-	if (!res.ok) {
-		let detail = `API error (${res.status})`;
-		try {
-			const err = await res.json();
-			detail = err?.detail || detail;
-		} catch (_) { /* ignore */ }
-		throw new Error(detail);
-	}
-
-	return res.json();
-}
-
 /**
  * List available AAC skills.
  * @returns {Promise<Array<{id: string, name: string, description: string, required_context: string[]}>>}
  */
 export async function getSkills() {
-	return apiFetch('/aac/skills');
+	return apiJson('/aac/skills');
 }
 
 /**
@@ -60,7 +26,7 @@ export async function getSkills() {
  * @returns {Promise<AacSession[]>}
  */
 export async function getSessions() {
-	return apiFetch('/aac/sessions');
+	return apiJson('/aac/sessions');
 }
 
 /**
@@ -69,7 +35,7 @@ export async function getSessions() {
  * @returns {Promise<AacSession>}
  */
 export async function getSession(sessionId) {
-	return apiFetch(`/aac/sessions/${sessionId}`);
+	return apiJson(`/aac/sessions/${sessionId}`);
 }
 
 /**
@@ -89,7 +55,7 @@ export async function createSession({ assistantId, skill, context } = {}) {
 		body.context = { ...context };
 		if (assistantId != null) body.context.assistant_id = assistantId;
 	}
-	return apiFetch('/aac/sessions', {
+	return apiJson('/aac/sessions', {
 		method: 'POST',
 		body: JSON.stringify(body),
 	});
@@ -102,7 +68,7 @@ export async function createSession({ assistantId, skill, context } = {}) {
  * @returns {Promise<{response: string, stats: Object}>}
  */
 export async function sendMessage(sessionId, message) {
-	return apiFetch(`/aac/sessions/${sessionId}/message`, {
+	return apiJson(`/aac/sessions/${sessionId}/message`, {
 		method: 'POST',
 		body: JSON.stringify({ message }),
 	});
@@ -110,26 +76,40 @@ export async function sendMessage(sessionId, message) {
 
 /**
  * Send a message and stream the response via SSE.
+ *
+ * Pass `signal` from an `AbortController` so the caller (typically the
+ * AAC terminal component) can cancel the stream on unmount. Without this
+ * the underlying fetch + reader keeps running in the background after the
+ * user navigates away — memory leak + ghost HTTP traffic. (#352)
+ *
+ * Routed through `apiFetch` so an expired token triggers global session
+ * recovery instead of a generic "HTTP 401" surfaced to the user. (#352, M1)
+ *
  * @param {string} sessionId
  * @param {string} message
  * @param {(chunk: string) => void} onChunk - called for each text chunk
  * @param {(stats: Object) => void} [onDone] - called when stream completes
  * @param {(error: string) => void} [onError] - called on error
  * @param {(status: Object) => void} [onStatus] - called for tool/status events
+ * @param {AbortSignal} [signal] - abort signal to cancel the stream
  */
-export async function sendMessageStream(sessionId, message, onChunk, onDone, onError, onStatus) {
-	const token = getToken();
-	if (!token) throw new Error('Not authenticated');
-
-	const url = getApiUrl(`/aac/sessions/${sessionId}/message/stream`);
-	const res = await fetch(url, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify({ message }),
-	});
+export async function sendMessageStream(sessionId, message, onChunk, onDone, onError, onStatus, signal) {
+	let res;
+	try {
+		res = await apiFetch(`/aac/sessions/${sessionId}/message/stream`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ message }),
+			signal,
+		});
+	} catch (e) {
+		// AbortError on unmount is expected; do not surface as an error.
+		if (e?.name === 'AbortError') return;
+		// Session-expired errors from apiFetch already triggered a redirect;
+		// just exit quietly so we don't paint a duplicate error in the terminal.
+		if (e instanceof Error && e.message.startsWith('Session expired')) return;
+		throw e;
+	}
 
 	if (!res.ok) {
 		const err = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
@@ -143,26 +123,35 @@ export async function sendMessageStream(sessionId, message, onChunk, onDone, onE
 	const decoder = new TextDecoder();
 	let buffer = '';
 
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) break;
+	try {
+		while (true) {
+			if (signal?.aborted) {
+				try { await reader.cancel(); } catch (_) { /* noop */ }
+				return;
+			}
+			const { done, value } = await reader.read();
+			if (done) break;
 
-		buffer += decoder.decode(value, { stream: true });
-		const lines = buffer.split('\n');
-		buffer = lines.pop() || '';
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split('\n');
+			buffer = lines.pop() || '';
 
-		for (const line of lines) {
-			if (!line.startsWith('data: ')) continue;
-			const payload = line.slice(6);
-			if (payload === '[DONE]') return;
-			try {
-				const data = JSON.parse(payload);
-				if (data.content) onChunk(data.content);
-				else if (data.status && onStatus) onStatus(data);
-				if (data.done && onDone) onDone(data.stats || {});
-				if (data.error && onError) onError(data.error);
-			} catch (_) { /* ignore parse errors */ }
+			for (const line of lines) {
+				if (!line.startsWith('data: ')) continue;
+				const payload = line.slice(6);
+				if (payload === '[DONE]') return;
+				try {
+					const data = JSON.parse(payload);
+					if (data.content) onChunk(data.content);
+					else if (data.status && onStatus) onStatus(data);
+					if (data.done && onDone) onDone(data.stats || {});
+					if (data.error && onError) onError(data.error);
+				} catch (_) { /* ignore parse errors */ }
+			}
 		}
+	} catch (e) {
+		if (e?.name === 'AbortError') return;
+		throw e;
 	}
 }
 
@@ -172,5 +161,5 @@ export async function sendMessageStream(sessionId, message, onChunk, onDone, onE
  * @returns {Promise<{success: boolean}>}
  */
 export async function deleteSession(sessionId) {
-	return apiFetch(`/aac/sessions/${sessionId}`, { method: 'DELETE' });
+	return apiJson(`/aac/sessions/${sessionId}`, { method: 'DELETE' });
 }

--- a/frontend/svelte-app/src/lib/services/adminService.js
+++ b/frontend/svelte-app/src/lib/services/adminService.js
@@ -1,226 +1,115 @@
-import { getApiUrl } from '$lib/config';
+import { apiFetch } from '$lib/services/apiClient';
+
+// All admin endpoints route through apiFetch so an expired token triggers a
+// global session reset + redirect, instead of a generic "Failed to fetch"
+// banner that would otherwise force the admin to manually reload. (#352, M16)
+
+/**
+ * @param {string} path
+ * @param {string} token
+ * @param {RequestInit} [init]
+ * @returns {Promise<any>}
+ */
+async function jsonRequest(path, token, init = {}) {
+	const response = await apiFetch(path, {
+		token,
+		headers: { 'Content-Type': 'application/json' },
+		...init,
+	});
+	if (!response.ok) {
+		// Tolerate non-JSON 5xx responses (Caddy/proxy HTML) instead of throwing
+		// the misleading "Failed to fetch" that the bare .json() path produced.
+		let detail;
+		try {
+			const err = await response.json();
+			detail = err?.error || err?.detail;
+		} catch (_) { /* not JSON */ }
+		throw new Error(detail || `Request failed (${response.status})`);
+	}
+	return response.json();
+}
 
 /**
  * Fetch the current user's profile (resource overview)
- * @param {string} token - Authorization token
- * @returns {Promise<any>} - Promise resolving to user profile data
+ * @param {string} token
+ * @returns {Promise<any>}
  */
 export async function getMyProfile(token) {
-	try {
-		const response = await fetch(getApiUrl('/user/profile'), {
-			method: 'GET',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			}
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to fetch profile');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error fetching user profile:', error);
-		throw error;
-	}
+	return jsonRequest('/user/profile', token, { method: 'GET' });
 }
 
 /**
  * Fetch a specific user's profile (admin/org-admin)
- * @param {string} token - Authorization token
- * @param {number} userId - User ID to fetch profile for
- * @returns {Promise<any>} - Promise resolving to user profile data
+ * @param {string} token
+ * @param {number} userId
+ * @returns {Promise<any>}
  */
 export async function getUserProfile(token, userId) {
-	try {
-		const response = await fetch(getApiUrl(`/admin/users/${userId}/profile`), {
-			method: 'GET',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			}
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to fetch user profile');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error fetching user profile:', error);
-		throw error;
-	}
+	return jsonRequest(`/admin/users/${userId}/profile`, token, { method: 'GET' });
 }
 
 /**
  * Disable a user account
- * @param {string} token - Authorization token
- * @param {number} userId - User ID to disable
- * @returns {Promise<any>} - Promise resolving to operation result
+ * @param {string} token
+ * @param {number} userId
+ * @returns {Promise<any>}
  */
 export async function disableUser(token, userId) {
-	try {
-		const response = await fetch(getApiUrl(`/admin/users/${userId}/disable`), {
-			method: 'PUT',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			}
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to disable user');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error disabling user:', error);
-		throw error;
-	}
+	return jsonRequest(`/admin/users/${userId}/disable`, token, { method: 'PUT' });
 }
 
 /**
  * Enable a user account
- * @param {string} token - Authorization token
- * @param {number} userId - User ID to enable
- * @returns {Promise<any>} - Promise resolving to operation result
+ * @param {string} token
+ * @param {number} userId
+ * @returns {Promise<any>}
  */
 export async function enableUser(token, userId) {
-	try {
-		const response = await fetch(getApiUrl(`/admin/users/${userId}/enable`), {
-			method: 'PUT',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			}
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to enable user');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error enabling user:', error);
-		throw error;
-	}
+	return jsonRequest(`/admin/users/${userId}/enable`, token, { method: 'PUT' });
 }
 
 /**
  * Disable multiple user accounts
- * @param {string} token - Authorization token
- * @param {number[]} userIds - Array of user IDs to disable
- * @returns {Promise<any>} - Promise resolving to bulk operation result
+ * @param {string} token
+ * @param {number[]} userIds
+ * @returns {Promise<any>}
  */
 export async function disableUsersBulk(token, userIds) {
-	try {
-		const response = await fetch(getApiUrl('/admin/users/disable-bulk'), {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify({ user_ids: userIds })
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to disable users');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error disabling users:', error);
-		throw error;
-	}
+	return jsonRequest('/admin/users/disable-bulk', token, {
+		method: 'POST',
+		body: JSON.stringify({ user_ids: userIds }),
+	});
 }
 
 /**
  * Enable multiple user accounts
- * @param {string} token - Authorization token
- * @param {number[]} userIds - Array of user IDs to enable
- * @returns {Promise<any>} - Promise resolving to bulk operation result
+ * @param {string} token
+ * @param {number[]} userIds
+ * @returns {Promise<any>}
  */
 export async function enableUsersBulk(token, userIds) {
-	try {
-		const response = await fetch(getApiUrl('/admin/users/enable-bulk'), {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify({ user_ids: userIds })
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to enable users');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error enabling users:', error);
-		throw error;
-	}
+	return jsonRequest('/admin/users/enable-bulk', token, {
+		method: 'POST',
+		body: JSON.stringify({ user_ids: userIds }),
+	});
 }
 
 /**
  * Check user dependencies (assistants and knowledge bases)
- * @param {string} token - Authorization token
- * @param {number} userId - User ID to check
- * @returns {Promise<any>} - Promise resolving to dependencies info
+ * @param {string} token
+ * @param {number} userId
+ * @returns {Promise<any>}
  */
 export async function checkUserDependencies(token, userId) {
-	try {
-		const response = await fetch(getApiUrl(`/admin/users/${userId}/dependencies`), {
-			method: 'GET',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			}
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to check user dependencies');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error checking user dependencies:', error);
-		throw error;
-	}
+	return jsonRequest(`/admin/users/${userId}/dependencies`, token, { method: 'GET' });
 }
 
 /**
  * Delete a disabled user (must have no dependencies)
- * @param {string} token - Authorization token
- * @param {number} userId - User ID to delete
- * @returns {Promise<any>} - Promise resolving to operation result
+ * @param {string} token
+ * @param {number} userId
+ * @returns {Promise<any>}
  */
 export async function deleteUser(token, userId) {
-	try {
-		const response = await fetch(getApiUrl(`/admin/users/${userId}`), {
-			method: 'DELETE',
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'Content-Type': 'application/json'
-			}
-		});
-
-		if (!response.ok) {
-			const error = await response.json();
-			throw new Error(error.error || error.detail || 'Failed to delete user');
-		}
-
-		return await response.json();
-	} catch (error) {
-		console.error('Error deleting user:', error);
-		throw error;
-	}
+	return jsonRequest(`/admin/users/${userId}`, token, { method: 'DELETE' });
 }

--- a/frontend/svelte-app/src/lib/services/analyticsService.js
+++ b/frontend/svelte-app/src/lib/services/analyticsService.js
@@ -7,7 +7,10 @@
 
 import { getApiUrl } from '$lib/config';
 import { browser } from '$app/environment';
-import axios from 'axios';
+// Shared axios instance with global 401 handling (#352, M1/M2/M3).
+import { apiAxios as axios } from '$lib/services/apiClient';
+import { isAxiosError } from 'axios';
+axios.isAxiosError = isAxiosError;
 
 /**
  * @typedef {Object} ChatSummary

--- a/frontend/svelte-app/src/lib/services/apiClient.js
+++ b/frontend/svelte-app/src/lib/services/apiClient.js
@@ -1,0 +1,175 @@
+/**
+ * Centralized API client for LAMB.
+ *
+ * Provides a single source of truth for:
+ * - Bearer token attachment (from localStorage userToken)
+ * - Global 401 handling — clears the session and redirects to login,
+ *   so an expired OWI session no longer leaves the UI silently broken
+ *   until the user manually reloads the page (#352, M1/M2/M3).
+ *
+ * Two transports are exported so existing services can migrate without a
+ * fetch ↔ axios rewrite:
+ *
+ *   - `apiFetch(path, options)` — fetch-based, returns Response
+ *   - `apiJson(path, options)`  — fetch-based, parses JSON, throws on !ok
+ *   - `apiAxios`                — axios instance with the same 401 interceptor
+ *
+ * Two auth-related extra options on top of standard `RequestInit`:
+ *   - `skipAuth`  — disable token auto-attach AND 401 redirect (login/signup)
+ *   - `token`     — use this token instead of the stored one (e.g. LTI bootstrap)
+ */
+
+import axios from 'axios';
+import { browser } from '$app/environment';
+import { goto } from '$app/navigation';
+import { base } from '$app/paths';
+import { getApiUrl } from '$lib/config';
+
+// Guard against re-entrant redirects: if a page has many concurrent in-flight
+// requests and they all 401 at once, only fire one redirect.
+let _redirecting = false;
+
+/** @returns {string} */
+function getStoredToken() {
+	return browser ? (localStorage.getItem('userToken') || '') : '';
+}
+
+async function handleUnauthorized() {
+	if (!browser) return;
+	if (_redirecting) return;
+	_redirecting = true;
+
+	try {
+		// Dynamic import to avoid circular dep with stores at module load.
+		const { clearCurrentSession } = await import('$lib/session/sessionManager');
+		clearCurrentSession();
+	} catch (e) {
+		console.error('Failed to clear session during 401 handling:', e);
+	}
+
+	try {
+		// Root path renders the Login component when not authenticated.
+		await goto(`${base}/`, { replaceState: true });
+	} catch (e) {
+		console.error('Failed to redirect after 401:', e);
+	}
+
+	// Reset the guard after navigation has had time to settle.
+	setTimeout(() => { _redirecting = false; }, 1500);
+}
+
+/**
+ * @typedef {RequestInit & { skipAuth?: boolean, token?: string }} ApiFetchOptions
+ */
+
+/**
+ * Centralized fetch with bearer-token attachment and global 401 handling.
+ *
+ * @param {string} path - API path (e.g. '/creator/assistants') or full URL
+ * @param {ApiFetchOptions} [options]
+ * @returns {Promise<Response>}
+ */
+export async function apiFetch(path, options = {}) {
+	const { skipAuth, token: explicitToken, headers: rawHeaders, ...fetchOptions } = options;
+	const headers = new Headers(rawHeaders || {});
+
+	let tokenForRequest = '';
+	if (!skipAuth) {
+		tokenForRequest = explicitToken || getStoredToken();
+		if (tokenForRequest && !headers.has('Authorization')) {
+			headers.set('Authorization', `Bearer ${tokenForRequest}`);
+		}
+	}
+
+	const url = path.startsWith('http') ? path : getApiUrl(path);
+	const res = await fetch(url, { ...fetchOptions, headers });
+
+	if (res.status === 401 && !skipAuth && tokenForRequest) {
+		// We sent a token and the server rejected it: session expired.
+		// Trigger global recovery and surface a clean error to the caller.
+		handleUnauthorized();
+		throw new Error('Session expired — redirecting to login');
+	}
+
+	return res;
+}
+
+/**
+ * JSON convenience wrapper. Throws on non-OK with the parsed `detail` or
+ * `error` field as the message. Use this for the common case of JSON
+ * request → JSON response endpoints.
+ *
+ * @param {string} path
+ * @param {ApiFetchOptions} [options]
+ * @returns {Promise<any>}
+ */
+export async function apiJson(path, options = {}) {
+	const headers = new Headers(options.headers || {});
+	if (!headers.has('Content-Type') && options.body && typeof options.body === 'string') {
+		headers.set('Content-Type', 'application/json');
+	}
+	const res = await apiFetch(path, { ...options, headers });
+
+	if (!res.ok) {
+		let detail = `API error (${res.status})`;
+		try {
+			const err = await res.json();
+			detail = err?.detail || err?.error || detail;
+		} catch (_) { /* response wasn't JSON */ }
+		throw new Error(detail);
+	}
+
+	// 204 No Content
+	if (res.status === 204) return null;
+
+	const text = await res.text();
+	if (!text) return null;
+	try {
+		return JSON.parse(text);
+	} catch (e) {
+		throw new Error('Invalid JSON response from server');
+	}
+}
+
+/**
+ * Shared axios instance for legacy services (knowledgeBaseService,
+ * assistantService, analyticsService, libraryService, templateService).
+ *
+ * - Auto-attaches the bearer token via a request interceptor (services no
+ *   longer need to thread the token through manually, though they may still
+ *   pass `Authorization` in headers and that takes precedence).
+ * - On 401 with a stored token, clears the session and redirects to login —
+ *   same global recovery as `apiFetch` (#352, M1/M2/M3).
+ *
+ * Use this instead of importing axios directly so 401 handling is consistent.
+ */
+export const apiAxios = axios.create();
+
+apiAxios.interceptors.request.use((config) => {
+	const headers = config.headers || {};
+	if (!headers.Authorization && !headers.authorization) {
+		const token = getStoredToken();
+		if (token) {
+			// axios v1 accepts header mutation either way; keep the case used
+			// elsewhere in this codebase.
+			config.headers = config.headers || {};
+			config.headers.Authorization = `Bearer ${token}`;
+		}
+	}
+	return config;
+});
+
+apiAxios.interceptors.response.use(
+	(response) => response,
+	(error) => {
+		const status = error?.response?.status;
+		if (status === 401 && getStoredToken()) {
+			handleUnauthorized();
+			// Surface a clean error so callers can early-out instead of painting
+			// stale "401 Unauthorized" UI as the redirect is in flight.
+			return Promise.reject(new Error('Session expired — redirecting to login'));
+		}
+		return Promise.reject(error);
+	}
+);
+

--- a/frontend/svelte-app/src/lib/services/assistantService.js
+++ b/frontend/svelte-app/src/lib/services/assistantService.js
@@ -1,6 +1,9 @@
 import { getApiUrl, getConfig } from '$lib/config';
 import { browser } from '$app/environment';
-import axios from 'axios';
+// Shared axios instance with global 401 handling (#352, M1/M2/M3).
+import { apiAxios as axios } from '$lib/services/apiClient';
+import { isAxiosError } from 'axios';
+axios.isAxiosError = isAxiosError;
 import { normalizeAssistantData } from '$lib/utils/assistantData';
 
 /**

--- a/frontend/svelte-app/src/lib/services/authService.js
+++ b/frontend/svelte-app/src/lib/services/authService.js
@@ -1,6 +1,10 @@
 import { getApiUrl } from '$lib/config'; // Use the new config helper
+import { apiFetch } from '$lib/services/apiClient';
 
 // This will be proxied to your FastAPI backend
+// NOTE: login() and signup() use raw fetch on purpose — at that point we have
+// no stored token yet, so the apiFetch 401 redirect would be incorrect (a 401
+// from the login endpoint is "wrong credentials", not "session expired").
 
 /**
  * Handles user login
@@ -99,16 +103,20 @@ export async function signup(name, email, password, secretKey) {
 /**
  * Fetches the current user's profile using their auth token.
  * Used after LTI login to populate user store with name, email, etc.
- * @param {string} token - Authentication token
+ *
+ * Routed through apiFetch so an expired token triggers global session
+ * recovery (clear + redirect to login) instead of leaving the app in a
+ * partial-login state where every subsequent call silently fails. (#352, M2)
+ *
+ * @param {string} token - Authentication token (LTI bootstrap path passes
+ *                         a token that may not be in localStorage yet).
  * @returns {Promise<any>} - Promise resolving to user profile data
  */
 export async function fetchUserProfile(token) {
   try {
-    const response = await fetch(getApiUrl('/me'), {
+    const response = await apiFetch('/me', {
       method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
+      token,
     });
 
     let data;
@@ -146,12 +154,10 @@ export async function fetchUserProfile(token) {
  */
 export async function getHelp(question, token) {
   try {
-    const response = await fetch(getApiUrl('/lamb_helper_assistant'), {
+    const response = await apiFetch('/lamb_helper_assistant', {
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      },
+      token,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ question })
     });
     

--- a/frontend/svelte-app/src/lib/services/knowledgeBaseService.js
+++ b/frontend/svelte-app/src/lib/services/knowledgeBaseService.js
@@ -1,6 +1,14 @@
-import axios from 'axios';
+// Use the shared axios instance from apiClient so all KB requests get
+// global 401 handling (clear session + redirect on token expiry). The local
+// alias keeps existing call sites compiling unchanged. (#352, M1/M2/M3)
+import { apiAxios as axios } from '$lib/services/apiClient';
 import { getApiUrl } from '$lib/config'; // Use the helper for API base
 import { browser } from '$app/environment';
+
+// Keep `axios.isAxiosError` available — re-export from the real package for
+// the few places this service uses it for error-shape detection.
+import { isAxiosError } from 'axios';
+axios.isAxiosError = isAxiosError;
 
 /**
  * @typedef {Object} IngestionConfig

--- a/frontend/svelte-app/src/lib/services/libraryService.js
+++ b/frontend/svelte-app/src/lib/services/libraryService.js
@@ -6,7 +6,10 @@
  * token auth, getApiUrl() for base URL, browser-only checks.
  */
 
-import axios from 'axios';
+// Shared axios instance with global 401 handling (#352, M1/M2/M3).
+import { apiAxios as axios } from '$lib/services/apiClient';
+import { isAxiosError } from 'axios';
+axios.isAxiosError = isAxiosError;
 import { getApiUrl } from '$lib/config';
 import { browser } from '$app/environment';
 

--- a/frontend/svelte-app/src/lib/services/organizationService.js
+++ b/frontend/svelte-app/src/lib/services/organizationService.js
@@ -1,4 +1,4 @@
-import { getApiUrl } from '$lib/config';
+import { apiFetch } from '$lib/services/apiClient';
 
 /**
  * Get list of all assistants in the organization
@@ -7,12 +7,10 @@ import { getApiUrl } from '$lib/config';
  */
 export async function getOrganizationAssistants(token) {
   try {
-    const response = await fetch(getApiUrl('/admin/org-admin/assistants'), {
+    const response = await apiFetch('/admin/org-admin/assistants', {
       method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      }
+      token,
+      headers: { 'Content-Type': 'application/json' }
     });
 
     if (!response.ok) {
@@ -26,5 +24,3 @@ export async function getOrganizationAssistants(token) {
     throw error;
   }
 }
-
-

--- a/frontend/svelte-app/src/lib/services/rubricService.js
+++ b/frontend/svelte-app/src/lib/services/rubricService.js
@@ -1,35 +1,21 @@
 import { getApiUrl } from '$lib/config';
 import { browser } from '$app/environment';
+// Routed through apiFetch so 401 triggers global session recovery (#352).
+import { apiFetch } from '$lib/services/apiClient';
 
 /**
- * Get authentication token from localStorage
- * @returns {string} The token
- */
-function getAuthToken() {
-    const token = localStorage.getItem('userToken');
-    if (!token) {
-        throw new Error('Not authenticated');
-    }
-    return token;
-}
-
-/**
- * Make authenticated fetch request
- * @param {string} url - The URL to fetch
+ * Make authenticated fetch request — wraps apiFetch with the JSON Content-Type
+ * default this service relies on. Token is auto-attached by apiFetch.
+ * @param {string} url - The URL to fetch (full URL, since most callers
+ *                       already build it with getApiUrl)
  * @param {Object} options - Fetch options
- * @returns {Promise<Response>} The fetch response
+ * @returns {Promise<Response>}
  */
 async function authenticatedFetch(url, options = {}) {
-    const token = getAuthToken();
-
-    const defaultOptions = {
-        headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-        }
-    };
-
-    return fetch(url, { ...defaultOptions, ...options });
+    return apiFetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+        ...options,
+    });
 }
 
 /**
@@ -93,7 +79,7 @@ export async function fetchRubrics(limit = 10, offset = 0, filters = {}) {
     const apiUrl = getApiUrl(`/rubrics?${params}`);
     console.log('Fetching rubrics from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
@@ -152,7 +138,7 @@ export async function fetchPublicRubrics(limit = 10, offset = 0, filters = {}) {
     const apiUrl = getApiUrl(`/rubrics/public?${params}`);
     console.log('Fetching public rubrics from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
@@ -195,7 +181,7 @@ export async function fetchShowcaseRubrics() {
     const apiUrl = getApiUrl('/rubrics/showcase');
     console.log('Fetching showcase rubrics from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
@@ -236,7 +222,7 @@ export async function fetchRubric(rubricId) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}`);
     console.log('Fetching rubric from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
@@ -286,7 +272,7 @@ export async function createRubric(rubricData) {
     const apiUrl = getApiUrl('/rubrics');
     console.log('Creating rubric at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${token}`
@@ -341,7 +327,7 @@ export async function updateRubric(rubricId, rubricData) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}`);
     console.log('Updating rubric at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'PUT',
         headers: {
             'Authorization': `Bearer ${token}`
@@ -382,7 +368,7 @@ export async function deleteRubric(rubricId) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}`);
     console.log('Deleting rubric at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'DELETE',
         headers: {
             'Authorization': `Bearer ${token}`
@@ -422,7 +408,7 @@ export async function duplicateRubric(rubricId) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}/duplicate`);
     console.log('Duplicating rubric at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${token}`
@@ -467,7 +453,7 @@ export async function toggleRubricVisibility(rubricId, isPublic) {
     const formData = new FormData();
     formData.append('is_public', isPublic.toString());
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'PUT',
         headers: {
             'Authorization': `Bearer ${token}`
@@ -510,7 +496,7 @@ export async function setShowcaseStatus(rubricId, isShowcase) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}/showcase`);
     console.log('Setting showcase status at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'PUT',
         headers: {
             'Authorization': `Bearer ${token}`,
@@ -552,7 +538,7 @@ export async function exportRubricJSON(rubricId) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}/export/json`);
     console.log('Exporting rubric JSON from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`
         }
@@ -609,7 +595,7 @@ export async function fetchRubricMarkdown(rubricId) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}/export/markdown`);
     console.log('Fetching rubric Markdown from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`
         }
@@ -649,7 +635,7 @@ export async function exportRubricMarkdown(rubricId) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}/export/markdown`);
     console.log('Exporting rubric Markdown from:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         headers: {
             'Authorization': `Bearer ${token}`
         }
@@ -710,7 +696,7 @@ export async function importRubric(file) {
     const apiUrl = getApiUrl('/rubrics/import');
     console.log('Importing rubric at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${token}`
@@ -764,7 +750,7 @@ export async function aiGenerateRubric(prompt, language = 'en', model = null) {
         requestBody.model = model;
     }
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${token}`,
@@ -814,7 +800,7 @@ export async function aiModifyRubric(rubricId, prompt) {
     const apiUrl = getApiUrl(`/rubrics/${rubricId}/ai-modify`);
     console.log('Modifying rubric with AI at:', apiUrl);
 
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${token}`,

--- a/frontend/svelte-app/src/lib/services/templateService.js
+++ b/frontend/svelte-app/src/lib/services/templateService.js
@@ -5,7 +5,10 @@
  * All methods require authentication via JWT token.
  */
 
-import axios from 'axios';
+// Shared axios instance with global 401 handling (#352, M1/M2/M3).
+import { apiAxios as axios } from '$lib/services/apiClient';
+import { isAxiosError } from 'axios';
+axios.isAxiosError = isAxiosError;
 import { getConfig } from '../config';
 
 const config = getConfig();

--- a/frontend/svelte-app/src/lib/services/testService.js
+++ b/frontend/svelte-app/src/lib/services/testService.js
@@ -1,38 +1,6 @@
-import { getApiUrl } from '$lib/config';
-import { browser } from '$app/environment';
-
-/** @returns {string} */
-function getToken() {
-	if (!browser) return '';
-	return localStorage.getItem('userToken') || '';
-}
-
-/** @param {string} endpoint @param {Object} [options] */
-async function apiFetch(endpoint, options = {}) {
-	const token = getToken();
-	if (!token) throw new Error('Not authenticated');
-
-	const url = getApiUrl(endpoint);
-	const res = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'Content-Type': 'application/json',
-			...options.headers,
-		},
-		...options,
-	});
-
-	if (!res.ok) {
-		let detail = `API error (${res.status})`;
-		try {
-			const err = await res.json();
-			detail = err?.detail || detail;
-		} catch (_) { /* ignore */ }
-		throw new Error(detail);
-	}
-
-	return res.json();
-}
+// Routed through the centralized apiJson so 401 triggers global session
+// recovery instead of leaving the test UI in a permanent error state. (#352)
+import { apiJson as apiFetch } from '$lib/services/apiClient';
 
 /**
  * List test scenarios for an assistant.

--- a/frontend/svelte-app/src/lib/session/sessionManager.js
+++ b/frontend/svelte-app/src/lib/session/sessionManager.js
@@ -67,11 +67,19 @@ export async function replaceSessionWithToken(token) {
  * Ensure the current session has a fully-loaded user profile.
  * Recovery path for page refreshes where the profile wasn't fully
  * populated (e.g. interrupted LTI flow that saved a token but not the name).
+ *
+ * If the profile fetch returns incomplete data (missing name/email), clear
+ * the session — staying half-logged-in is worse than forcing a re-login,
+ * because every downstream component breaks on `null` user fields. (#353, H6)
  */
 export async function ensureProfileLoaded() {
 	if (!browser) return;
 	const { isLoggedIn, name } = get(user);
 	if (isLoggedIn && !name) {
-		await user.fetchAndPopulateProfile();
+		const result = await user.fetchAndPopulateProfile();
+		if (!result?.success) {
+			console.warn('Profile bootstrap failed, clearing session:', result?.error);
+			clearCurrentSession();
+		}
 	}
 }

--- a/frontend/svelte-app/src/lib/stores/aacStore.svelte.js
+++ b/frontend/svelte-app/src/lib/stores/aacStore.svelte.js
@@ -3,28 +3,41 @@
  *
  * Tracks which sessions are open as tabs, which one is active,
  * and persists tab state to sessionStorage for page navigation.
+ *
+ * Implementation note: this module previously used Svelte 5 `$state` runes
+ * directly, but cross-module reactivity to runes did not propagate reliably
+ * to subscriber components in production builds. Components compensated by
+ * polling `getOpenTabs()` every 500ms — high CPU and reactivity churn (#352, H6).
+ *
+ * Now backed by `writable()` stores from `svelte/store`, which propagate
+ * across modules cleanly. Components subscribe via `$openTabs` / `$activeTabId`
+ * rather than polling. The named function exports are preserved so non-reactive
+ * call sites (mutations from event handlers) keep working.
  */
+
+import { writable, get } from 'svelte/store';
 
 /** @typedef {{ id: string, title: string, assistantId: number|null, skill: string|null, lastMessageAt: number }} TabInfo */
 
-/** @type {TabInfo[]} */
-let openTabs = $state([]);
+/** @type {import('svelte/store').Writable<TabInfo[]>} */
+export const openTabs = writable([]);
 
-/** @type {string|null} */
-let activeTabId = $state(null);
+/** @type {import('svelte/store').Writable<string|null>} */
+export const activeTabId = writable(null);
 
-/** @type {boolean} */
-let showTabs = $state(false);
+/** @type {import('svelte/store').Writable<boolean>} */
+export const showTabs = writable(false);
 
-// Restore from sessionStorage on load
+// Restore from sessionStorage on load (browser only).
 if (typeof window !== 'undefined') {
 	try {
 		const saved = sessionStorage.getItem('aac_tabs');
 		if (saved) {
 			const data = JSON.parse(saved);
-			openTabs = data.tabs || [];
-			activeTabId = data.activeId || null;
-			showTabs = (data.tabs || []).length > 0;
+			const tabs = data.tabs || [];
+			openTabs.set(tabs);
+			activeTabId.set(data.activeId || null);
+			showTabs.set(tabs.length > 0);
 		}
 	} catch (_) { /* ignore */ }
 }
@@ -32,8 +45,8 @@ if (typeof window !== 'undefined') {
 function persist() {
 	if (typeof window === 'undefined') return;
 	sessionStorage.setItem('aac_tabs', JSON.stringify({
-		tabs: openTabs,
-		activeId: activeTabId,
+		tabs: get(openTabs),
+		activeId: get(activeTabId),
 	}));
 }
 
@@ -45,16 +58,17 @@ function persist() {
  * @param {string|null} [skill]
  */
 export function openTab(id, title, assistantId = null, skill = null) {
-	// Don't duplicate
-	if (openTabs.find(t => t.id === id)) {
-		activeTabId = id;
-		showTabs = true;
+	const current = get(openTabs);
+	if (current.find(t => t.id === id)) {
+		// Don't duplicate; just activate.
+		activeTabId.set(id);
+		showTabs.set(true);
 		persist();
 		return;
 	}
-	openTabs = [...openTabs, { id, title, assistantId, skill, lastMessageAt: Date.now() }];
-	activeTabId = id;
-	showTabs = true;
+	openTabs.set([...current, { id, title, assistantId, skill, lastMessageAt: Date.now() }]);
+	activeTabId.set(id);
+	showTabs.set(true);
 	persist();
 }
 
@@ -63,11 +77,12 @@ export function openTab(id, title, assistantId = null, skill = null) {
  * @param {string} id
  */
 export function closeTab(id) {
-	openTabs = openTabs.filter(t => t.id !== id);
-	if (activeTabId === id) {
-		activeTabId = openTabs.length > 0 ? openTabs[openTabs.length - 1].id : null;
+	const remaining = get(openTabs).filter(t => t.id !== id);
+	openTabs.set(remaining);
+	if (get(activeTabId) === id) {
+		activeTabId.set(remaining.length > 0 ? remaining[remaining.length - 1].id : null);
 	}
-	showTabs = openTabs.length > 0;
+	showTabs.set(remaining.length > 0);
 	persist();
 }
 
@@ -76,22 +91,22 @@ export function closeTab(id) {
  * @param {string} id
  */
 export function setActiveTab(id) {
-	activeTabId = id;
+	activeTabId.set(id);
 	persist();
 }
 
 /** Hide the tab bar (go back to main view). */
 export function hideTabs() {
-	showTabs = false;
-	activeTabId = null;
+	showTabs.set(false);
+	activeTabId.set(null);
 	persist();
 }
 
 /** Clear all tabs and remove from sessionStorage. Call on logout. */
 export function resetTabs() {
-	openTabs = [];
-	activeTabId = null;
-	showTabs = false;
+	openTabs.set([]);
+	activeTabId.set(null);
+	showTabs.set(false);
 	if (typeof window !== 'undefined') {
 		sessionStorage.removeItem('aac_tabs');
 	}
@@ -99,17 +114,17 @@ export function resetTabs() {
 
 /** @returns {TabInfo[]} */
 export function getOpenTabs() {
-	return openTabs;
+	return get(openTabs);
 }
 
 /** @returns {string|null} */
 export function getActiveTabId() {
-	return activeTabId;
+	return get(activeTabId);
 }
 
 /** @returns {boolean} */
 export function isTabsVisible() {
-	return showTabs;
+	return get(showTabs);
 }
 
 /**
@@ -119,10 +134,13 @@ export function isTabsVisible() {
  */
 export function recordTabActivity(id) {
 	const AWAY_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
-	const tab = openTabs.find(t => t.id === id);
+	const tabs = get(openTabs);
+	const tab = tabs.find(t => t.id === id);
 	if (!tab) return false;
 	const wasAway = (Date.now() - (tab.lastMessageAt || 0)) > AWAY_THRESHOLD_MS;
-	tab.lastMessageAt = Date.now();
+	// Replace the tab to trigger reactivity (mutating the existing object
+	// would not notify subscribers).
+	openTabs.set(tabs.map(t => t.id === id ? { ...t, lastMessageAt: Date.now() } : t));
 	persist();
 	return wasAway;
 }

--- a/frontend/svelte-app/src/lib/stores/assistantStore.js
+++ b/frontend/svelte-app/src/lib/stores/assistantStore.js
@@ -81,25 +81,29 @@ const createAssistantsStore = () => {
       try {
         // Fetch fresh data from the backend
         // getAssistants returns an object: { assistants: Assistant[], total_count: number }
-        const response = await getAssistants(); 
-        
-        // Update store with new data - extract the array
+        const response = await getAssistants();
+
+        // Defensive: an unexpected response shape used to leave the store
+        // with `items: undefined` and the next render iterating over a
+        // non-iterable. Always coerce to an array. (#352, H12)
+        const items = Array.isArray(response?.assistants) ? response.assistants : [];
+
         set({
-          items: response.assistants, // Assign the array to items
+          items,
           loading: false,
           error: null,
           lastLoaded: new Date()
         });
-        
-        // Log the length of the assistants array
-        console.log('Assistants store updated with fresh data:', response.assistants?.length || 0, 'items');
+
+        console.log('Assistants store updated with fresh data:', items.length, 'items');
       } catch (error) {
         console.error('Error loading assistants:', error);
         let message = 'Failed to load assistants';
         if (error instanceof Error) {
           message = error.message;
         }
-        // Update store with error
+        // Update store with error. Preserve any previously loaded items
+        // so a transient failure during a refresh doesn't blank the UI.
         update(state => ({
           ...state,
           loading: false,

--- a/frontend/svelte-app/src/lib/stores/templateStore.js
+++ b/frontend/svelte-app/src/lib/stores/templateStore.js
@@ -35,28 +35,38 @@ export const templateSelectCallback = writable(null);
 // Error state
 export const templateError = writable(null);
 
+// Sequence counters: every load call increments and tags itself; if a newer
+// call lands first, the older one drops its writes. Prevents last-wins
+// races when $effect re-fires before a previous load completes. (#353, M3)
+let _userLoadSeq = 0;
+let _sharedLoadSeq = 0;
+
 /**
  * Load user's templates
  */
 export async function loadUserTemplates() {
+    const mySeq = ++_userLoadSeq;
     try {
         userTemplatesLoading.set(true);
         templateError.set(null);
-        
+
         const page = get(userTemplatesPage);
         const limit = get(userTemplatesLimit);
         const offset = (page - 1) * limit;
-        
+
         const result = await templateService.listUserTemplates(limit, offset);
-        
+        if (mySeq !== _userLoadSeq) return; // a newer call superseded ours
+
         userTemplates.set(result.templates);
         userTemplatesTotal.set(result.total);
-        
+
     } catch (error) {
+        if (mySeq !== _userLoadSeq) return;
+        if (error instanceof Error && error.message.startsWith('Session expired')) return;
         console.error('Error loading user templates:', error);
         templateError.set(error.message || 'Failed to load templates');
     } finally {
-        userTemplatesLoading.set(false);
+        if (mySeq === _userLoadSeq) userTemplatesLoading.set(false);
     }
 }
 
@@ -64,24 +74,28 @@ export async function loadUserTemplates() {
  * Load shared templates
  */
 export async function loadSharedTemplates() {
+    const mySeq = ++_sharedLoadSeq;
     try {
         sharedTemplatesLoading.set(true);
         templateError.set(null);
-        
+
         const page = get(sharedTemplatesPage);
         const limit = get(sharedTemplatesLimit);
         const offset = (page - 1) * limit;
-        
+
         const result = await templateService.listSharedTemplates(limit, offset);
-        
+        if (mySeq !== _sharedLoadSeq) return;
+
         sharedTemplates.set(result.templates);
         sharedTemplatesTotal.set(result.total);
-        
+
     } catch (error) {
+        if (mySeq !== _sharedLoadSeq) return;
+        if (error instanceof Error && error.message.startsWith('Session expired')) return;
         console.error('Error loading shared templates:', error);
         templateError.set(error.message || 'Failed to load shared templates');
     } finally {
-        sharedTemplatesLoading.set(false);
+        if (mySeq === _sharedLoadSeq) sharedTemplatesLoading.set(false);
     }
 }
 

--- a/frontend/svelte-app/src/lib/stores/userStore.js
+++ b/frontend/svelte-app/src/lib/stores/userStore.js
@@ -110,18 +110,25 @@ const createUserStore = () => {
     /**
      * Fetches the user profile from the backend and populates the store.
      * Should be called after setToken() for LTI login flows.
+     *
+     * Validates that the response carries the minimum required fields
+     * (name + email). Previously a `{success: true, data: {}}` reply would
+     * leave the user "logged in" with name=null/email=null, breaking every
+     * downstream component that assumes those fields exist. Now treated as
+     * a failure and surfaced via the returned result. (#353, H6)
      */
     fetchAndPopulateProfile: async () => {
       const { fetchUserProfile } = await import('$lib/services/authService.js');
       const token = browser ? localStorage.getItem('userToken') : null;
       if (!token) return null;
-      
+
       const result = await fetchUserProfile(token);
-      if (result?.success && result.data) {
-        const userData = { ...result.data, token };
+      const data = result?.success ? result.data : null;
+      if (data && data.name && data.email) {
+        const userData = { ...data, token };
         if (browser) {
-          localStorage.setItem('userName', userData.name || '');
-          localStorage.setItem('userEmail', userData.email || '');
+          localStorage.setItem('userName', userData.name);
+          localStorage.setItem('userEmail', userData.email);
           if (userData.launch_url) {
             localStorage.setItem('OWI_url', userData.launch_url);
           }
@@ -130,13 +137,22 @@ const createUserStore = () => {
         set({
           isLoggedIn: true,
           token: token,
-          name: userData.name || null,
-          email: userData.email || null,
+          name: userData.name,
+          email: userData.email,
           owiUrl: userData.launch_url || null,
           data: userData
         });
+        return result;
       }
-      return result;
+
+      // Profile response missing required fields — surface a structured
+      // failure so callers (sessionManager.replaceSessionWithToken,
+      // sessionManager.ensureProfileLoaded) can decide whether to clear
+      // the session and force re-login.
+      return {
+        success: false,
+        error: result?.error || 'Profile data missing required fields (name/email)',
+      };
     },
     
     // Logout function

--- a/frontend/svelte-app/src/lib/utils/sanitize.js
+++ b/frontend/svelte-app/src/lib/utils/sanitize.js
@@ -1,0 +1,51 @@
+/**
+ * Markdown rendering with HTML sanitization.
+ *
+ * Wrap any `{@html …}` site that renders user/LLM/CMS-controlled markdown
+ * with `renderMarkdownSafe()` so a stored XSS payload (e.g. `<script>`,
+ * `<img onerror=…>`, `<iframe>`) cannot execute in another user's browser.
+ *
+ * DOMPurify is browser-only. The build is statically pre-rendered (adapter-static)
+ * so SSR doesn't touch user content — but if a caller runs this in an SSR
+ * context, fall back to returning the raw marked output rather than crashing.
+ * (#353, M2)
+ */
+
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import { browser } from '$app/environment';
+
+/**
+ * Parse markdown to HTML and sanitize the result.
+ * Use this anywhere you would otherwise write `{@html marked(text)}`.
+ *
+ * @param {string} text - Markdown source
+ * @param {object} [options]
+ * @param {boolean} [options.breaks=true] - Convert single newlines to <br>
+ * @param {boolean} [options.gfm=true] - Enable GitHub-flavoured markdown
+ * @returns {string} Sanitized HTML
+ */
+export function renderMarkdownSafe(text, options = {}) {
+	if (!text) return '';
+	const { breaks = true, gfm = true } = options;
+	const html = String(marked.parse(text, { breaks, gfm }));
+	if (!browser) return html;
+	return DOMPurify.sanitize(html, {
+		// Strip event handlers and javascript: URIs by default. Allow common
+		// safe tags + class/id attrs so Tailwind prose styles still apply.
+		USE_PROFILES: { html: true },
+	});
+}
+
+/**
+ * Sanitize a pre-built HTML string (no markdown parsing).
+ * Use for HTML returned from a backend or third-party that you must render.
+ *
+ * @param {string} html
+ * @returns {string}
+ */
+export function sanitizeHtml(html) {
+	if (!html) return '';
+	if (!browser) return html;
+	return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+}

--- a/frontend/svelte-app/src/routes/+layout.js
+++ b/frontend/svelte-app/src/routes/+layout.js
@@ -23,10 +23,17 @@ export const load = async () => {
     setLocale(localeToSet);
   }
   
-  // Wait for the locale to be fully loaded before continuing
-  // This is critical for SSR to work properly
-  await waitLocale();
-  
+  // Wait for the locale to be fully loaded before continuing.
+  // If the locale JSON fails to load (network blip, asset hash drift),
+  // proceed without it — setupI18n() registered a fallback that will
+  // resolve via the existing svelte-i18n machinery on next attempt.
+  // Throwing here would blank the entire app until reload (#352).
+  try {
+    await waitLocale();
+  } catch (err) {
+    console.error('waitLocale failed, continuing with fallback:', err);
+  }
+
   // The load function needs to return an object, even if empty
   return {};
 }; 

--- a/frontend/svelte-app/src/routes/+page.svelte
+++ b/frontend/svelte-app/src/routes/+page.svelte
@@ -5,11 +5,19 @@
 	import Signup from '$lib/components/Signup.svelte';
 	import UserDashboard from '$lib/components/UserDashboard.svelte';
 	import { user } from '$lib/stores/userStore';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { marked } from 'marked';
-	import { getApiUrl } from '$lib/config';
 	import { _, locale } from '$lib/i18n';
+	import { apiFetch } from '$lib/services/apiClient';
 	import { getMyProfile } from '$lib/services/adminService';
+
+	// Track mount status so async fetches that resolve after the user
+	// navigates away don't write state to a destroyed component. Also tag
+	// each loadNews() invocation so a slow request from a previous locale
+	// doesn't overwrite content for the current locale. (#353, H5)
+	let isMounted = true;
+	let newsLoadId = 0;
+	onDestroy(() => { isMounted = false; });
 
 	let config = $state(null);
 	let authMode = $state('login'); // 'login' or 'signup'
@@ -44,13 +52,17 @@
 		try {
 			isLoadingProfile = true;
 			profileError = null;
-			profileData = await getMyProfile($user.token);
+			const data = await getMyProfile($user.token);
+			if (!isMounted) return;
+			profileData = data;
 		} catch (error) {
+			if (!isMounted) return;
+			if (error instanceof Error && error.message.startsWith('Session expired')) return;
 			console.error('Error loading profile:', error);
 			profileError = error instanceof Error ? error.message : 'Failed to load profile';
 			profileData = null;
 		} finally {
-			isLoadingProfile = false;
+			if (isMounted) isLoadingProfile = false;
 		}
 	}
 
@@ -61,20 +73,22 @@
 			return;
 		}
 
-		try {
-			isLoadingNews = true;
-			const currentLang = $locale || 'en';
-			const newsUrl = getApiUrl(`news/${currentLang}`);
+		// Tag this invocation; a slow request from a previous locale must
+		// not overwrite content for the current one. (#353, H5)
+		const myLoadId = ++newsLoadId;
+		isLoadingNews = true;
 
-			const response = await fetch(newsUrl, {
-				headers: {
-					'Authorization': `Bearer ${$user.token}`,
-					'Content-Type': 'application/json'
-				}
+		try {
+			const currentLang = $locale || 'en';
+			const response = await apiFetch(`news/${currentLang}`, {
+				headers: { 'Content-Type': 'application/json' }
 			});
+
+			if (!isMounted || myLoadId !== newsLoadId) return;
 
 			if (response.ok) {
 				const data = await response.json();
+				if (!isMounted || myLoadId !== newsLoadId) return;
 				if (data.success && data.content && data.content.trim()) {
 					newsContent = String(marked.parse(data.content));
 				} else {
@@ -82,16 +96,15 @@
 				}
 			} else if (response.status === 404) {
 				// Fallback to English
-				const fallbackUrl = getApiUrl('news/en');
-				const fallbackResponse = await fetch(fallbackUrl, {
-					headers: {
-						'Authorization': `Bearer ${$user.token}`,
-						'Content-Type': 'application/json'
-					}
+				const fallbackResponse = await apiFetch('news/en', {
+					headers: { 'Content-Type': 'application/json' }
 				});
+
+				if (!isMounted || myLoadId !== newsLoadId) return;
 
 				if (fallbackResponse.ok) {
 					const fallbackData = await fallbackResponse.json();
+					if (!isMounted || myLoadId !== newsLoadId) return;
 					if (fallbackData.success && fallbackData.content && fallbackData.content.trim()) {
 						newsContent = String(marked.parse(fallbackData.content));
 					} else {
@@ -103,27 +116,32 @@
 			} else if (response.status === 503) {
 				try {
 					const cacheData = await response.json();
+					if (!isMounted || myLoadId !== newsLoadId) return;
 					if (cacheData.success && cacheData.content) {
 						newsContent = String(marked.parse(cacheData.content));
 					} else {
 						newsContent = '';
 					}
 				} catch (e) {
+					if (!isMounted || myLoadId !== newsLoadId) return;
 					newsContent = '';
 				}
 			} else {
 				newsContent = '';
 			}
 		} catch (error) {
+			if (!isMounted || myLoadId !== newsLoadId) return;
+			// apiFetch already redirected on session expiry — don't paint a stale error.
+			if (error instanceof Error && error.message.startsWith('Session expired')) return;
 			newsContent = '';
 			console.error('Error fetching news:', error);
 		} finally {
-			isLoadingNews = false;
+			if (isMounted && myLoadId === newsLoadId) isLoadingNews = false;
 		}
 	}
 
 	// Load data when component mounts
-	onMount(async () => {
+	onMount(() => {
 		if ($user.isLoggedIn) {
 			loadProfile();
 			loadNews();

--- a/frontend/svelte-app/src/routes/+page.svelte
+++ b/frontend/svelte-app/src/routes/+page.svelte
@@ -6,10 +6,10 @@
 	import UserDashboard from '$lib/components/UserDashboard.svelte';
 	import { user } from '$lib/stores/userStore';
 	import { onMount, onDestroy } from 'svelte';
-	import { marked } from 'marked';
 	import { _, locale } from '$lib/i18n';
 	import { apiFetch } from '$lib/services/apiClient';
 	import { getMyProfile } from '$lib/services/adminService';
+	import { renderMarkdownSafe } from '$lib/utils/sanitize';
 
 	// Track mount status so async fetches that resolve after the user
 	// navigates away don't write state to a destroyed component. Also tag
@@ -90,7 +90,7 @@
 				const data = await response.json();
 				if (!isMounted || myLoadId !== newsLoadId) return;
 				if (data.success && data.content && data.content.trim()) {
-					newsContent = String(marked.parse(data.content));
+					newsContent = renderMarkdownSafe(data.content);
 				} else {
 					newsContent = '';
 				}
@@ -106,7 +106,7 @@
 					const fallbackData = await fallbackResponse.json();
 					if (!isMounted || myLoadId !== newsLoadId) return;
 					if (fallbackData.success && fallbackData.content && fallbackData.content.trim()) {
-						newsContent = String(marked.parse(fallbackData.content));
+						newsContent = renderMarkdownSafe(fallbackData.content);
 					} else {
 						newsContent = '';
 					}
@@ -118,7 +118,7 @@
 					const cacheData = await response.json();
 					if (!isMounted || myLoadId !== newsLoadId) return;
 					if (cacheData.success && cacheData.content) {
-						newsContent = String(marked.parse(cacheData.content));
+						newsContent = renderMarkdownSafe(cacheData.content);
 					} else {
 						newsContent = '';
 					}

--- a/frontend/svelte-app/src/routes/agent/+page.svelte
+++ b/frontend/svelte-app/src/routes/agent/+page.svelte
@@ -4,7 +4,7 @@
     import { _, locale } from '$lib/i18n';
     import { user } from '$lib/stores/userStore';
     import { createSession, getSessions, deleteSession } from '$lib/services/aacService';
-    import { openTab, setActiveTab, getActiveTabId, closeTab } from '$lib/stores/aacStore.svelte';
+    import { openTab, setActiveTab, getActiveTabId, closeTab, activeTabId } from '$lib/stores/aacStore.svelte';
     import AacTerminal from '$lib/components/aac/AacTerminal.svelte';
     import { goto } from '$app/navigation';
 
@@ -13,8 +13,11 @@
     let loading = $state(true);
     let error = $state('');
 
-    // React to global tab bar switches
-    let storeActiveId = $derived(getActiveTabId());
+    // React to global tab bar switches. Subscribe to the writable store so this
+    // updates whenever the active tab changes anywhere in the app — previously
+    // this relied on rune-via-getter dependency tracking that broke when the
+    // store was migrated away from $state runes (#352, H6).
+    let storeActiveId = $derived($activeTabId);
     $effect(() => {
         if (storeActiveId && storeActiveId !== sessionId && !loading) {
             sessionId = storeActiveId;

--- a/frontend/svelte-app/src/routes/agent/history/[id]/+page.svelte
+++ b/frontend/svelte-app/src/routes/agent/history/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { onMount } from 'svelte';
+    import { onMount, onDestroy } from 'svelte';
     import { page } from '$app/stores';
     import { _ } from '$lib/i18n';
     import { getSession } from '$lib/services/aacService';
@@ -12,6 +12,11 @@
     let error = $state('');
     let showAudit = $state(false);
 
+    // Don't write state on a destroyed component if the user navigates away
+    // while the session fetch is in flight. (#352, L1)
+    let isMounted = true;
+    onDestroy(() => { isMounted = false; });
+
     function renderMarkdown(text) {
         if (!text) return '';
         return marked.parse(text, { breaks: true });
@@ -20,11 +25,16 @@
     onMount(async () => {
         const id = $page.params.id;
         try {
-            session = await getSession(id);
+            const data = await getSession(id);
+            if (!isMounted) return;
+            session = data;
         } catch (e) {
+            if (!isMounted) return;
+            if (e instanceof Error && e.message.startsWith('Session expired')) return;
             error = e.message || 'Session not found';
+        } finally {
+            if (isMounted) loading = false;
         }
-        loading = false;
     });
 
     function getVisibleMessages() {

--- a/frontend/svelte-app/src/routes/assistants/+page.svelte
+++ b/frontend/svelte-app/src/routes/assistants/+page.svelte
@@ -47,7 +47,7 @@
     import AacTerminal from '$lib/components/aac/AacTerminal.svelte';
     import AssistantTests from '$lib/components/aac/AssistantTests.svelte';
     import { createSession } from '$lib/services/aacService';
-    import { openTab, closeTab, setActiveTab, getOpenTabs, getActiveTabId } from '$lib/stores/aacStore.svelte';
+    import { openTab, closeTab, setActiveTab, getOpenTabs, getActiveTabId, openTabs as openTabsStore } from '$lib/stores/aacStore.svelte';
 
     // --- State Management ---
     /** @type {'list' | 'create' | 'detail' | 'shared' | 'templates'} */
@@ -76,7 +76,9 @@
     let aacSkillStartup = $state(false);
     /** @type {boolean} */
     let aacLaunching = $state(false);
-    let aacTabs = $derived(getOpenTabs());
+    // Subscribe to the openTabs writable store so this list updates when tabs
+    // are opened/closed anywhere in the app (#352, H6).
+    let aacTabs = $derived($openTabsStore);
 
     /**
      * Launch an AAC skill session for the current assistant.
@@ -272,9 +274,15 @@
      * @param {number} id
      * @param {boolean} forceRefresh - Force refresh even if ID is the same (used after updates)
      */
-    async function fetchAssistantDetail(id, forceRefresh = false) { 
+    // Tag every fetchAssistantDetail call so a slow earlier request that
+    // resolves AFTER a newer one cannot overwrite the now-current selection
+    // with stale data. (#352, M12)
+    let detailFetchSeq = 0;
+
+    async function fetchAssistantDetail(id, forceRefresh = false) {
         if (lastAttemptedId === id && !forceRefresh) return; // Skip if same ID unless forcing refresh
         lastAttemptedId = id;
+        const mySeq = ++detailFetchSeq;
         // startEditMode is already set by the subscription callback
         loadingDetail = true;
         detailError = '';
@@ -284,6 +292,7 @@
         try {
             console.log(`Fetching assistant ID: ${id}.`); // Removed edit log here
             const assistantData = await getAssistantById(id);
+            if (mySeq !== detailFetchSeq) return; // a newer fetch has started — drop ours
             if (assistantData) {
                 const fullAssistantData = {
                     ...normalizeAssistantData(assistantData),
@@ -299,11 +308,13 @@
                 showList();
             }
         } catch (error) {
+            if (mySeq !== detailFetchSeq) return;
+            if (error instanceof Error && error.message.startsWith('Session expired')) return;
             console.error('Error fetching assistant details:', error);
             detailError = error instanceof Error ? error.message : $_('error_fetching_assistant');
             showList();
         } finally {
-            loadingDetail = false;
+            if (mySeq === detailFetchSeq) loadingDetail = false;
         }
     }
 

--- a/frontend/svelte-app/src/routes/org-admin/+page.svelte
+++ b/frontend/svelte-app/src/routes/org-admin/+page.svelte
@@ -3,7 +3,12 @@
     import { page } from '$app/stores';
     import { goto } from '$app/navigation';
     import { base } from '$app/paths';
-    import axios from 'axios';
+    // Shared axios instance: bearer-token auto-attach + global 401 redirect.
+    // Replaces the raw axios import so a mid-session token expiry no longer
+    // leaves the admin panel showing "Failed to fetch" banners. (#353, M4)
+    import { apiAxios as axios } from '$lib/services/apiClient';
+    import { isAxiosError } from 'axios';
+    axios.isAxiosError = isAxiosError;
     import { user } from '$lib/stores/userStore';
     import AssistantSharingModal from '$lib/components/assistants/AssistantSharingModal.svelte';
     import Pagination from '$lib/components/common/Pagination.svelte';
@@ -19,9 +24,13 @@
     import ChangePasswordModal from '$lib/components/admin/shared/ChangePasswordModal.svelte';
     import UserActionModal from '$lib/components/admin/shared/UserActionModal.svelte';
 
-    // Get user data  
+    // Get user data
     /** @type {any} */
     let userData = $state(null);
+
+    // Track mount status so async fetches that resolve after the user
+    // navigates away don't write state to a destroyed component. (#353, M4)
+    let isMounted = true;
 
     // API base URL
     const API_BASE = '/creator/admin';
@@ -542,9 +551,12 @@
                 }
             });
 
+            if (!isMounted) return;
             console.log('Dashboard API Response:', response.data);
             dashboardData = response.data;
         } catch (err) {
+            if (!isMounted) return;
+            if (err instanceof Error && err.message.startsWith('Session expired')) return;
             console.error('Error fetching dashboard:', err);
             if (axios.isAxiosError(err) && err.response?.status === 403) {
                 error = 'Access denied. Organization admin privileges required.';
@@ -557,7 +569,7 @@
             }
             dashboardData = null;
         } finally {
-            isLoadingDashboard = false;
+            if (isMounted) isLoadingDashboard = false;
         }
     }
 
@@ -621,12 +633,15 @@
                 }
             });
 
+            if (!isMounted) return;
             console.log('Users API Response:', response.data);
             orgUsers = response.data || [];
             console.log(`Fetched ${orgUsers.length} users`);
             usersLoaded = true; // Mark as loaded even if empty
             applyUsersFilters(); // Apply filters and pagination
         } catch (err) {
+            if (!isMounted) return;
+            if (err instanceof Error && err.message.startsWith('Session expired')) return;
             console.error('Error fetching users:', err);
             if (axios.isAxiosError(err) && err.response?.status === 403) {
                 usersError = 'Access denied. Organization admin privileges required.';
@@ -640,7 +655,7 @@
             orgUsers = [];
             usersLoaded = true; // Mark as loaded even on error to prevent infinite loops
         } finally {
-            isLoadingUsers = false;
+            if (isMounted) isLoadingUsers = false;
         }
     }
     
@@ -1258,17 +1273,20 @@
             };
             
             const response = await axios.get(`${API_BASE}/org-admin/assistants`, { headers });
+            if (!isMounted) return;
             orgAssistants = response.data.assistants || [];
             assistantsLoaded = true; // Mark as loaded even if empty
-            
+
             // Load share counts for all assistants
             await loadAssistantShareCounts();
         } catch (err) {
+            if (!isMounted) return;
+            if (err instanceof Error && err.message.startsWith('Session expired')) return;
             console.error('Error fetching assistants:', err);
             assistantsError = err.response?.data?.detail || 'Failed to fetch assistants';
             assistantsLoaded = true; // Mark as loaded even on error to prevent infinite loops
         } finally {
-            isLoadingAssistants = false;
+            if (isMounted) isLoadingAssistants = false;
         }
     }
 
@@ -1381,6 +1399,7 @@
                 headers: { 'Authorization': `Bearer ${token}` }
             });
 
+            if (!isMounted) return;
             signupSettings = signupResponse.data;
 
             // Initialize signup edit form
@@ -1393,6 +1412,8 @@
             // It will be loaded when needed (contains slow API tests)
 
         } catch (err) {
+            if (!isMounted) return;
+            if (err instanceof Error && err.message.startsWith('Session expired')) return;
             console.error('Error fetching settings:', err);
             if (axios.isAxiosError(err) && err.response?.status === 403) {
                 settingsError = 'Access denied. Organization admin privileges required.';
@@ -1404,7 +1425,7 @@
                 settingsError = 'An unknown error occurred while fetching settings.';
             }
         } finally {
-            isLoadingSettings = false;
+            if (isMounted) isLoadingSettings = false;
         }
     }
 
@@ -2193,6 +2214,7 @@
 
     onDestroy(() => {
         console.log("Organization admin page unmounting");
+        isMounted = false;
     });
 
     // Reactive statements to handle view changes

--- a/frontend/svelte-app/static/config.js.sample
+++ b/frontend/svelte-app/static/config.js.sample
@@ -38,6 +38,7 @@ window.LAMB_CONFIG = {
   features: {
     // Enable/disable features as needed
     enableOpenWebUi: true,
-    enableDebugMode: true
+    enableDebugMode: true,
+    enableLibraries: true
   }
 };


### PR DESCRIPTION
## Summary
Merge of `dev` into `feature/issue#277/phase4_lamba_port` to bring in resilience fixes (#352, #353), new services, and bug fixes from the main development line.
## Key Changes
### Frontend Architecture
- **Merged `svelte-app` SPA into `creator-app`** — completed the monorepo migration by consolidating the legacy svelte-app into the creator-app package
- **Added `apiClient.js`** to creator-app — centralized API client with `apiFetch`, `apiJson`, and `apiAxios` providing global 401 handling (expired token → auto redirect to login)
- **Added `sanitize.js`** to `@lamb/ui` — markdown sanitization utility with DOMPurify for XSS protection
- **Added `signup()` and `getHelp()`** to `@lamb/ui` authService — functions that were missing after the monorepo migration
### Resilience & Bug Fixes (from dev)
- **`+layout.js`**: Added `try/catch` around `waitLocale()` to prevent blank app on i18n load failure
- **`assistantStore.js`**: Added defensive `Array.isArray()` check to prevent store corruption
- **`Login.svelte` / `Signup.svelte`**: Added `try/finally` blocks to prevent loading state from getting stuck
- **`PublishModal.svelte`**: Added `onDestroy` cleanup for closeTimer
- **`adminService.js`**: Migrated to `apiFetch` for global 401 handling
- **`userStore.js`**: Added validation for `name` and `email` fields to prevent incomplete login state
### Build Fixes Applied
- Fixed broken imports across multiple files (`+layout.js`, `Nav.svelte`, `assistantStore.js`)
- Added `marked` and `dompurify` as dependencies to `@lamb/ui`
- Exported `renderMarkdownSafe` and `sanitizeHtml` from `@lamb/ui`
- Added hardcoded `getConfig()` workaround in `Nav.svelte` (temporary until moved to `@lamb/ui`)
## Known Issues & Future Work
Full details in `frontend/MERGE_DEV_TO_PHASE4.md`. Key items:
### High Priority
1. **Merge two `apiClient.js` files** — `utils/apiClient.js` (sessionGuard) and `services/apiClient.js` (401 handling) have overlapping responsibilities
2. **Move `apiClient.js` to `@lamb/ui`** — would enable all modules (creator-app, module-chat, module-file-eval) to use `apiFetch` with global 401 handling
3. **Update `authService.fetchUserProfile()` to use `apiFetch`** — currently uses raw `fetch()` without 401 handling due to circular dependency
### Medium Priority
4. **Migrate remaining raw `fetch()` calls** to `apiFetch` (assistantService, org-admin page)
5. **Migrate module-chat and module-file-eval** to `apiFetch`
6. **Fix `@lamb/ui/i18n` subpath imports** in Pagination.svelte and RubricMetadataForm.svelte
7. **Add XSS sanitization** to module-file-eval markdown rendering
### Low Priority
8. **Move `getConfig()` to `@lamb/ui`** — fix hardcoded workaround in Nav.svelte
9. **Migrate 4 files from `marked` to `renderMarkdownSafe`** from `@lamb/ui`
10. **Migrate `createEventDispatcher` to Svelte 5 callback props** (~15 components)
## Related Issues
- #277 (Phase 4 — File Evaluation)
- #275 (Docker production architecture)
- #332 (De-anonymization)
- #336 (Library Manager integration)
- #352 (Resilience — global 401 handling)
- #353 (Resilience phase 4b)