### PR TITLE
fix(#363): fresh local-stack setup loses bootstrap admin role and creator users on org delete

### DIFF
--- a/backend/lamb/database_manager.py
+++ b/backend/lamb/database_manager.py
@@ -656,6 +656,9 @@ class LambDatabaseManager:
                 logger.info(
                     f"Updated admin user role to 'admin' in system organization")
 
+        # Ensure LAMB-side system role matches OWI (bootstrap admin should be system admin).
+        self.update_creator_user_role(config.OWI_ADMIN_EMAIL, 'admin')
+
     def run_migrations(self):
         """Run database migrations for schema updates"""
         logger.info("Running database migrations")

--- a/backend/lamb/database_manager.py
+++ b/backend/lamb/database_manager.py
@@ -2075,13 +2075,19 @@ class LambDatabaseManager:
                     WHERE organization_id = ?
                 """, (org_id,))
 
-                # 4. Creator_users (organization_roles, lti_identity_links,
-                #    kb_registry, prompt_templates and bulk_import_logs all
-                #    carry ON DELETE CASCADE / SET NULL and follow).
+                # 4. Creator_users — move them to the system org rather than
+                #    deleting them, so users survive organization deletion.
                 cursor.execute(f"""
-                    DELETE FROM {self.table_prefix}Creator_users
+                    SELECT id FROM {self.table_prefix}organizations
+                    WHERE is_system = 1 LIMIT 1
+                """)
+                sys_row = cursor.fetchone()
+                system_org_id = sys_row[0] if sys_row else None
+                cursor.execute(f"""
+                    UPDATE {self.table_prefix}Creator_users
+                    SET organization_id = ?, updated_at = ?
                     WHERE organization_id = ?
-                """, (org_id,))
+                """, (system_org_id, int(time.time()), org_id))
 
                 # 5. collections
                 cursor.execute(f"""

--- a/testing/playwright/global-setup.js
+++ b/testing/playwright/global-setup.js
@@ -27,18 +27,42 @@ module.exports = async (config) => {
   // If already authenticated in some environments, just persist storage.
   const existingToken = await page.evaluate(() => localStorage.getItem('userToken'));
   if (!existingToken) {
+    // Wait for the email input to exist in the DOM.
     await page.waitForSelector('#email', { timeout: 30_000 });
+
+    // Wait for full load + network idle so Vite has finished streaming all JS
+    // chunks and SvelteKit hydration has wired up the form's onsubmit handler.
+    // Without this, clicking on slower machines fires a native form submission
+    // (URL becomes /?email=…&password=…) instead of the XHR handler.
+    await page.waitForLoadState('load');
+    await page.waitForLoadState('networkidle');
+
+    // Double-check that SvelteKit has hydrated by polling for its runtime
+    // marker. This is a zero-cost guard on fast machines (already true by the
+    // time networkidle resolves) and a reliable gate on slow ones.
+    await page.waitForFunction(
+      () => typeof window.__sveltekit_dev !== 'undefined' || typeof window.__sveltekit !== 'undefined',
+      { timeout: 30_000 }
+    );
+
     await page.fill('#email', email);
     await page.fill('#password', password);
 
-    // Matches your current scripts: login is "form > button".
+    // Click the submit button (selector is intentionally narrow) and
+    // concurrently wait for the POST /creator/login XHR response.  This is
+    // deterministic: we know auth succeeded the moment the server replies,
+    // with no blind sleep required.
     await Promise.all([
-      page.waitForLoadState('networkidle').catch(() => {}),
+      page.waitForResponse(
+        (r) => r.url().includes('/creator/login') && r.request().method() === 'POST',
+        { timeout: 30_000 }
+      ),
       page.click('form > button')
     ]);
 
-    // Give time for localStorage token to be set.
-    await page.waitForTimeout(1500);
+    // Poll until the SPA has stored the token in localStorage.  waitForFunction
+    // resolves as soon as the predicate returns truthy — no fixed wait.
+    await page.waitForFunction(() => !!localStorage.getItem('userToken'), { timeout: 15_000 });
   }
 
   const tokenAfter = await page.evaluate(() => localStorage.getItem('userToken'));


### PR DESCRIPTION
## Purpose

Three independent regressions surfaced when bringing up the LAMB stack from a fresh clone. Each blocks a different flow — system-admin operations, organization deletion data integrity, and Playwright auth bootstrap on slower machines. Fixing them lets a fresh checkout reach 99+/108 Playwright passes without per-developer SQL or test-code workarounds.

## Changes

- **Bootstrap admin role:** `ensure_system_admin` now explicitly sets the LAMB-side `role='admin'` for `admin@owi.com` after both the create and update branches converge. Migration 11b only fires for legacy DBs (its `password_hash IS NULL` filter never matches a fresh-bootstrap row), so a code-level sync is required. Idempotent — runs every boot.
- **Org-deletion data preservation:** `delete_organization` previously `DELETE`d creator users belonging to the org being deleted. It now selects the system org's id and `UPDATE`s the affected rows to that id, preserving user history and any assistants/KBs they own.
- **Playwright global-setup determinism:** the form-submit was clicking before Svelte 5 hydration bound `onsubmit`, so on slower machines the click triggered a native form submission and `/creator/login` was never sent. Replaced the 1500ms blind sleep with hydration-readiness gates (`waitForLoadState('load' | 'networkidle')` + `waitForFunction` on the SvelteKit runtime marker) and event-driven completion (`waitForResponse` on the POST + `waitForFunction` polling `localStorage.userToken`).

## Related

- Closes #363