### PR TITLE
Enhancement: youtube video titles

### DIFF
--- a/backend/lamb/completions/rag/simple_rag.py
+++ b/backend/lamb/completions/rag/simple_rag.py
@@ -255,8 +255,19 @@ def rag_processor(
                         main_url = remote_source_url or original_url or source_url
 
                         if main_url:
+                            # For YouTube videos, use video_title if available, otherwise video_id
+                            if "video_id" in metadata and metadata["video_id"]:
+                                # Check if we have the full video title
+                                if "video_title" in metadata and metadata["video_title"] and metadata["video_title"] != "Unknown":
+                                    title = metadata["video_title"]
+                                else:
+                                    # Fallback to video_id format
+                                    title = f"YouTube: {metadata['video_id']}"
+                            else:
+                                title = metadata.get("filename", metadata.get("original_filename", "Unknown"))
+                            
                             source_entry = {
-                                "title": metadata.get("filename", metadata.get("original_filename", "Unknown")),
+                                "title": title,
                                 "url": main_url,
                                 "similarity": doc.get("similarity", 0)
                             }

--- a/lamb-kb-server-stable/backend/plugins/youtube_transcript_ingest.py
+++ b/lamb-kb-server-stable/backend/plugins/youtube_transcript_ingest.py
@@ -118,8 +118,12 @@ def _chunk_transcript(pieces: List[Dict[str, Any]], chunk_duration: float) -> Li
     return chunks
 
 
-def _fetch_transcript(video_id: str, languages: Iterable[str], proxy_url: Optional[str]) -> List[Dict[str, Any]]:
-    """Fetch raw transcript pieces using yt-dlp."""
+def _fetch_transcript(video_id: str, languages: Iterable[str], proxy_url: Optional[str]) -> tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Fetch raw transcript pieces using yt-dlp.
+    
+    Returns:
+        tuple: (transcript_pieces, video_info) where video_info contains title, duration, etc.
+    """
     if not _YT_DLP_AVAILABLE:
         raise ImportError(
             'yt-dlp not installed. Install with "pip install yt-dlp".'
@@ -211,8 +215,16 @@ def _fetch_transcript(video_id: str, languages: Iterable[str], proxy_url: Option
                 raise ValueError("YouTube rate-limited this request (429).")
 
             response.raise_for_status()
+            
+            # Extract video metadata
+            video_info = {
+                'title': info.get('title', 'Unknown'),
+                'duration': info.get('duration'),
+                'uploader': info.get('uploader'),
+                'upload_date': info.get('upload_date')
+            }
 
-            return _parse_srt_content(response.text)
+            return _parse_srt_content(response.text), video_info
 
         except Exception as e:
             raise ValueError(f"Failed to extract subtitles: {e}")
@@ -461,7 +473,7 @@ class YouTubeTranscriptIngestPlugin(IngestPlugin):
                 urls), f"Fetching transcript for video {video_id}...")
 
             try:    
-                pieces = _fetch_transcript(video_id, [language], proxy_url)
+                pieces, video_info = _fetch_transcript(video_id, [language], proxy_url)
 
             except ValueError as e:
                 # Skip videos without transcripts or other extraction failures
@@ -500,6 +512,7 @@ class YouTubeTranscriptIngestPlugin(IngestPlugin):
                     "ingestion_plugin": self.name,
                     "source_url": youtube_url_with_timestamp,
                     "video_id": video_id,
+                    "video_title": video_info.get('title', 'Unknown'),
                     "language": language,
                     "chunk_index": idx,
                     "chunk_count": total,


### PR DESCRIPTION
This enhancement improves source citation by displaying actual video titles
 instead of just video IDs when YouTube videos are used as RAG sources.

 Changes:

 1. `backend/lamb/completions/rag/simple_rag.py`
    - Enhanced title detection logic for YouTube videos
    - Prioritizes video_title metadata field if available
    - Falls back to 'YouTube: {video_id}' format if title not found
    - Maintains backward compatibility with existing documents

 3. `lamb-kb-server-stable/backend/plugins/youtube_transcript_ingest.py`
    - Modified _fetch_transcript() to return tuple (pieces, video_info)
    - Extracts video metadata (title, duration, uploader, upload_date) from yt-dlp
    - Stores video_title in chunk metadata during ingestion
    - Updated plugin_version to reflect this enhancement

 Impact: 
 - **Newly ingested** YouTube videos will display full titles in citations
 - Example: 'Introduction to AI in Education' instead of 'YouTube: WSNaRfZrYvw'
 - Existing documents without video_title will continue using video_id format
 - Improves UX by making source citations more readable and informative"

Fixes  #373