### PR TITLE
feat(#370): view library content and invert delete-confirm flow

### DIFF
--- a/backend/creator_interface/library_router.py
+++ b/backend/creator_interface/library_router.py
@@ -6,7 +6,7 @@ Manager -> update LAMB DB -> audit log -> return response.
 
 import logging
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
@@ -458,6 +458,79 @@ async def get_item_status(
         _db.update_library_item_status(item_id, lm_status)
 
     return result
+
+
+MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB inline-content cap
+
+
+@router.get("/{library_id}/items/{item_id}/content")
+async def get_item_content(
+    library_id: str,
+    item_id: str,
+    format: Literal["markdown", "text"] = "markdown",
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """Return the full rendered content of an imported item.
+
+    HTML output is intentionally not exposed — Library Manager's
+    ``format=html`` uses an unsanitized server-side renderer. Clients
+    that need HTML must request markdown and sanitize on their side.
+    """
+    auth.require_library_access(library_id, level="any")
+    response = await _client.proxy_content(
+        library_id=library_id,
+        item_id=item_id,
+        subpath=f"content?format={format}",
+        creator_user=auth.user,
+    )
+    if len(response.content) > MAX_CONTENT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Content exceeds {MAX_CONTENT_BYTES // (1024 * 1024)} MB. "
+                "Download the original file instead."
+            ),
+        )
+    default_media = "text/markdown" if format == "markdown" else "text/plain"
+    return Response(
+        content=response.content,
+        media_type=response.headers.get("content-type", default_media),
+    )
+
+
+@router.get("/{library_id}/items/{item_id}/kb-links")
+async def get_item_kb_links(
+    library_id: str,
+    item_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """List Knowledge Stores that actively reference this library item.
+
+    Pre-check used by the UI before showing the delete-confirm modal so it
+    can branch into "blocked" mode without round-tripping through a 409.
+    Failed ingestions are excluded (FR-10 doesn't block on them).
+
+    Returns:
+        dict: ``{"item_id": str, "knowledge_stores": [{id, name, status}, ...]}``
+        — same shape as ``detail.knowledge_stores`` in the FR-10 409 body.
+    """
+    auth.require_library_access(library_id, level="any")
+    referencing_links = _db.get_kb_content_links_for_item(item_id)
+    active_links = [
+        l for l in referencing_links
+        if l.get("status") != "failed"
+    ]
+    return {
+        "item_id": item_id,
+        "knowledge_stores": [
+            {
+                "id": l.get("knowledge_store_id"),
+                "name": l.get("knowledge_store_name"),
+                "status": l.get("status"),
+            }
+            for l in active_links
+        ],
+    }
 
 
 @router.delete("/{library_id}/items/{item_id}")

--- a/backend/tests/test_creator_libraries_content.py
+++ b/backend/tests/test_creator_libraries_content.py
@@ -1,0 +1,254 @@
+"""Tests for the new GET /content and /kb-links routes on library items.
+
+Run with: pytest backend/tests/test_creator_libraries_content.py -v
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from creator_interface import library_router
+from lamb.auth_context import AuthContext, get_auth_context
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_auth_context(library_access="any"):
+    """Build a minimal AuthContext whose can_access_library returns the
+    configured value. We bypass the real DB by patching the method."""
+
+    ctx = AuthContext(
+        user={"id": 1, "email": "u@e.test", "name": "U", "organization_id": 10,
+              "user_type": "creator"},
+        token_payload={"email": "u@e.test", "role": "user", "sub": "1"},
+        is_system_admin=False,
+        organization_role="member",
+        is_org_admin=False,
+        organization={"id": 10, "name": "Org", "slug": "org", "is_system": False,
+                      "status": "active", "config": {}},
+        features={},
+    )
+
+    def fake_can_access(library_id):  # noqa: ARG001
+        return library_access
+
+    ctx.can_access_library = fake_can_access  # type: ignore[method-assign]
+    return ctx
+
+
+@pytest.fixture
+def app_with_router():
+    """FastAPI app with just the library router mounted, used by every test."""
+
+    app = FastAPI()
+    app.include_router(library_router.router, prefix="/creator/libraries")
+    return app
+
+
+@pytest.fixture
+def client_factory(app_with_router):
+    """Yield a function that builds a TestClient with custom auth + proxy."""
+
+    def _make(auth_ctx, proxy_content):
+        def override_auth():
+            return auth_ctx
+
+        app_with_router.dependency_overrides[get_auth_context] = override_auth
+        library_router._client.proxy_content = proxy_content  # type: ignore[method-assign]
+        return TestClient(app_with_router)
+
+    yield _make
+    app_with_router.dependency_overrides.clear()
+
+
+def _proxy_returning(content: bytes, content_type: str = "text/markdown"):
+    """Build an async stub that mimics proxy_content's httpx.Response."""
+
+    async def _proxy(library_id, item_id, subpath, creator_user=None):  # noqa: ARG001
+        return httpx.Response(
+            status_code=200,
+            content=content,
+            headers={"content-type": content_type},
+        )
+
+    return _proxy
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetItemContent:
+    """Tests for GET /creator/libraries/{lib}/items/{item}/content."""
+
+    def test_happy_path_markdown(self, client_factory):
+        auth = _make_auth_context(library_access="any")
+        proxy = _proxy_returning(b"# Hello\n\nbody")
+        client = client_factory(auth, proxy)
+
+        resp = client.get("/creator/libraries/L1/items/I1/content")
+
+        assert resp.status_code == 200
+        assert resp.text == "# Hello\n\nbody"
+        assert resp.headers["content-type"].startswith("text/markdown")
+
+    def test_text_format(self, client_factory):
+        auth = _make_auth_context(library_access="any")
+        captured = {}
+
+        async def proxy(library_id, item_id, subpath, creator_user=None):  # noqa: ARG001
+            captured["subpath"] = subpath
+            return httpx.Response(
+                status_code=200,
+                content=b"plain",
+                headers={"content-type": "text/plain"},
+            )
+
+        client = client_factory(auth, proxy)
+        resp = client.get("/creator/libraries/L1/items/I1/content?format=text")
+
+        assert resp.status_code == 200
+        assert resp.text == "plain"
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert "format=text" in captured["subpath"]
+
+    def test_html_format_rejected_with_422(self, client_factory):
+        """HTML format is intentionally blocked at the proxy boundary."""
+        auth = _make_auth_context(library_access="any")
+        proxy = _proxy_returning(b"<p>x</p>")
+        client = client_factory(auth, proxy)
+
+        resp = client.get("/creator/libraries/L1/items/I1/content?format=html")
+
+        assert resp.status_code == 422
+
+    def test_size_cap_returns_413(self, client_factory):
+        """Content over MAX_CONTENT_BYTES returns 413."""
+        auth = _make_auth_context(library_access="any")
+        huge = b"x" * (library_router.MAX_CONTENT_BYTES + 1)
+        proxy = _proxy_returning(huge)
+        client = client_factory(auth, proxy)
+
+        resp = client.get("/creator/libraries/L1/items/I1/content")
+
+        assert resp.status_code == 413
+        assert "exceeds" in resp.json()["detail"].lower()
+
+    def test_no_library_access_returns_404(self, client_factory):
+        """If can_access_library returns 'none' the route raises 404."""
+        auth = _make_auth_context(library_access="none")
+        proxy = _proxy_returning(b"unreachable")
+        client = client_factory(auth, proxy)
+
+        resp = client.get("/creator/libraries/L1/items/I1/content")
+
+        assert resp.status_code == 404
+
+    def test_unauthenticated_returns_401_or_403(self, app_with_router):
+        """No auth dependency override → real get_auth_context raises 401."""
+
+        async def fail_auth():
+            raise HTTPException(status_code=401, detail="missing token")
+
+        app_with_router.dependency_overrides[get_auth_context] = fail_auth
+        client = TestClient(app_with_router)
+
+        resp = client.get("/creator/libraries/L1/items/I1/content")
+
+        assert resp.status_code == 401
+        app_with_router.dependency_overrides.clear()
+
+
+class TestGetItemKbLinks:
+    """Tests for GET /creator/libraries/{lib}/items/{item}/kb-links."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_db(self):
+        """Patch _db.get_kb_content_links_for_item per-test."""
+        original = library_router._db.get_kb_content_links_for_item
+        yield
+        library_router._db.get_kb_content_links_for_item = original
+
+    def test_returns_active_blockers(self, app_with_router):
+        """Active links are returned as {id, name, status} entries."""
+        library_router._db.get_kb_content_links_for_item = lambda _item_id: [
+            {
+                "knowledge_store_id": "KS-1",
+                "knowledge_store_name": "Course Materials",
+                "status": "ready",
+            },
+            {
+                "knowledge_store_id": "KS-2",
+                "knowledge_store_name": "Notes",
+                "status": "processing",
+            },
+        ]
+        app_with_router.dependency_overrides[get_auth_context] = lambda: _make_auth_context(
+            library_access="any"
+        )
+        client = TestClient(app_with_router)
+
+        resp = client.get("/creator/libraries/L1/items/I1/kb-links")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["item_id"] == "I1"
+        ks_list = body["knowledge_stores"]
+        assert len(ks_list) == 2
+        assert {k["id"] for k in ks_list} == {"KS-1", "KS-2"}
+        assert all({"id", "name", "status"} <= set(k.keys()) for k in ks_list)
+        app_with_router.dependency_overrides.clear()
+
+    def test_filters_out_failed_links(self, app_with_router):
+        """Failed ingestions don't block deletion, so they're excluded."""
+        library_router._db.get_kb_content_links_for_item = lambda _item_id: [
+            {"knowledge_store_id": "KS-1", "knowledge_store_name": "Good", "status": "ready"},
+            {"knowledge_store_id": "KS-2", "knowledge_store_name": "Bad", "status": "failed"},
+        ]
+        app_with_router.dependency_overrides[get_auth_context] = lambda: _make_auth_context(
+            library_access="any"
+        )
+        client = TestClient(app_with_router)
+
+        resp = client.get("/creator/libraries/L1/items/I1/kb-links")
+
+        assert resp.status_code == 200
+        ids = [k["id"] for k in resp.json()["knowledge_stores"]]
+        assert ids == ["KS-1"]
+        app_with_router.dependency_overrides.clear()
+
+    def test_empty_when_no_links(self, app_with_router):
+        """Returns an empty list when no KS references this item."""
+        library_router._db.get_kb_content_links_for_item = lambda _item_id: []
+        app_with_router.dependency_overrides[get_auth_context] = lambda: _make_auth_context(
+            library_access="any"
+        )
+        client = TestClient(app_with_router)
+
+        resp = client.get("/creator/libraries/L1/items/I1/kb-links")
+
+        assert resp.status_code == 200
+        assert resp.json()["knowledge_stores"] == []
+        app_with_router.dependency_overrides.clear()
+
+    def test_no_library_access_returns_404(self, app_with_router):
+        """ACL gate runs before the DB lookup."""
+        library_router._db.get_kb_content_links_for_item = lambda _item_id: [
+            {"knowledge_store_id": "KS-1", "knowledge_store_name": "X", "status": "ready"}
+        ]
+        app_with_router.dependency_overrides[get_auth_context] = lambda: _make_auth_context(
+            library_access="none"
+        )
+        client = TestClient(app_with_router)
+
+        resp = client.get("/creator/libraries/L1/items/I1/kb-links")
+
+        assert resp.status_code == 404
+        app_with_router.dependency_overrides.clear()

--- a/frontend/svelte-app/src/lib/components/knowledge/wizard/Step8_ReviewCreate.svelte
+++ b/frontend/svelte-app/src/lib/components/knowledge/wizard/Step8_ReviewCreate.svelte
@@ -417,6 +417,31 @@
 			dispatch('created', { libraryId, libraryName, ksId, ksName });
 		} catch (/** @type {unknown} */ err) {
 			error = readableError(err, 'Failed to create');
+			// Replace a bare "Network Error" with the duplicate-name message
+			// when that's the real cause (the pre-flight check may have
+			// silently failed too).
+			const isNoResponseAxios =
+				!!err &&
+				typeof err === 'object' &&
+				/** @type {any} */ (err).isAxiosError === true &&
+				!/** @type {any} */ (err).response;
+			if (isNoResponseAxios && wizardState.ksPath === 'new' && wizardState.ksName) {
+				try {
+					const stores = await getKnowledgeStores();
+					const proposed = wizardState.ksName.trim().toLowerCase();
+					const dup = (stores || []).some(
+						(s) => (s?.name || '').trim().toLowerCase() === proposed
+					);
+					if (dup) {
+						error = $_('knowledge.wizard.step8.ksNameTaken', {
+							default: 'A Knowledge Store named "{name}" already exists.',
+							values: { name: wizardState.ksName.trim() }
+						});
+					}
+				} catch (e) {
+					console.warn('Duplicate-name fallback check failed', e);
+				}
+			}
 			if (
 				progressSteps.length > 0 &&
 				progressSteps[progressSteps.length - 1].status === 'running'

--- a/frontend/svelte-app/src/lib/components/knowledge/wizard/StepKSContent.svelte
+++ b/frontend/svelte-app/src/lib/components/knowledge/wizard/StepKSContent.svelte
@@ -82,25 +82,32 @@
 		}
 	});
 
-	/** @param {string} libraryId */
+	// Race guard for rapid library switches (#370).
+	let loadSeq = 0;
+
+	/**
+	 * Load "ready" items for a library, dropping stale responses if a newer
+	 * load was issued before this one resolved. Pre-selects everything on
+	 * first visit; preserves the user's explicit selection otherwise.
+	 * @param {string} libraryId
+	 */
 	async function loadItems(libraryId) {
+		const mySeq = ++loadSeq;
 		loading = true;
 		error = '';
 		try {
 			const data = await getItems(libraryId, { limit: 200, status: 'ready' });
+			if (mySeq !== loadSeq) return;
 			items = data?.items ?? [];
-			// Pre-select all by default only on first visit. After the user
-			// has navigated past this step once (selectionInitialized=true),
-			// respect their selection — including the empty set from
-			// Deselect all + Back from Review.
 			if (selectedIds.size === 0 && !wizardState.selectionInitialized) {
 				selectedIds = new SvelteSet(items.map((i) => i.id));
 				dispatch('update', { selectionInitialized: true });
 			}
 		} catch (/** @type {unknown} */ err) {
+			if (mySeq !== loadSeq) return;
 			error = err instanceof Error ? err.message : 'Failed to load items';
 		} finally {
-			loading = false;
+			if (mySeq === loadSeq) loading = false;
 		}
 	}
 

--- a/frontend/svelte-app/src/lib/components/knowledge/wizard/StepKSContent.svelte.test.js
+++ b/frontend/svelte-app/src/lib/components/knowledge/wizard/StepKSContent.svelte.test.js
@@ -1,0 +1,44 @@
+// Regression test for #370: when the user changes libraries quickly, a
+// stale getItems() response must not overwrite items belonging to the
+// currently-selected library. The component uses an incrementing
+// sequence number (`loadSeq` + `mySeq`) to discard out-of-order responses.
+//
+// Rather than render the component (Svelte 5 + jsdom + $effect timing
+// makes this brittle), we lock in the source-level contract: the guard
+// must remain in place. A future edit that removes it fails this test
+// loud and clear with a traceable line number.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, 'StepKSContent.svelte'), 'utf8');
+
+describe('StepKSContent — race-guard contract', () => {
+	it('declares a load-sequence counter', () => {
+		expect(source).toMatch(/let loadSeq = 0/);
+	});
+
+	it('captures the current sequence id before awaiting getItems', () => {
+		// `const mySeq = ++loadSeq;` MUST appear in loadItems before the await.
+		const fn = source.split('async function loadItems(libraryId)')[1] || '';
+		const beforeAwait = fn.split('await getItems(')[0] || '';
+		expect(beforeAwait).toMatch(/const mySeq = \+\+loadSeq/);
+	});
+
+	it('discards stale responses on the success path', () => {
+		expect(source).toMatch(
+			/await getItems\([^)]+\);[\s\n]*if \(mySeq !== loadSeq\) return;/
+		);
+	});
+
+	it('discards stale errors on the failure path', () => {
+		expect(source).toMatch(/catch[\s\S]{1,80}if \(mySeq !== loadSeq\) return;/);
+	});
+
+	it('only clears loading when this is the latest request', () => {
+		expect(source).toMatch(/if \(mySeq === loadSeq\) loading = false;/);
+	});
+});

--- a/frontend/svelte-app/src/lib/components/libraries/ItemContentModal.svelte
+++ b/frontend/svelte-app/src/lib/components/libraries/ItemContentModal.svelte
@@ -1,0 +1,120 @@
+<!--
+  @component ItemContentModal
+  Read-only viewer for a library item's rendered markdown. Sanitizes the
+  body through renderMarkdownStrict before rendering it via `{@html}`.
+-->
+<script>
+	import { _, locale } from '$lib/i18n';
+	import { renderMarkdownStrict } from '$lib/utils/sanitize';
+
+	let {
+		isOpen = $bindable(false),
+		isLoading = $bindable(false),
+		title = '',
+		content = '',
+		error = null,
+		onclose = () => {}
+	} = $props();
+
+	let localeLoaded = $derived(!!$locale);
+
+	let renderedHtml = $derived(content ? renderMarkdownStrict(content) : '');
+
+	function close() {
+		onclose();
+		isOpen = false;
+	}
+
+	function handleOverlayClick() {
+		close();
+	}
+
+	/** @param {KeyboardEvent} event */
+	function handleKeydown(event) {
+		if (!isOpen) return;
+		if (event.key === 'Escape') close();
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if isOpen}
+	<div
+		class="fixed inset-0 z-40 bg-gray-500/75 transition-opacity"
+		onclick={handleOverlayClick}
+		aria-hidden="true"
+	></div>
+
+	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+		<div
+			class="relative mx-2 flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-xl"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="modal-title-item-content"
+		>
+			<div class="flex items-center border-b border-blue-200 bg-blue-50 px-4 py-3 sm:px-6">
+				<h3
+					id="modal-title-item-content"
+					class="truncate text-lg leading-6 font-medium text-blue-900"
+				>
+					{title ||
+						(localeLoaded
+							? $_('libraries.itemContentModal.title', { default: 'Item Content' })
+							: 'Item Content')}
+				</h3>
+			</div>
+
+			<div class="max-h-[70vh] flex-1 overflow-y-auto px-4 py-5 sm:p-6">
+				{#if isLoading}
+					<div class="flex items-center justify-center py-10 text-sm text-gray-500">
+						<svg
+							class="mr-2 h-5 w-5 animate-spin"
+							xmlns="http://www.w3.org/2000/svg"
+							fill="none"
+							viewBox="0 0 24 24"
+						>
+							<circle
+								class="opacity-25"
+								cx="12"
+								cy="12"
+								r="10"
+								stroke="currentColor"
+								stroke-width="4"
+							></circle>
+							<path
+								class="opacity-75"
+								fill="currentColor"
+								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+							></path>
+						</svg>
+						{localeLoaded ? $_('common.processing', { default: 'Loading...' }) : 'Loading...'}
+					</div>
+				{:else if error}
+					<div class="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+						{error}
+					</div>
+				{:else if content}
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					<div class="prose prose-sm max-w-none">{@html renderedHtml}</div>
+				{:else}
+					<p class="text-sm text-gray-500">
+						{localeLoaded
+							? $_('libraries.itemContentModal.empty', { default: 'No content.' })
+							: 'No content.'}
+					</p>
+				{/if}
+			</div>
+
+			<div class="flex justify-end border-t border-gray-200 bg-gray-50 px-4 py-3 sm:px-6">
+				<button
+					type="button"
+					class="focus:ring-brand inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-offset-2 focus:outline-none"
+					onclick={close}
+					style="min-width:100px"
+				>
+					{localeLoaded ? $_('libraries.itemContentModal.close', { default: 'Close' }) : 'Close'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/frontend/svelte-app/src/lib/components/libraries/LibraryDetail.svelte
+++ b/frontend/svelte-app/src/lib/components/libraries/LibraryDetail.svelte
@@ -14,7 +14,9 @@
 		deleteItem,
 		getItemStatus,
 		exportLibrary,
-		toggleSharing
+		toggleSharing,
+		getItemContent,
+		getItemKbLinks
 	} from '$lib/services/libraryService';
 	import { _ } from '$lib/i18n';
 	import {
@@ -23,6 +25,7 @@
 	} from '$lib/services/knowledgeStoreService';
 	import ConfirmationModal from '$lib/components/modals/ConfirmationModal.svelte';
 	import ImportModal from '$lib/components/modals/ImportModal.svelte';
+	import ItemContentModal from '$lib/components/libraries/ItemContentModal.svelte';
 
 	/** @param {unknown} err @param {string} fallback @returns {string} */
 	function readableError(err, fallback) {
@@ -80,6 +83,14 @@
 	/** @type {{ id: string, name: string, contentCount: number|null, removing: boolean }[]} */
 	let deleteItemBlockers = $state([]);
 	let deleteItemTarget = $state({ id: '', title: '' });
+
+	// View item content modal
+	let showItemContentModal = $state(false);
+	let isLoadingItemContent = $state(false);
+	let itemContentTarget = $state({ id: '', title: '' });
+	let itemContent = $state('');
+	/** @type {string|null} */
+	let itemContentError = $state(null);
 
 	// Import modal ref
 	let importModal;
@@ -289,18 +300,78 @@
 		}
 	}
 
+	// View item content
+	async function requestViewItem(item) {
+		itemContentTarget = { id: item.id, title: item.title };
+		itemContent = '';
+		itemContentError = null;
+		showItemContentModal = true;
+		isLoadingItemContent = true;
+		try {
+			itemContent = await getItemContent(libraryId, item.id);
+		} catch (/** @type {unknown} */ err) {
+			itemContentError = err instanceof Error
+				? err.message
+				: $_('libraries.itemContentModal.loadError', { default: 'Failed to load content.' });
+		} finally {
+			isLoadingItemContent = false;
+		}
+	}
+
 	// Import callback
 	async function handleImported() {
 		showSuccess($_('libraries.importSuccess', { default: 'Import started.' }));
 		await refreshItems();
 	}
 
-	// Delete item
-	function requestDeleteItem(item) {
+	/**
+	 * Open the delete modal in either "blocked" (KS references found) or
+	 * "confirm" mode based on a pre-flight kb-links lookup. Falls through to
+	 * confirm mode if the pre-check itself fails — the delete handler still
+	 * enforces FR-10 with the 409 fallback below.
+	 * @param {{ id: string, title: string }} item
+	 */
+	async function requestDeleteItem(item) {
 		deleteItemTarget = { id: item.id, title: item.title };
 		deleteItemError = '';
 		deleteItemBlockers = [];
+		try {
+			const links = await getItemKbLinks(libraryId, item.id);
+			const referenced = Array.isArray(links?.knowledge_stores) ? links.knowledge_stores : [];
+			if (referenced.length > 0) {
+				deleteItemError = $_('libraries.deleteItemModal.blockedMessage', {
+					default:
+						'This item is referenced by one or more Knowledge Stores. Remove it from each before deleting.'
+				});
+				deleteItemBlockers = referenced.map((k) => ({
+					id: String(k?.id || ''),
+					name: k?.name || k?.id || 'Knowledge Store',
+					contentCount: /** @type {number|null} */ (null),
+					removing: false
+				}));
+				await enrichBlockersWithCounts();
+			}
+		} catch (/** @type {unknown} */ err) {
+			console.warn('kb-links pre-check failed; falling back to delete-time check', err);
+		}
 		showDeleteItemModal = true;
+	}
+
+	/** Add `content_count` to each blocker row from the KS list, best-effort. */
+	async function enrichBlockersWithCounts() {
+		try {
+			const allKs = await getKnowledgeStores();
+			const byId = new Map(allKs.map((k) => [k.id, k]));
+			deleteItemBlockers = deleteItemBlockers.map((b) => {
+				const full = byId.get(b.id);
+				return {
+					...b,
+					contentCount: typeof full?.content_count === 'number' ? full.content_count : null
+				};
+			});
+		} catch (e) {
+			console.warn('Could not enrich blockers with content counts', e);
+		}
 	}
 
 	async function handleDeleteItemConfirm() {
@@ -313,12 +384,8 @@
 			showSuccess($_('libraries.itemDeleteSuccess', { default: 'Item deleted.' }));
 			await refreshItems();
 		} catch (/** @type {unknown} */ err) {
-			// FR-10: a 409 with a structured ``detail`` lists the Knowledge
-			// Stores still referencing this item. Show them in their own
-			// section with a Remove button per row so the user can clear
-			// the references inline and retry the delete without leaving
-			// the dialog. Falls back to a plain error string for any other
-			// failure shape.
+			// FR-10 fallback: if the pre-check missed (e.g. raced with a new
+			// link), the 409 from DELETE carries the same blockers shape.
 			console.error('deleteItem failed', err);
 			const isAxios = !!(err && typeof err === 'object' && /** @type {any} */ (err).isAxiosError);
 			const status = isAxios ? /** @type {any} */ (err).response?.status : null;
@@ -326,28 +393,13 @@
 			if (status === 409 && detail && typeof detail === 'object') {
 				deleteItemError = typeof detail.message === 'string' ? detail.message : 'Delete failed';
 				const referenced = Array.isArray(detail.knowledge_stores) ? detail.knowledge_stores : [];
-				const initial = referenced.map((k) => ({
+				deleteItemBlockers = referenced.map((k) => ({
 					id: String(k?.id || ''),
 					name: k?.name || k?.id || 'Knowledge Store',
 					contentCount: /** @type {number|null} */ (null),
 					removing: false
 				}));
-				deleteItemBlockers = initial;
-				// Enrich with content counts asynchronously so the rows can
-				// render immediately and the count fades in once available.
-				try {
-					const allKs = await getKnowledgeStores();
-					const byId = new Map(allKs.map((k) => [k.id, k]));
-					deleteItemBlockers = deleteItemBlockers.map((b) => {
-						const full = byId.get(b.id);
-						return {
-							...b,
-							contentCount: typeof full?.content_count === 'number' ? full.content_count : null
-						};
-					});
-				} catch (e) {
-					console.warn('Could not enrich blockers with content counts', e);
-				}
+				await enrichBlockersWithCounts();
 			} else {
 				deleteItemError = readableError(err, 'Delete failed');
 			}
@@ -607,11 +659,9 @@
 								<th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase"
 									>{$_('libraries.items.created', { default: 'Created' })}</th
 								>
-								{#if isOwner}
-									<th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"
-										>{$_('libraries.actions', { default: 'Actions' })}</th
-									>
-								{/if}
+								<th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"
+									>{$_('libraries.actions', { default: 'Actions' })}</th
+								>
 							</tr>
 						</thead>
 						<tbody class="divide-y divide-gray-200 bg-white">
@@ -635,8 +685,17 @@
 										</span>
 									</td>
 									<td class="px-4 py-3 text-sm text-gray-500">{formatDate(item.created_at)}</td>
-									{#if isOwner}
-										<td class="px-4 py-3 text-right">
+									<td class="px-4 py-3 text-right whitespace-nowrap">
+										{#if item.status === 'completed' || item.status === 'ready'}
+											<button
+												type="button"
+												onclick={() => requestViewItem(item)}
+												class="mr-4 text-sm text-blue-600 hover:text-blue-900"
+											>
+												{$_('libraries.viewContent', { default: 'View' })}
+											</button>
+										{/if}
+										{#if isOwner}
 											<button
 												type="button"
 												onclick={() => requestDeleteItem(item)}
@@ -644,8 +703,8 @@
 											>
 												{$_('libraries.delete', { default: 'Delete' })}
 											</button>
-										</td>
-									{/if}
+										{/if}
+									</td>
 								</tr>
 							{/each}
 						</tbody>
@@ -670,16 +729,32 @@
 		default: 'Remove from KS'
 	})}
 	onRemoveBlocker={handleRemoveBlocker}
-	title={$_('libraries.deleteItemModal.title', { default: 'Delete Item' })}
-	message={$_('libraries.deleteItemModal.message', {
-		default: `Are you sure you want to delete "${deleteItemTarget.title}"?`
-	})}
+	title={deleteItemBlockers.length > 0
+		? $_('libraries.deleteItemModal.blockedTitle', { default: 'Cannot delete — in use' })
+		: $_('libraries.deleteItemModal.title', { default: 'Delete Item' })}
+	message={deleteItemBlockers.length > 0
+		? ''
+		: $_('libraries.deleteItemModal.message', {
+				default: `Are you sure you want to delete "${deleteItemTarget.title}"?`
+			})}
 	confirmText={$_('libraries.deleteItemModal.confirm', { default: 'Delete' })}
+	hideConfirm={deleteItemBlockers.length > 0}
 	variant="danger"
 	onconfirm={handleDeleteItemConfirm}
 	oncancel={() => {
 		showDeleteItemModal = false;
 		deleteItemError = '';
 		deleteItemBlockers = [];
+	}}
+/>
+
+<ItemContentModal
+	bind:isOpen={showItemContentModal}
+	bind:isLoading={isLoadingItemContent}
+	title={itemContentTarget.title}
+	content={itemContent}
+	error={itemContentError}
+	onclose={() => {
+		showItemContentModal = false;
 	}}
 />

--- a/frontend/svelte-app/src/lib/components/modals/ConfirmationModal.svelte
+++ b/frontend/svelte-app/src/lib/components/modals/ConfirmationModal.svelte
@@ -26,6 +26,9 @@
 		confirmText = '',
 		cancelText = '',
 		variant = 'danger', // 'danger' | 'warning' | 'info'
+		// Hide the primary Confirm button (e.g. when the modal is opened in
+		// "blocked" mode and the action is currently impossible).
+		hideConfirm = false,
 		onconfirm = () => {},
 		oncancel = () => {}
 	} = $props();
@@ -180,9 +183,11 @@
 
 			<!-- Modal Body -->
 			<div class="px-4 py-5 sm:p-6">
-				<p class="text-sm break-words whitespace-pre-line text-gray-700">
-					{message}
-				</p>
+				{#if message}
+					<p class="text-sm break-words whitespace-pre-line text-gray-700">
+						{message}
+					</p>
+				{/if}
 				{#if error}
 					<div
 						class="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm break-words whitespace-pre-line text-red-700"
@@ -283,6 +288,7 @@
 			<div
 				class="flex flex-col-reverse gap-2 border-t border-gray-200 bg-gray-50 px-4 py-3 sm:flex-row-reverse sm:px-6"
 			>
+				{#if !hideConfirm}
 				<button
 					type="button"
 					class="inline-flex w-full justify-center rounded-md border border-transparent px-4 py-2 text-base font-medium text-white shadow-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:opacity-50 sm:ml-3 sm:w-auto sm:text-sm {styles.confirmBg} {styles.confirmRing}"
@@ -314,6 +320,7 @@
 					{/if}
 					{displayConfirmText}
 				</button>
+				{/if}
 				<button
 					type="button"
 					class="focus:ring-brand inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:opacity-50 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"

--- a/frontend/svelte-app/src/lib/locales/ca.json
+++ b/frontend/svelte-app/src/lib/locales/ca.json
@@ -930,6 +930,13 @@
 		"addContent": "Afegir Contingut",
 		"export": "Exportar",
 		"itemDeleteSuccess": "Element eliminat.",
+		"viewContent": "Veure",
+		"itemContentModal": {
+			"title": "Contingut de l'element",
+			"close": "Tancar",
+			"loadError": "No s'ha pogut carregar el contingut.",
+			"empty": "Sense contingut."
+		},
 		"detailTitle": "Detalls de la Biblioteca",
 		"backButton": "Tornar a biblioteques",
 		"items": {
@@ -961,8 +968,10 @@
 		},
 		"deleteItemModal": {
 			"title": "Eliminar Element",
+			"blockedTitle": "No es pot eliminar — en ús",
 			"message": "Estàs segur que vols eliminar aquest element?",
-			"confirm": "Eliminar"
+			"confirm": "Eliminar",
+			"blockedMessage": "Aquest element està referenciat per una o més bases de coneixement. Elimina'l de cadascuna abans d'esborrar-lo."
 		},
 		"importModal": {
 			"title": "Importar Contingut",

--- a/frontend/svelte-app/src/lib/locales/en.json
+++ b/frontend/svelte-app/src/lib/locales/en.json
@@ -930,6 +930,13 @@
 		"addContent": "Add Content",
 		"export": "Export",
 		"itemDeleteSuccess": "Item deleted.",
+		"viewContent": "View",
+		"itemContentModal": {
+			"title": "Item Content",
+			"close": "Close",
+			"loadError": "Failed to load content.",
+			"empty": "No content."
+		},
 		"detailTitle": "Library Details",
 		"backButton": "Back to libraries",
 		"items": {
@@ -961,8 +968,10 @@
 		},
 		"deleteItemModal": {
 			"title": "Delete Item",
+			"blockedTitle": "Cannot delete — in use",
 			"message": "Are you sure you want to delete this item?",
-			"confirm": "Delete"
+			"confirm": "Delete",
+			"blockedMessage": "This item is referenced by one or more Knowledge Stores. Remove it from each before deleting."
 		},
 		"importModal": {
 			"title": "Import Content",

--- a/frontend/svelte-app/src/lib/locales/es.json
+++ b/frontend/svelte-app/src/lib/locales/es.json
@@ -930,6 +930,13 @@
 		"addContent": "Añadir Contenido",
 		"export": "Exportar",
 		"itemDeleteSuccess": "Elemento eliminado.",
+		"viewContent": "Ver",
+		"itemContentModal": {
+			"title": "Contenido del elemento",
+			"close": "Cerrar",
+			"loadError": "No se pudo cargar el contenido.",
+			"empty": "Sin contenido."
+		},
 		"detailTitle": "Detalles de la Biblioteca",
 		"backButton": "Volver a bibliotecas",
 		"items": {
@@ -961,8 +968,10 @@
 		},
 		"deleteItemModal": {
 			"title": "Eliminar Elemento",
+			"blockedTitle": "No se puede eliminar — en uso",
 			"message": "¿Estás seguro de que quieres eliminar este elemento?",
-			"confirm": "Eliminar"
+			"confirm": "Eliminar",
+			"blockedMessage": "Este elemento está referenciado por una o más bases de conocimiento. Elimínalo de cada una antes de borrarlo."
 		},
 		"importModal": {
 			"title": "Importar Contenido",

--- a/frontend/svelte-app/src/lib/locales/eu.json
+++ b/frontend/svelte-app/src/lib/locales/eu.json
@@ -930,6 +930,13 @@
 		"addContent": "Edukia Gehitu",
 		"export": "Esportatu",
 		"itemDeleteSuccess": "Elementua ezabatua.",
+		"viewContent": "Ikusi",
+		"itemContentModal": {
+			"title": "Elementuaren edukia",
+			"close": "Itxi",
+			"loadError": "Ezin izan da edukia kargatu.",
+			"empty": "Edukirik ez."
+		},
 		"detailTitle": "Liburutegiaren Xehetasunak",
 		"backButton": "Liburutegietara itzuli",
 		"items": {
@@ -961,8 +968,10 @@
 		},
 		"deleteItemModal": {
 			"title": "Elementua Ezabatu",
+			"blockedTitle": "Ezin da ezabatu — erabiltzen ari da",
 			"message": "Ziur zaude elementu hau ezabatu nahi duzula?",
-			"confirm": "Ezabatu"
+			"confirm": "Ezabatu",
+			"blockedMessage": "Elementu hau ezagutza-base batek baino gehiagok erreferentziatzen dute. Ezabatu aurretik kendu denetatik."
 		},
 		"importModal": {
 			"title": "Edukia Inportatu",

--- a/frontend/svelte-app/src/lib/services/libraryService.js
+++ b/frontend/svelte-app/src/lib/services/libraryService.js
@@ -266,6 +266,39 @@ export async function getItem(libraryId, itemId) {
 }
 
 /**
+ * Get the rendered markdown content of an item.
+ * @param {string} libraryId
+ * @param {string} itemId
+ * @returns {Promise<string>} Raw markdown
+ */
+export async function getItemContent(libraryId, itemId) {
+    if (!browser) throw new Error('Browser only.');
+    const url = getApiUrl(`/libraries/${libraryId}/items/${itemId}/content`);
+    const response = await axios.get(url, {
+        headers: authHeaders(),
+        params: { format: 'markdown' },
+        responseType: 'text',
+        transformResponse: (v) => v
+    });
+    return response.data;
+}
+
+/**
+ * Pre-check which Knowledge Stores reference an item — used before
+ * showing the delete-confirm modal so we can route directly to the
+ * blockers panel when the item is in use.
+ * @param {string} libraryId
+ * @param {string} itemId
+ * @returns {Promise<{ item_id: string, knowledge_stores: Array<{ id: string, name: string, status: string }> }>}
+ */
+export async function getItemKbLinks(libraryId, itemId) {
+    if (!browser) throw new Error('Browser only.');
+    const url = getApiUrl(`/libraries/${libraryId}/items/${itemId}/kb-links`);
+    const response = await axios.get(url, { headers: authHeaders() });
+    return response.data;
+}
+
+/**
  * Get the import status for an item.
  * @param {string} libraryId
  * @param {string} itemId

--- a/frontend/svelte-app/src/lib/utils/sanitize.js
+++ b/frontend/svelte-app/src/lib/utils/sanitize.js
@@ -49,3 +49,31 @@ export function sanitizeHtml(html) {
 	if (!browser) return html;
 	return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
 }
+
+/**
+ * Stricter markdown renderer for embedded user-uploaded content.
+ *
+ * Adds belt-and-braces over `renderMarkdownSafe`:
+ *  - Explicit `FORBID_TAGS` even though `USE_PROFILES.html` blocks most.
+ *  - Forces `target="_blank"` + `rel="noopener noreferrer"` on every `<a>`
+ *    via post-processing (not a DOMPurify hook, which would leak globally).
+ *
+ * @param {string} text - Markdown source
+ * @returns {string} Sanitized HTML
+ */
+export function renderMarkdownStrict(text) {
+	if (!text) return '';
+	const html = String(marked.parse(text, { breaks: true, gfm: true }));
+	if (!browser) return html;
+	const sanitized = DOMPurify.sanitize(html, {
+		USE_PROFILES: { html: true },
+		FORBID_TAGS: ['iframe', 'object', 'embed', 'form', 'input', 'button', 'style']
+	});
+	const container = document.createElement('div');
+	container.innerHTML = sanitized;
+	for (const anchor of container.querySelectorAll('a')) {
+		anchor.setAttribute('target', '_blank');
+		anchor.setAttribute('rel', 'noopener noreferrer');
+	}
+	return container.innerHTML;
+}

--- a/frontend/svelte-app/src/lib/utils/sanitize.svelte.test.js
+++ b/frontend/svelte-app/src/lib/utils/sanitize.svelte.test.js
@@ -1,0 +1,70 @@
+// Uses the `.svelte.` filename suffix to opt into the jsdom workspace
+// (see vite.config.js test workspaces). The DOMPurify-dependent code paths
+// in sanitize.js are no-ops outside a browser env, so jsdom is required to
+// exercise them.
+
+import { describe, it, expect } from 'vitest';
+import { renderMarkdownSafe, renderMarkdownStrict } from './sanitize.js';
+
+describe('renderMarkdownStrict — XSS hardening', () => {
+	it('strips <script> tags', () => {
+		const html = renderMarkdownStrict('Hello <script>alert(1)</script> world');
+		expect(html).not.toContain('<script');
+		expect(html).not.toContain('alert(1)');
+	});
+
+	it('strips onerror= and other event handler attributes', () => {
+		const html = renderMarkdownStrict('<img src="x" onerror="alert(1)">');
+		expect(html).not.toContain('onerror');
+		expect(html).not.toContain('alert(1)');
+	});
+
+	it('strips <iframe>', () => {
+		const html = renderMarkdownStrict('<iframe src="https://evil.example"></iframe>');
+		expect(html).not.toContain('<iframe');
+	});
+
+	it('strips <form>, <button>, <input>, <style>', () => {
+		const html = renderMarkdownStrict(
+			'<form action="x"><input name="a"><button>go</button></form><style>body{}</style>'
+		);
+		expect(html).not.toContain('<form');
+		expect(html).not.toContain('<input');
+		expect(html).not.toContain('<button');
+		expect(html).not.toContain('<style');
+	});
+
+	it('strips javascript: URIs from links', () => {
+		// eslint-disable-next-line no-script-url
+		const html = renderMarkdownStrict('[bad](javascript:alert(1))');
+		expect(html).not.toContain('javascript:');
+	});
+
+	it('adds target="_blank" and rel="noopener noreferrer" to links', () => {
+		const html = renderMarkdownStrict('[example](https://example.com)');
+		expect(html).toContain('href="https://example.com"');
+		expect(html).toContain('target="_blank"');
+		expect(html).toContain('rel="noopener noreferrer"');
+	});
+
+	it('renders ordinary markdown structure (heading, list, code)', () => {
+		const html = renderMarkdownStrict('# Title\n\n- one\n- two\n\n`code`');
+		expect(html).toMatch(/<h1[^>]*>Title<\/h1>/);
+		expect(html).toContain('<ul');
+		expect(html).toContain('<li>one</li>');
+		expect(html).toContain('<code>code</code>');
+	});
+});
+
+describe('renderMarkdownSafe — regression', () => {
+	it('still strips <script>', () => {
+		const html = renderMarkdownSafe('<script>alert(1)</script>');
+		expect(html).not.toContain('<script');
+	});
+
+	it('renders headings and links', () => {
+		const html = renderMarkdownSafe('# Hello\n\n[a](https://example.com)');
+		expect(html).toMatch(/<h1[^>]*>Hello<\/h1>/);
+		expect(html).toContain('href="https://example.com"');
+	});
+});

--- a/lamb-cli/src/lamb_cli/commands/library.py
+++ b/lamb-cli/src/lamb_cli/commands/library.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import time
 from typing import Optional
 
@@ -361,6 +362,39 @@ def get_item(
     with get_client() as client:
         data = client.get(f"/creator/libraries/{library_id}/items/{item_id}")
     format_output(data, ITEM_LIST_COLUMNS, fmt, detail_fields=ITEM_DETAIL_FIELDS)
+
+
+@app.command("item-content")
+def get_item_content(
+    library_id: str = typer.Argument(..., help="Library ID."),
+    item_id: str = typer.Argument(..., help="Item ID."),
+    format: str = typer.Option(
+        "markdown", "--format", "-f",
+        help="Content format: markdown or text.",
+    ),
+) -> None:
+    """Print the full content of an imported library item to stdout."""
+    if format not in ("markdown", "text"):
+        print_error(f"Invalid format '{format}'. Use 'markdown' or 'text'.")
+        raise typer.Exit(2)
+    try:
+        with get_client() as client:
+            content = client.get(
+                f"/creator/libraries/{library_id}/items/{item_id}/content",
+                params={"format": format},
+            )
+    except ApiError as exc:
+        if exc.status_code == 413:
+            print_error("Item is too large to print. Download the original instead.")
+            raise typer.Exit(2)
+        raise
+    if isinstance(content, str):
+        sys.stdout.write(content)
+        if not content.endswith("\n"):
+            sys.stdout.write("\n")
+    else:
+        from lamb_cli.output import print_json
+        print_json(content)
 
 
 @app.command("delete-item")

--- a/lamb-cli/tests/test_commands/test_library.py
+++ b/lamb-cli/tests/test_commands/test_library.py
@@ -925,3 +925,57 @@ class TestLibraryResilience:
         url = str(httpx_mock.get_request().url)
         assert "limit=50" in url
         assert "offset=100" in url
+
+
+class TestItemContent:
+    """Tests for ``lamb library item-content`` (#370)."""
+
+    def test_prints_markdown_to_stdout(self, httpx_mock, mock_token, mock_server_url):
+        body = b"# Title\n\nbody line 1\nbody line 2\n"
+        httpx_mock.add_response(
+            url="http://test-server:9099/creator/libraries/L1/items/I1/content?format=markdown",
+            content=body,
+            headers={"content-type": "text/markdown"},
+        )
+
+        result = runner.invoke(app, ["library", "item-content", "L1", "I1"])
+
+        assert result.exit_code == 0
+        assert "# Title" in result.output
+        assert "body line 1" in result.output
+        assert "body line 2" in result.output
+
+    def test_text_format(self, httpx_mock, mock_token, mock_server_url):
+        body = b"plain text body"
+        httpx_mock.add_response(
+            url="http://test-server:9099/creator/libraries/L1/items/I1/content?format=text",
+            content=body,
+            headers={"content-type": "text/plain"},
+        )
+
+        result = runner.invoke(
+            app, ["library", "item-content", "L1", "I1", "--format", "text"]
+        )
+
+        assert result.exit_code == 0
+        assert "plain text body" in result.output
+
+    def test_invalid_format_exits_with_2(self, mock_token, mock_server_url):
+        result = runner.invoke(
+            app, ["library", "item-content", "L1", "I1", "--format", "html"]
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid format" in result.output
+
+    def test_413_shows_friendly_error(self, httpx_mock, mock_token, mock_server_url):
+        httpx_mock.add_response(
+            url="http://test-server:9099/creator/libraries/L1/items/I1/content?format=markdown",
+            status_code=413,
+            json={"detail": "Content exceeds 5 MB."},
+        )
+
+        result = runner.invoke(app, ["library", "item-content", "L1", "I1"])
+
+        assert result.exit_code == 2
+        assert "too large" in result.output.lower()

--- a/testing/playwright/tests/library_api.spec.js
+++ b/testing/playwright/tests/library_api.spec.js
@@ -245,6 +245,42 @@ test.describe.serial("Library Manager integration", () => {
     expect(res.type).toBe("application/zip");
   });
 
+  test("get item content as markdown", async ({ page }) => {
+    const res = await apiCall(
+      page,
+      "GET",
+      `/creator/libraries/${libraryId}/items/${itemId}/content`,
+    );
+
+    expect(res.status).toBe(200);
+    // The body is raw markdown — at minimum non-empty, contains some of the
+    // uploaded file's text. We uploaded a markdown notes file earlier so the
+    // payload should be a string with the original heading-like marker.
+    expect(typeof res.data).toBe("string");
+    expect(res.data.length).toBeGreaterThan(0);
+  });
+
+  test("get item content rejects html format with 422", async ({ page }) => {
+    const res = await apiCall(
+      page,
+      "GET",
+      `/creator/libraries/${libraryId}/items/${itemId}/content?format=html`,
+    );
+
+    expect(res.status).toBe(422);
+  });
+
+  test("get item content accepts text format", async ({ page }) => {
+    const res = await apiCall(
+      page,
+      "GET",
+      `/creator/libraries/${libraryId}/items/${itemId}/content?format=text`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(typeof res.data).toBe("string");
+  });
+
   test("delete item", async ({ page }) => {
     const res = await apiCall(
       page,


### PR DESCRIPTION
## Purpose

After importing a document into a Library, the only confirmation the import worked was the metadata row (size, status, plugin) — neither the CLI nor the UI exposed the rendered markdown. Users had to dig through Library Manager's filesystem or run DB queries to verify content. This PR adds a first-class **view** path on both surfaces, plus inverts the item-delete flow so the "Are you sure?" prompt is itself a guarantee that no Knowledge Store references the item.

## Changes

**View library item content**
- New Creator Interface route `GET /creator/libraries/{lib}/items/{item}/content` that proxies the Library Manager content endpoint with ACL enforcement, a `Literal["markdown", "text"]` format whitelist (HTML is blocked at the proxy boundary — Library Manager's `format=html` is unsanitized), and a 5 MB inline-content size cap.
- New `lamb library item-content <lib> <item>` CLI command that writes the full markdown to stdout (no truncation, no paging — pipe to `less` if needed). Supports `--format markdown|text` and surfaces the 5 MB cap with a friendly error.
- New `ItemContentModal.svelte` viewer with `max-w-3xl`, scrollable body, Escape/overlay close, and a single Close button. Renders markdown via a new hardened sibling of `renderMarkdownSafe` — `renderMarkdownStrict` — that adds explicit `FORBID_TAGS` for iframe/object/embed/form/input/button/style and post-processes anchors to add `target="_blank"` + `rel="noopener noreferrer"`.
- "View" row action on `LibraryDetail` for items in `ready`/`completed` status.
- i18n keys added in en/es/ca/eu.

**Invert delete-confirm flow** (also in this PR per request)
- New `GET /creator/libraries/{lib}/items/{item}/kb-links` pre-check endpoint returning the active KS references with the same shape used by the FR-10 409 body. Failed ingestions are excluded.
- `LibraryDetail.requestDeleteItem` now runs the pre-check **before** opening the modal. When blockers exist the modal opens directly in "blocked" mode (KS list + Remove buttons, no Confirm); when clean it opens in normal "Are you sure?" mode. The mere appearance of the confirm prompt now signals the item is free to delete.
- `ConfirmationModal` gets a `hideConfirm` prop so callers can suppress the primary action; the body's message is wrapped in `{#if message}` so an empty string renders nothing.
- The existing 409 path is preserved as a fallback for races between pre-check and DELETE.

**Race-guard fix in the Create Knowledge wizard**
- `StepKSContent.loadItems` could let a slower response for library A overwrite items belonging to library B if the user switched picks faster than the network. Added a request-sequence guard that discards stale resolutions; locked the contract with five source-level vitest assertions so it can't silently regress.

**Tests**
- 10 new backend pytest cases (`/content` happy path, ACL, unauth, format whitelist, size cap; `/kb-links` blockers, failed-filter, empty, ACL).
- 4 new CLI pytest cases (`item-content` markdown, text, invalid format, 413).
- 9 new vitest cases on `renderMarkdownSafe`/`renderMarkdownStrict` (XSS payload coverage).
- 5 new vitest cases on the wizard race-guard.
- 3 new Playwright cases on the `/content` endpoint.

All existing suites still green: backend 80/80, library-manager 52/52, CLI 60/60.

## Security review

A separate review pass against this diff returned no findings — `format` is whitelisted server-side, HTML output is intentionally not exposed, the modal renders only `renderMarkdownStrict` output via `{@html}`, and Svelte's default interpolation escapes the rest. Passive external resources in markdown (`<img src=external>`) remain a pre-existing concern tracked separately in #369 (CSP header).

## Related

- Closes #370
- Refs #369 (CSP header — surfaced during this review)