### PR TITLE
fix(#377): migrate url_import to firecrawl-py 2.x API

### DIFF
--- a/library-manager/backend/plugins/url_import.py
+++ b/library-manager/backend/plugins/url_import.py
@@ -69,16 +69,18 @@ class UrlImportPlugin(LibraryImportPlugin):
 
         t0 = time.monotonic()
         try:
+            # firecrawl-py >= 2.x: crawl_url() → crawl(), kwargs not a params dict.
+            from firecrawl.v2.types import ScrapeOptions  # noqa: PLC0415
             app = FirecrawlApp(api_key=api_key, api_url=api_url)
-            crawl_params = {
-                "limit": limit,
-                "maxDepth": max_depth,
-                "scrapeOptions": {"formats": ["markdown"]},
-            }
-            if not crawl_domain:
-                crawl_params["allowExternalLinks"] = False
-
-            crawl_result = app.crawl_url(url, params=crawl_params, poll_interval=5)
+            crawl_result = app.crawl(
+                url,
+                limit=limit,
+                max_discovery_depth=max_depth,
+                crawl_entire_domain=crawl_domain,
+                allow_external_links=False,
+                scrape_options=ScrapeOptions(formats=["markdown"]),
+                poll_interval=5,
+            )
         except Exception as exc:
             raise RuntimeError(f"Firecrawl crawl failed for {url}: {exc}") from exc
 
@@ -109,13 +111,25 @@ class UrlImportPlugin(LibraryImportPlugin):
 
             if hasattr(doc, "markdown"):
                 page_md = doc.markdown or ""
-                page_url = getattr(doc, "url", "") or (
-                    getattr(doc, "metadata", {}) or {}
-                ).get("sourceURL", "")
-                page_title = (getattr(doc, "metadata", {}) or {}).get("title", "")
+                # firecrawl-py 2.x metadata is a Pydantic model (attrs);
+                # legacy dict form used camelCase (sourceURL). Handle both.
+                meta = getattr(doc, "metadata", None)
+                if meta is not None and not isinstance(meta, dict):
+                    page_url = (
+                        getattr(meta, "url", "")
+                        or getattr(meta, "source_url", "")
+                        or ""
+                    )
+                    page_title = getattr(meta, "title", "") or ""
+                elif isinstance(meta, dict):
+                    page_url = meta.get("sourceURL", "") or meta.get("source_url", "")
+                    page_title = meta.get("title", "")
+                page_url = page_url or getattr(doc, "url", "")
             elif isinstance(doc, dict):
                 page_md = doc.get("markdown", "")
-                page_url = doc.get("metadata", {}).get("sourceURL", "")
+                page_url = doc.get("metadata", {}).get("sourceURL", "") or doc.get(
+                    "metadata", {}
+                ).get("source_url", "")
                 page_title = doc.get("metadata", {}).get("title", "")
 
             if page_md.strip():


### PR DESCRIPTION
## Purpose

URL imports fail at runtime with `AttributeError: 'Firecrawl' object has no attribute 'crawl_url'`. The plugin was written against firecrawl-py 0.x; the dependency currently in the library-manager container is firecrawl-py 4.25.2, which renamed the entry points and reshaped the response objects.

## Changes

- Replace `app.crawl_url(url, params={...}, poll_interval=5)` with `app.crawl(url, **kwargs, scrape_options=ScrapeOptions(formats=["markdown"]), poll_interval=5)` — keyword arguments now carry `limit`, `max_discovery_depth`, `crawl_entire_domain`, `allow_external_links` directly.
- Per-page metadata extraction handles both the new Pydantic `DocumentMetadata` (attribute access on `source_url`/`title`) and the legacy dict form (camelCase `sourceURL`) for forward compatibility.
- No behavior change to the zero-pages fallback, progress reporting, or surrounding plugin scaffolding.

The migration is dependency-only — no public API of the plugin changes, no other call sites needed updates.

## Verification

- `library-manager/tests/` — 52/52 passing against the patched plugin.
- Live smoke against a self-hosted Firecrawl instance: queue an import of `https://example.com`, item reaches status `ready`, content endpoint returns non-empty markdown.

## Related

- Closes #377