### PR TITLE
Library manager docker image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -18,6 +18,7 @@ on:
           - lamb
           - lamb-kb
           - openwebui
+          - lamb-library-manager
       manual_tag:
         description: "Tag to publish for manual runs (for example: dev or v0.5.0)"
         required: true
@@ -47,6 +48,9 @@ jobs:
           - image_name: openwebui
             dockerfile: open-webui/Dockerfile
             context: open-webui
+          - image_name: lamb-library-manager
+            dockerfile: library-manager/Dockerfile
+            context: library-manager
 
     steps:
       - name: Checkout

--- a/docker-compose.next.yaml
+++ b/docker-compose.next.yaml
@@ -36,7 +36,7 @@ services:
       openwebui:
         condition: service_healthy
       library-manager:
-        condition: service_started
+        condition: service_healthy
 
   kb:
     image: ghcr.io/lamb-project/lamb-kb:latest

--- a/docker-compose.next.yaml
+++ b/docker-compose.next.yaml
@@ -57,7 +57,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - kb-data:/app/backend/data
+      - kb-data:/app/data
       - kb-static:/app/backend/static
 
   library-manager:

--- a/docker-compose.next.yaml
+++ b/docker-compose.next.yaml
@@ -57,7 +57,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - kb-data:/app/data
+      - kb-data:/app/backend/data
       - kb-static:/app/backend/static
 
   library-manager:

--- a/docker-compose.next.yaml
+++ b/docker-compose.next.yaml
@@ -23,6 +23,8 @@ services:
       OWI_ADMIN_NAME: ${OWI_ADMIN_NAME?Set OWI_ADMIN_NAME}
       OWI_ADMIN_EMAIL: ${OWI_ADMIN_EMAIL?Set OWI_ADMIN_EMAIL}
       OWI_ADMIN_PASSWORD: ${OWI_ADMIN_PASSWORD?Set OWI_ADMIN_PASSWORD}
+      LAMB_LIBRARY_SERVER: http://library-manager:9091
+      LAMB_LIBRARY_TOKEN: ${LAMB_LIBRARY_TOKEN?Set LAMB_LIBRARY_TOKEN}
     ports:
       - "9099:9099"
     volumes:
@@ -33,6 +35,8 @@ services:
         condition: service_started
       openwebui:
         condition: service_healthy
+      library-manager:
+        condition: service_started
 
   kb:
     image: ghcr.io/lamb-project/lamb-kb:latest
@@ -55,6 +59,28 @@ services:
     volumes:
       - kb-data:/app/backend/data
       - kb-static:/app/backend/static
+
+  library-manager:
+    image: ghcr.io/lamb-project/lamb-library-manager:latest
+    build:
+      context: ./library-manager
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      PORT: ${LIBRARY_MANAGER_PORT:-9091}
+      LAMB_API_TOKEN: ${LAMB_LIBRARY_TOKEN?Set LAMB_LIBRARY_TOKEN}
+      DATA_DIR: /app/data
+      MAX_CONCURRENT_IMPORTS: ${LIBRARY_MANAGER_MAX_CONCURRENT_IMPORTS:-3}
+      IMPORT_TASK_TIMEOUT_SECONDS: ${LIBRARY_MANAGER_IMPORT_TIMEOUT:-600}
+      PERMALINK_PREFIX: /docs
+    volumes:
+      - library-manager-data:/app/data
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9091/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   openwebui:
     image: ghcr.io/lamb-project/openwebui:latest
@@ -93,4 +119,5 @@ volumes:
   kb-data:
   kb-static:
   openwebui-data:
+  library-manager-data:
   ollama-data:


### PR DESCRIPTION
This PR adds library-manager Docker image to CI and compose stack (fixes #375)

- Add `library-manager` to the build-images.yml workflow matrix so it is
  built and published as `ghcr.io/lamb-project/lamb-library-manager:latest`
  alongside the existing images (lamb, lamb-kb, openwebui).
- Add `library-manager` service to docker-compose.next.yaml with its
  published image, persistent volume, healthcheck, and environment
  variables (`LAMB_API_TOKEN` forwarded from `LAMB_LIBRARY_TOKEN`).
- Expose `LAMB_LIBRARY_SERVER` and `LAMB_LIBRARY_TOKEN` to the lamb
  service so it can reach the library-manager internally.
- Set lamb's dependency on library-manager to `service_healthy` to avoid
  race conditions where lamb proxies requests before the service is
  actually listening (observed during production testing).