### PR TITLE
feat(completions): add opt-in include_eval_metadata to expose retrieved RAG context

### DIFF
--- a/backend/lamb/completions/main.py
+++ b/backend/lamb/completions/main.py
@@ -442,7 +442,8 @@ def load_plugins(plugin_type: str) -> Dict[str, Any]:
 async def run_lamb_assistant(
     request: Dict[str, Any],
     assistant: int,  # now expect only an assistant id as int
-    headers: Optional[Dict[str, str]] = None # Add optional headers argument
+    headers: Optional[Dict[str, str]] = None, # Add optional headers argument
+    include_eval_metadata: bool = False  # opt-in: attach retrieved RAG context to the response
 ):
     """
     Implements a non WS version of create completion.
@@ -546,6 +547,19 @@ async def run_lamb_assistant(
                     provider=provider,
                     usage_data=llm_response["usage"]
                 )
+
+            # Opt-in: surface the retrieved RAG context so the evaluation
+            # framework can score answers against what was actually retrieved.
+            # Only attached when the caller set include_eval_metadata; the extra
+            # top-level key is ignored by standard OpenAI-compatible clients, so
+            # default callers get an unchanged response. Streaming is left as-is.
+            if include_eval_metadata and isinstance(rag_context, dict):
+                llm_response["eval_metadata"] = {
+                    "rag_context": {
+                        "context": rag_context.get("context", ""),
+                        "sources": rag_context.get("sources", []),
+                    }
+                }
 
             return Response(
                 content=json.dumps(llm_response, indent=2), # Ensure pretty printing if desired

--- a/backend/main.py
+++ b/backend/main.py
@@ -753,6 +753,11 @@ async def generate_openai_chat_completion(request: Request):
     model = form_data.get('model')
     messages = form_data.get('messages', [])
     stream = form_data.get('stream', False)
+    # Opt-in eval flag: when true, the response carries the retrieved RAG
+    # context under `eval_metadata` (consumed by the evaluation framework).
+    # Captured here because the DummyFormData wrapper below only preserves
+    # model/messages/stream; absent by default so normal callers are unaffected.
+    include_eval_metadata = bool(form_data.get('include_eval_metadata', False))
 
     multimodal_logger.info("Final parsed data:")
     multimodal_logger.info(f"Model: {model}")
@@ -822,10 +827,14 @@ async def generate_openai_chat_completion(request: Request):
         request_data = form_data.model_dump()
         multimodal_logger.debug(f"Request data being sent: {json.dumps(request_data, indent=2)[:1000]}...")
 
+        # Pass the opt-in eval flag as an explicit arg, NOT inside request_data:
+        # the connector forwards request body fields to the provider SDK, so an
+        # unknown key in the body would break the upstream API call.
         response = await run_lamb_assistant(
             request=request_data,
             assistant=assistant_id,
-            headers=common_headers # Pass headers to the assistant runner
+            headers=common_headers, # Pass headers to the assistant runner
+            include_eval_metadata=include_eval_metadata
         )
 
         multimodal_logger.info(f"Assistant returned response, type: {type(response)}")

--- a/backend/tests/test_eval_metadata.py
+++ b/backend/tests/test_eval_metadata.py
@@ -1,0 +1,91 @@
+"""Tests for the opt-in `include_eval_metadata` response field.
+
+When a caller sets `include_eval_metadata=True`, `run_lamb_assistant` attaches
+the retrieved RAG context to the non-streaming response under
+`eval_metadata.rag_context.context` (consumed by the lamb-eval framework). When
+the flag is absent the response is unchanged. These tests exercise that logic
+directly with the heavy dependencies (DB, plugin loading, connector, RAG) mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).parent.parent
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from lamb.completions import main as completions_main  # noqa: E402
+
+_RETRIEVED = "RETRIEVED CHUNK TEXT"
+_RAG_CONTEXT = {"context": _RETRIEVED, "sources": [{"title": "doc", "score": 0.9}]}
+
+
+def _patches(rag_context):
+    """Patch every external dependency of run_lamb_assistant.
+
+    connector is "ollama" so the token-usage logging branch is skipped.
+    """
+    assistant_details = MagicMock(owner="creator@example.com", organization_id=None)
+    plugin_config = {
+        "connector": "ollama",
+        "rag_processor": "knowledge_store_rag",
+        "llm": "test-llm",
+        "document_rag": "",
+    }
+    connector_func = AsyncMock(return_value={"id": "chatcmpl-x", "choices": [{"message": {"content": "hi"}}]})
+    return [
+        patch.object(completions_main, "get_assistant_details", return_value=assistant_details),
+        patch.object(completions_main, "parse_plugin_config", return_value=plugin_config),
+        patch.object(completions_main, "_provider_for_connector", return_value=None),
+        patch.object(completions_main, "maybe_route_non_streaming_task", AsyncMock(return_value=None)),
+        patch.object(
+            completions_main,
+            "load_and_validate_plugins",
+            return_value=(MagicMock(), {"ollama": connector_func}, MagicMock()),
+        ),
+        patch.object(completions_main, "get_rag_context", AsyncMock(return_value=rag_context)),
+        patch.object(completions_main, "process_completion_request", return_value=[{"role": "user", "content": "q"}]),
+    ]
+
+
+async def _run(include_eval_metadata, rag_context=_RAG_CONTEXT):
+    request = {"model": "lamb_assistant.1", "messages": [{"role": "user", "content": "q"}], "stream": False}
+    ctxs = _patches(rag_context)
+    for c in ctxs:
+        c.start()
+    try:
+        resp = await completions_main.run_lamb_assistant(
+            request=request, assistant=1, headers={}, include_eval_metadata=include_eval_metadata
+        )
+    finally:
+        for c in ctxs:
+            c.stop()
+    return json.loads(resp.body)
+
+
+@pytest.mark.asyncio
+async def test_flag_true_attaches_retrieved_context():
+    body = await _run(include_eval_metadata=True)
+    assert body["eval_metadata"]["rag_context"]["context"] == _RETRIEVED
+    assert body["eval_metadata"]["rag_context"]["sources"]
+    # The base OpenAI response is preserved.
+    assert body["choices"][0]["message"]["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_flag_absent_leaves_response_unchanged():
+    body = await _run(include_eval_metadata=False)
+    assert "eval_metadata" not in body
+
+
+@pytest.mark.asyncio
+async def test_flag_true_but_no_rag_context_omits_eval_metadata():
+    # A non-dict rag_context (e.g. no_rag returns None upstream) must not attach.
+    body = await _run(include_eval_metadata=True, rag_context=None)
+    assert "eval_metadata" not in body


### PR DESCRIPTION
## Purpose
The evaluation framework (lamb-eval) sends `include_eval_metadata: true` on `/v1/chat/completions` and reads `eval_metadata.rag_context.context` to score answers against what the assistant actually retrieved. LAMB never returned that field, so RAG metrics fell back to authored reference contexts. This adds the backend half — strictly opt-in and backward-compatible.

## Changes
- `backend/main.py` — captures the opt-in `include_eval_metadata` flag from the request body and passes it as an **explicit argument** to `run_lamb_assistant` (not inside the request dict, which the connector forwards to the provider SDK and would break the upstream call).
- `backend/lamb/completions/main.py` — `run_lamb_assistant` gains an `include_eval_metadata: bool = False` param; on the **non-streaming** path only, when set, it attaches the already-computed RAG context as `eval_metadata.rag_context.{context,sources}`. No retrieval or plugin changes.
- `backend/tests/test_eval_metadata.py` — unit tests for flag-on / flag-off / no-rag-context.

## Safety / compatibility
- Absent flag → byte-identical response. Streaming path untouched. Extra top-level key is ignored by standard OpenAI-compatible clients.
- Verified live against the running demo: flag → `eval_metadata` with real retrieved context (answer grounded in it); no flag → unchanged; streaming intact; health 200 throughout.
- Backend suite: **121 passed** (3 new), no regressions. Cross-repo: lamb-eval now populates `retrieved_contexts` from the live response.

## Related
- Implements the deferred LAMB-backend half of lamb-eval issue #94.
