### PR TITLE
feat(knowledge-stores): relabel 'Advanced' as 'Vector indexing' + scaffold future indexing strategy

### DIFF
--- a/frontend/svelte-app/src/lib/components/knowledgeStores/AddContentToKSModal.svelte
+++ b/frontend/svelte-app/src/lib/components/knowledgeStores/AddContentToKSModal.svelte
@@ -6,7 +6,7 @@
              empty ones, clearly badged) and pick one as the source.
     Step 2 — Items:   show ready items in the picked library, checkboxes +
              select-all, must pick at least one to advance.
-    Step 3 — Review:  list of items about to be ingested + the Add button.
+    Step 3 — Review:  list of items about to be indexed + the Add button.
 
   Draft auto-save uses the shared wizardDraftStore so a closed modal can
   be resumed on the same KS (state: { step, libraryId, itemIds }).
@@ -409,7 +409,7 @@
 			{#if step === 1}
 				<p class="type-body-muted">
 					{$_('knowledgeStores.addContentModal.libraryHint', {
-						default: 'Pick the library that contains the items to ingest.'
+						default: 'Pick the library that contains the items to index.'
 					})}
 				</p>
 				{#if loadingLibs}
@@ -485,7 +485,7 @@
 						variant="warning"
 						description={$_('knowledgeStores.addContentModal.libraryEmptyHint', {
 							default:
-								'This library has no items ready to ingest. Go back and choose a different library, or import content into this one first.'
+								'This library has no items ready to index. Go back and choose a different library, or import content into this one first.'
 						})}
 					/>
 				{:else if items.filter((i) => i.status === 'ready').length === 0}
@@ -505,7 +505,7 @@
 					).length}
 					<div class="flex items-center justify-between">
 						<span class="text-text type-body font-medium">
-							{$_('knowledgeStores.addContentModal.itemsLabel', { default: 'Items to ingest' })}
+							{$_('knowledgeStores.addContentModal.itemsLabel', { default: 'Items to index' })}
 						</span>
 						<Button variant="ghost" size="sm" onclick={toggleAllItems}>
 							{selectedItemIds.size === selectableCount
@@ -567,7 +567,7 @@
 			{:else}
 				<p class="type-body-muted">
 					{$_('knowledgeStores.addContentModal.reviewHint', {
-						default: 'Review what will be ingested, then click Add.'
+						default: 'Review what will be indexed, then click Add.'
 					})}
 				</p>
 				<div class="border-border bg-surface-muted rounded-md border p-3">
@@ -581,7 +581,7 @@
 				<div>
 					<p class="type-label mb-1">
 						{$_('knowledgeStores.addContentModal.reviewItems', {
-							default: 'Items to ingest',
+							default: 'Items to index',
 							values: { count: selectedItemIds.size }
 						})}
 						<span class="text-text-muted ml-1">({selectedItemIds.size})</span>

--- a/frontend/svelte-app/src/lib/components/modals/CreateKnowledgeStoreModal.svelte
+++ b/frontend/svelte-app/src/lib/components/modals/CreateKnowledgeStoreModal.svelte
@@ -409,8 +409,8 @@
 					<summary
 						class="cursor-pointer px-3 py-2 text-sm font-medium text-[#2271b3] select-none hover:underline"
 					>
-						{$_('knowledgeStores.createModal.advancedLabel', {
-							default: 'Advanced: chunking, embedding, vector DB'
+						{$_('knowledgeStores.createModal.vectorIndexingLabel', {
+							default: 'Vector indexing: chunking, embedding, vector DB'
 						})}
 					</summary>
 
@@ -611,6 +611,27 @@
 								</fieldset>
 							{/if}
 						{/if}
+					</div>
+				</details>
+
+				<!-- Scaffold for a future, non-vector indexing strategy. Disabled
+				     placeholder so the UI makes clear that "vector indexing" is one
+				     of several possible indexing strategies. When a new strategy is
+				     added (backend registry + /knowledge-stores/options), replace
+				     this with a real selector and its config panel. -->
+				<details class="rounded-md border border-gray-200 bg-gray-50 opacity-70">
+					<summary
+						class="cursor-pointer px-3 py-2 text-sm font-medium text-gray-400 select-none hover:underline"
+					>
+						{$_('knowledgeStores.createModal.otherIndexingLabel', {
+							default: 'Other indexing strategy (coming soon)'
+						})}
+					</summary>
+					<div class="p-3 text-xs text-gray-500">
+						{$_('knowledgeStores.createModal.otherIndexingHint', {
+							default:
+								'Additional indexing strategies (beyond vector indexing) will be selectable here in a future version.'
+						})}
 					</div>
 				</details>
 

--- a/frontend/svelte-app/src/lib/components/modals/CreateKnowledgeStoreModal.svelte
+++ b/frontend/svelte-app/src/lib/components/modals/CreateKnowledgeStoreModal.svelte
@@ -240,7 +240,7 @@
 		if (!chunkingStrategy || !embeddingVendor || !embeddingModel || !vectorDb) {
 			error = $_('knowledgeStores.createModal.advancedIncomplete', {
 				default:
-					'Some required fields are missing. Open the Advanced section to review chunking and embedding settings.'
+					'Some required fields are missing. Open the Vector indexing section to review chunking and embedding settings.'
 			});
 			advancedOpen = true;
 			return false;

--- a/frontend/svelte-app/src/lib/locales/ca.json
+++ b/frontend/svelte-app/src/lib/locales/ca.json
@@ -1430,7 +1430,9 @@
 				"nameTooLong": "El nom ha de tenir menys de 100 caràcters",
 				"shareLabel": "Compartir amb la meva organització",
 				"shareHint": "Ho pots canviar més tard des de la vista de detall de l'Emmagatzematge de Coneixement.",
-				"advancedLabel": "Avançat: fragmentació, proveïdor/model d'embeddings, base de dades vectorial"
+				"vectorIndexingLabel": "Indexació vectorial: fragmentació, proveïdor/model d'embeddings, base de dades vectorial",
+				"otherIndexingLabel": "Una altra estratègia d'indexació (properament)",
+				"otherIndexingHint": "En una versió futura es podran seleccionar aquí altres estratègies d'indexació (més enllà de la vectorial)."
 			}
 		}
 	},

--- a/frontend/svelte-app/src/lib/locales/en.json
+++ b/frontend/svelte-app/src/lib/locales/en.json
@@ -1233,15 +1233,15 @@
 		},
 		"addContentModal": {
 			"title": "Add Library Content to Knowledge Store",
-			"description": "Pick a library and the items to ingest. Only items with status \"ready\" can be ingested.",
+			"description": "Pick a library and the items to index. Only items with status \"ready\" can be indexed.",
 			"libraryLabel": "Library",
-			"itemsLabel": "Items to ingest",
+			"itemsLabel": "Items to index",
 			"selectAll": "Select all",
 			"deselectAll": "Deselect all",
 			"selected": "selected",
 			"noLibraries": "No libraries available. Create a library and import some content first.",
 			"noItems": "Select at least one item.",
-			"noItems2": "This library has no ready items to ingest.",
+			"noItems2": "This library has no ready items to index.",
 			"submit": "Add to Knowledge Store",
 			"submitting": "Adding..."
 		}
@@ -1330,7 +1330,7 @@
 				"noVendorConfigured": "Your organization has no embedding providers configured. Ask an admin to add an API key in the organization settings."
 			},
 			"step7": {
-				"title": "Pick items to ingest",
+				"title": "Pick items to index",
 				"description": "Choose which library items to index in the Knowledge Store.",
 				"allItems": "All items"
 			},
@@ -1339,8 +1339,8 @@
 				"description": "Review your choices below. Click Create to proceed.",
 				"libraryHeading": "Library",
 				"ksHeading": "Knowledge Store",
-				"itemsHeading": "Items to ingest",
-				"itemsToIngest": "Items to ingest",
+				"itemsHeading": "Items to index",
+				"itemsToIngest": "Items to index",
 				"submit": "Create",
 				"submitting": "Creating...",
 				"heading": "Review & create",

--- a/frontend/svelte-app/src/lib/locales/es.json
+++ b/frontend/svelte-app/src/lib/locales/es.json
@@ -1430,7 +1430,9 @@
 				"nameTooLong": "El nombre debe tener menos de 100 caracteres",
 				"shareLabel": "Compartir con mi organización",
 				"shareHint": "Puedes cambiarlo más tarde desde la vista de detalle del Almacén de Conocimiento.",
-				"advancedLabel": "Avanzado: fragmentación, proveedor/modelo de embeddings, base de datos vectorial"
+				"vectorIndexingLabel": "Indexación vectorial: fragmentación, proveedor/modelo de embeddings, base de datos vectorial",
+				"otherIndexingLabel": "Otra estrategia de indexación (próximamente)",
+				"otherIndexingHint": "En una versión futura se podrán seleccionar aquí otras estrategias de indexación (más allá de la vectorial)."
 			}
 		}
 	},

--- a/frontend/svelte-app/src/lib/locales/eu.json
+++ b/frontend/svelte-app/src/lib/locales/eu.json
@@ -1430,7 +1430,9 @@
 				"nameTooLong": "Izenak 100 karaktere baino gutxiago izan behar ditu",
 				"shareLabel": "Partekatu nire erakundearekin",
 				"shareHint": "Geroago alda dezakezu Knowledge Store xehetasun ikuspegitik.",
-				"advancedLabel": "Aurreratua: zatiketa, txertaketa hornitzaile/eredua, datu-base bektoriala"
+				"vectorIndexingLabel": "Bektore-indexazioa: zatiketa, txertaketa hornitzaile/eredua, datu-base bektoriala",
+				"otherIndexingLabel": "Beste indexazio-estrategia bat (laster)",
+				"otherIndexingHint": "Etorkizuneko bertsio batean, beste indexazio-estrategia batzuk (bektorialaz haratago) hemen hautatu ahal izango dira."
 			}
 		}
 	},


### PR DESCRIPTION
## Purpose
The "Create Knowledge Store" modal's collapsible panel is labeled **"Advanced: chunking, embedding, vector DB"**, which implicitly assumes **vector indexing** is the only way to index. We will add other indexing strategies in the future, so the UI should make clear that vector indexing is *one* strategy.

## Changes (purely presentational — no backend/API change)
- Renamed the panel label **"Advanced" → "Vector indexing"** (key `advancedLabel` → `vectorIndexingLabel`).
- Added a disabled **"Other indexing strategy (coming soon)"** placeholder `<details>` directly below it (with a hint), scaffolding a future, non-vector strategy.
- i18n: renamed the key and added `otherIndexingLabel` / `otherIndexingHint` in `es`/`ca`/`eu`; `en` uses the component's inline defaults (matching the existing pattern — `en.json` has no `knowledgeStores.createModal` block).

## Extensibility note (from a full review of the create-KS flow)
The modal is already **fully dynamic**: chunking strategies, embedding vendors, and vector-DB backends are fetched from `GET /knowledge-stores/options`, backed by the KB-server plugin registries (`ChunkingRegistry`/`EmbeddingRegistry`/`VectorDBRegistry`, auto-discovered at startup). So adding a new *vector* component is **backend-only and auto-surfaces** — no frontend change. A genuinely new *indexing paradigm* (non-vector) would need a new backend registry + an options field, at which point this placeholder is replaced with a real selector + config panel.

## Validation
- `CreateKnowledgeStoreModal.svelte` is prettier-clean and introduces **no new** `svelte-check` findings (pre-existing `<script>` warnings are untouched).
- All four locale JSONs parse; the diff is minimal (3 keys per locale, matching the section's existing indentation).
- No change to the create payload or validation logic, so the working create-KS flow is unaffected.

## Related
- Branched from `integration/kbserver-lamb-dev-main`.
