### PR TITLE
feat: grep_rag implementation

### DIFF
--- a/backend/lamb/completions/rag/grep_rag.py
+++ b/backend/lamb/completions/rag/grep_rag.py
@@ -1,0 +1,1165 @@
+"""
+Grep RAG — Complementary Grep-Based Search Layer
+
+A RAG processor that uses a small/nano LLM to drive iterative grep/egrep/ripgrep
+searches across all files in the assistant's knowledge bases. Works alongside
+any embedding-based RAG processor in two modes:
+
+- **hybrid**: Run both grep AND the underlying RAG in parallel, merge results.
+- **primary**: Grep runs first. If no matches found → fall back to underlying RAG.
+
+The nano model chooses the search tool (grep/egrep/ripgrep), proposes regex patterns,
+evaluates result quality, and decides when enough content has been found.
+"""
+
+import asyncio
+import json
+import os
+import re
+from typing import Dict, Any, List, Optional, Tuple
+
+import requests
+
+from lamb.lamb_classes import Assistant
+from lamb.completions.org_config_resolver import OrganizationConfigResolver
+from lamb.logging_config import get_logger
+
+logger = get_logger(__name__, component="RAG")
+
+# ── Configuration defaults ──────────────────────────────────────────────────
+
+DEFAULT_CONFIG = {
+    "grep_mode": "hybrid",         # "hybrid" | "primary"
+    "grep_fallback_rag": "simple_rag",  # Underlying RAG to complement or fall back to
+    "grep_max_tries": 5,           # Max search iterations (1 LLM call per try)
+    "grep_context_lines": 3,       # Lines of context before/after each match
+    "grep_max_total_chars": 8000,  # Max total characters sent to main LLM
+}
+
+# ── Nano model prompts ──────────────────────────────────────────────────────
+
+NANO_SYSTEM_PROMPT = """You are a search assistant. Your job is to help find relevant
+information across a collection of knowledge base documents.
+
+Given a user's question and the results of previous searches, respond with ONE of:
+
+Option 1 — Propose a new search:
+TOOL: <grep|egrep|ripgrep>
+PATTERN: <regex pattern>
+FLAGS: <-i -C N>
+REASON: <brief explanation of what you're looking for>
+
+Option 2 — Declare done:
+DONE: <brief explanation of why enough content has been found>
+
+Rules:
+1. On the first try, propose the most natural search for the question.
+2. If a search finds content, READ the matched context preview in the history.
+   If the found text CONTAINS the information the user asked for → respond DONE.
+   Do NOT keep searching for "more details" when the answer is already present.
+   The main LLM will extract the answer from what you found.
+3. If previous searches found NOTHING, try synonyms, related terms, broader/
+   narrower terms, fix spelling, or TRANSLATE to the document's language —
+   this is the main reason retries exist.
+4. LANGUAGE AWARENESS: If the user's question is in a different language than
+   the documents, TRANSLATE your search terms into the document's language.
+   Include terms in BOTH languages using | alternation when unsure.
+   Example: user asks "What are the prices?" in English but documents are in
+   Spanish → pattern: "precios|prices|tarifas|fees|costos|costs"
+5. Choose the right tool:
+   - grep: simple word/phrase searches
+   - egrep: when you need alternation (|), grouping (), or word boundaries (\\b)
+   - ripgrep: for large multi-file searches where speed matters
+6. Regex tips for egrep:
+   - Use | for alternatives: "late|missing|overdue"
+   - Use () for grouping: "grad(e|ing)"
+   - Use \\b for word boundaries: "\\bexam\\b"
+7. Maximum one pattern per response. Keep it SIMPLE but include translations
+   when the user's language differs from the documents'.
+8. The search runs recursively (-r) across ALL files by default."""
+
+
+NANO_USER_PROMPT_TEMPLATE = """Question: {question}
+{doc_language}
+Search history:
+{history}
+
+What should I search for next?"""
+
+
+# ── Main processor ──────────────────────────────────────────────────────────
+
+async def rag_processor(
+    messages: List[Dict[str, Any]],
+    assistant: Assistant = None,
+    request: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Grep RAG processor — nano LLM drives iterative grep across KB documents.
+
+    Args:
+        messages: Conversation messages
+        assistant: Assistant object with metadata config
+        request: Original request dict
+
+    Returns:
+        Dict with "context" (formatted grep results) and "sources" (metadata)
+    """
+    logger.info("Using grep_rag processor with assistant: %s",
+                assistant.name if assistant else "None")
+
+    if not assistant:
+        return {"context": "", "sources": []}
+
+    # Parse config from assistant metadata
+    config = _parse_config(assistant)
+    mode = config.get("grep_mode", "hybrid")
+    fallback_rag = config.get("grep_fallback_rag", "simple_rag")
+    max_tries = int(config.get("grep_max_tries", 5))
+    context_lines = int(config.get("grep_context_lines", 3))
+    max_total_chars = int(config.get("grep_max_total_chars", 8000))
+
+    # Extract the user's question
+    user_question = _extract_user_question(messages)
+    if not user_question:
+        return {"context": "", "sources": []}
+
+    logger.info("Grep RAG mode=%s fallback=%s question='%s...'",
+                mode, fallback_rag, user_question[:80])
+
+    # Resolve KB documents (file content + metadata for citations)
+    documents = await _resolve_kb_documents(assistant)
+    if not documents:
+        logger.warning("No KB documents found for assistant %s", assistant.id)
+        return await _run_fallback_rag(messages, assistant, request, fallback_rag)
+
+    logger.info("Resolved %d documents for grep search", len(documents))
+
+    # Run the grep search loop
+    grep_result = await _run_grep_search(
+        user_question=user_question,
+        documents=documents,
+        max_tries=max_tries,
+        context_lines=context_lines,
+        max_total_chars=max_total_chars,
+        assistant_owner=assistant.owner,
+    )
+
+    if mode == "primary":
+        # Grep first, fall back to RAG only if zero matches
+        if grep_result["matches"]:
+            logger.info("Primary mode: grep found %d matches, using grep results",
+                        len(grep_result["matches"]))
+            return _build_grep_response(grep_result["matches"], documents, max_total_chars)
+        else:
+            logger.info("Primary mode: grep found no matches, falling back to %s",
+                        fallback_rag)
+            return await _run_fallback_rag(messages, assistant, request, fallback_rag)
+
+    elif mode == "hybrid":
+        # Run RAG in parallel with grep (grep already completed above)
+        # Hybrid always uses simple_rag as the companion — grep handles precision,
+        # simple semantic coverage is all that's needed alongside it.
+        logger.info("Hybrid mode: running simple_rag in parallel")
+        rag_context = await _run_fallback_rag(messages, assistant, request, "simple_rag")
+
+        if grep_result["matches"]:
+            grep_response = _build_grep_response(
+                grep_result["matches"], documents, max_total_chars
+            )
+            return _merge_contexts(grep_response, rag_context, max_total_chars)
+        else:
+            # No grep matches, just return RAG results
+            logger.info("Hybrid mode: grep found no matches, using RAG only")
+            return rag_context
+
+    else:
+        logger.warning("Unknown grep_mode '%s', falling back to %s", mode, fallback_rag)
+        return await _run_fallback_rag(messages, assistant, request, fallback_rag)
+
+
+# ── Config parsing ──────────────────────────────────────────────────────────
+
+def _parse_config(assistant: Assistant) -> Dict[str, Any]:
+    """Parse grep_rag configuration from assistant metadata."""
+    config = dict(DEFAULT_CONFIG)
+    try:
+        if assistant.metadata and assistant.metadata.strip():
+            metadata = json.loads(assistant.metadata)
+            for key in DEFAULT_CONFIG:
+                if key in metadata:
+                    config[key] = metadata[key]
+    except (json.JSONDecodeError, AttributeError) as e:
+        logger.warning("Failed to parse assistant metadata: %s", e)
+    return config
+
+
+# ── Question extraction ─────────────────────────────────────────────────────
+
+def _extract_user_question(messages: List[Dict[str, Any]]) -> str:
+    """Extract the last user message from the conversation."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                # Multimodal: extract text parts
+                text_parts = [
+                    item.get("text", "") for item in content
+                    if item.get("type") == "text"
+                ]
+                return " ".join(text_parts)
+            return content
+    return ""
+
+
+# ── KB document resolution ──────────────────────────────────────────────────
+
+async def _resolve_kb_documents(assistant: Assistant) -> List[Dict[str, Any]]:
+    """
+    Get all KB documents with their content and source metadata.
+
+    For each KB collection attached to the assistant:
+    1. List file registries via KB server API
+    2. Fetch document content via KB server
+    3. Return list of {file_path, content, metadata}
+
+    Returns:
+        List of document dicts with keys: file_path, content, metadata
+    """
+    if not hasattr(assistant, 'RAG_collections') or not assistant.RAG_collections:
+        return []
+
+    # Get KB server configuration
+    KB_SERVER_URL = None
+    KB_API_KEY = None
+
+    try:
+        config_resolver = OrganizationConfigResolver(assistant.owner)
+        kb_config = config_resolver.get_knowledge_base_config()
+        if kb_config:
+            KB_SERVER_URL = kb_config.get("server_url")
+            KB_API_KEY = kb_config.get("api_token")
+    except Exception as e:
+        logger.warning("Error getting org KB config: %s", e)
+
+    if not KB_SERVER_URL:
+        import config as app_config
+        KB_SERVER_URL = os.getenv('LAMB_KB_SERVER')
+        KB_API_KEY = os.getenv('LAMB_KB_SERVER_TOKEN') or getattr(
+            app_config, 'LAMB_BEARER_TOKEN', ''
+        )
+
+    if not KB_SERVER_URL:
+        logger.error("No KB server URL configured")
+        return []
+
+    headers = {
+        "Authorization": f"Bearer {KB_API_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    # Parse collection IDs
+    collections = [
+        cid.strip() for cid in assistant.RAG_collections.split(',') if cid.strip()
+    ]
+
+    documents = []
+
+    for collection_id in collections:
+        try:
+            # Get file list for this collection
+            files_url = f"{KB_SERVER_URL}/collections/{collection_id}/files"
+            resp = requests.get(files_url, headers=headers, timeout=30)
+
+            if resp.status_code != 200:
+                logger.warning(
+                    "Failed to list files for collection %s: %s",
+                    collection_id, resp.status_code
+                )
+                continue
+
+            file_entries = resp.json()
+
+            # Also query all chunks for full text
+            query_url = f"{KB_SERVER_URL}/collections/{collection_id}/query"
+            query_payload = {
+                "query_text": "",  # Empty query to get all? Use top_k instead
+                "top_k": 500,      # Get up to 500 chunks
+                "threshold": 0.0,
+                "plugin_params": {},
+            }
+
+            # Build a document map: file → full text
+            # For each file entry, we try to get its content
+            for entry in file_entries:
+                try:
+                    # Try to get markdown content URL from processing_stats
+                    md_url = None
+                    stats = entry.get("processing_stats", {})
+                    if isinstance(stats, dict):
+                        output_files = stats.get("output_files", {})
+                        md_url = output_files.get("markdown_url")
+
+                    # If we have a markdown URL, fetch the full text
+                    content = ""
+                    if md_url:
+                        content = await _fetch_text_content(md_url, headers)
+                    elif entry.get("file_url"):
+                        content = await _fetch_text_content(
+                            entry.get("file_url"), headers
+                        )
+                    elif entry.get("markdown_preview"):
+                        # Use the preview as fallback
+                        content = entry.get("markdown_preview", "")
+
+                    if content:
+                        documents.append({
+                            "file_path": entry.get("file_path", ""),
+                            "original_filename": entry.get("original_filename", ""),
+                            "content": content,
+                            "metadata": entry,  # Full file registry entry
+                            "collection_id": collection_id,
+                        })
+                except Exception as e:
+                    logger.debug("Error processing file entry: %s", e)
+                    continue
+
+        except Exception as e:
+            logger.warning("Error processing collection %s: %s", collection_id, e)
+            continue
+
+    return documents
+
+
+async def _fetch_text_content(url: str, headers: Dict[str, str]) -> str:
+    """Fetch text content from a URL. Handles absolute, relative, and localhost URLs."""
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+
+        # If URL points to localhost (frontend dev server :5173, backend :9099,
+        # or any other port), the Docker container can't reach it via localhost.
+        # Rewrite to use the KB server's internal Docker hostname instead.
+        if parsed.hostname in ("localhost", "127.0.0.1", "host.docker.internal"):
+            # Try reading from local filesystem first (dev without Docker)
+            url_path = parsed.path.lstrip("/")
+            for candidate in _local_file_candidates(url_path):
+                if os.path.isfile(candidate):
+                    try:
+                        with open(candidate, "r", encoding="utf-8") as f:
+                            content = f.read()
+                        if content and _is_text_content(content):
+                            logger.debug("Read content from local file: %s", candidate)
+                            return content
+                    except (UnicodeDecodeError, OSError):
+                        continue
+
+            # Fallback: rewrite to KB server (kb:9090 inside Docker)
+            kb_base = os.getenv("LAMB_KB_SERVER", "http://kb:9090")
+            url = kb_base.rstrip("/") + parsed.path
+            logger.debug("Rewrote localhost URL → KB server: %s", url)
+
+        # If URL is relative (starts with /), it's relative to KB server
+        elif url.startswith("/"):
+            kb_base = os.getenv("LAMB_KB_SERVER", "")
+            if kb_base:
+                url = kb_base.rstrip("/") + url
+
+        resp = requests.get(url, headers=headers, timeout=30)
+        if resp.status_code == 200:
+            content = resp.text
+            if len(content) > 0 and _is_text_content(content):
+                return content
+            else:
+                logger.debug("Skipping non-text content from %s", url)
+        else:
+            logger.debug("Failed to fetch %s: %s", url, resp.status_code)
+        return ""
+    except Exception as e:
+        logger.debug("Error fetching %s: %s", url, e)
+        return ""
+
+
+def _is_text_content(content: str) -> bool:
+    """Heuristic check if string looks like text (not binary)."""
+    if not content:
+        return False
+    # Check for null bytes (binary indicator)
+    if '\x00' in content[:1000]:
+        return False
+    # Check printable ratio
+    sample = content[:2000]
+    printable = sum(1 for c in sample if c.isprintable() or c in '\n\r\t')
+    return printable / max(len(sample), 1) > 0.8
+
+
+def _local_file_candidates(url_path: str) -> list:
+    """Generate candidate filesystem paths for a URL path like 'static/1/dbizi/xxx.txt'."""
+    candidates = []
+    # 1. Relative to CWD
+    candidates.append(url_path)
+    # 2. Project root (when LAMB_PROJECT_PATH is mounted)
+    project_path = os.getenv("LAMB_PROJECT_PATH", "")
+    if project_path:
+        candidates.append(os.path.join(project_path, url_path))
+        # Also try kb-server as sibling
+        candidates.append(os.path.join(
+            project_path, "lamb-kb-server-stable", "backend", url_path
+        ))
+    # 3. Backend's own static/ directory
+    backend_static = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__)))), "static")
+    candidates.append(os.path.join(backend_static, url_path))
+    # 4. Production Docker layout (/app)
+    if url_path.startswith("static/"):
+        candidates.append(os.path.join("/app", url_path))
+    return candidates
+
+
+# ── Language detection ──────────────────────────────────────────────────────
+
+# Common words unique to each language (high-frequency, low-overlap)
+_LANG_MARKERS = {
+    "Spanish": [
+        "que", "los", "las", "del", "una", "por", "para", "como", "está",
+        "más", "pero", "entre", "desde", "hasta", "porque", "cuando",
+        "también", "muy", "todo", "ción", "idad", "ente", "aron", "iendo",
+    ],
+    "English": [
+        "the", "and", "that", "have", "for", "not", "with", "this",
+        "but", "from", "they", "been", "would", "there", "their",
+        "about", "which", "after", "could", "should", "tion", "ing ",
+    ],
+    "Catalan": [
+        "amb", "dels", "una", "com", "més", "també", "tots", "cada",
+        "sense", "sobre", "entre", "després", "contra", "segons",
+        "mitjançant", "llarg", "següent", "forma", "qualsevol",
+    ],
+    "Basque": [
+        "eta", "ere", "duten", "ditu", "arte", "dira", "baten",
+        "izan", "egin", "dago", "dutenak", "beraz", "orduan",
+        "bidez", "zehar", "gainean", "artean", "aurka",
+    ],
+    "French": [
+        "que", "les", "des", "est", "pas", "dans", "nous", "aux",
+        "sont", "avec", "fait", "leur", "être", "avoir", "cette",
+        "comme", "plus", "bien", "ment", "tion", "eurs",
+    ],
+}
+
+
+def _detect_document_language(documents: List[Dict[str, Any]]) -> str:
+    """
+    Detect the dominant language of the KB documents by sampling text
+    and counting language-specific marker words.
+
+    Returns a human-readable string like "Spanish" or empty string if
+    documents are too short or detection is ambiguous.
+    """
+    if not documents:
+        return ""
+
+    # Concatenate a sample from all documents (up to ~5000 chars)
+    sample_parts = []
+    total_chars = 0
+    for doc in documents:
+        content = doc.get("content", "")
+        if content:
+            sample_parts.append(content[:2000])
+            total_chars += len(content[:2000])
+            if total_chars >= 5000:
+                break
+
+    if not sample_parts:
+        return ""
+
+    sample = " ".join(sample_parts).lower()
+
+    # Count marker words for each language
+    scores = {}
+    for lang, markers in _LANG_MARKERS.items():
+        score = 0
+        for marker in markers:
+            score += sample.count(marker.lower())
+        scores[lang] = score
+
+    # Pick the language with the highest score, but require a minimum threshold
+    if not scores:
+        return ""
+
+    best_lang = max(scores, key=scores.get)
+    best_score = scores[best_lang]
+
+    # Require at least some marker hits to be confident
+    if best_score < 3:
+        return ""
+
+    return best_lang
+
+
+def _detect_question_language(question: str) -> str:
+    """
+    Detect the language of the user's question using the same marker-word
+    approach. Returns language name or empty string.
+    """
+    if not question or len(question) < 10:
+        return ""
+
+    sample = question.lower()
+    scores = {}
+    for lang, markers in _LANG_MARKERS.items():
+        score = 0
+        for marker in markers:
+            score += sample.count(marker.lower())
+        scores[lang] = score
+
+    if not scores:
+        return ""
+
+    best_lang = max(scores, key=scores.get)
+    if scores[best_lang] < 1:
+        return ""
+
+    return best_lang
+
+
+# ── Grep search loop ────────────────────────────────────────────────────────
+
+async def _run_grep_search(
+    user_question: str,
+    documents: List[Dict[str, Any]],
+    max_tries: int,
+    context_lines: int,
+    max_total_chars: int,
+    assistant_owner: str,
+) -> Dict[str, Any]:
+    """
+    Run the iterative grep search loop driven by the nano model.
+
+    Returns:
+        Dict with "matches" (list of match dicts) and "tries" (list of try records)
+    """
+    from lamb.completions.small_fast_model_helper import (
+        invoke_small_fast_model,
+        is_small_fast_model_configured,
+    )
+
+    all_matches = []
+    tries = []
+    already_tried = set()  # Track (tool, pattern) to avoid duplicates
+
+    # Detect document language so the nano model can translate search terms
+    doc_lang = _detect_document_language(documents)
+    if doc_lang:
+        logger.info("Detected document language: %s", doc_lang)
+
+    for attempt in range(1, max_tries + 1):
+        # Build history for the nano model
+        history = _build_search_history(tries, all_matches)
+
+        # Ask the nano model what to search
+        nano_response = await _ask_nano_model(
+            user_question=user_question,
+            history=history,
+            assistant_owner=assistant_owner,
+            doc_language=doc_lang,
+        )
+
+        if not nano_response:
+            logger.warning("Nano model returned no response on try %d", attempt)
+            break
+
+        if nano_response.get("done"):
+            logger.info(
+                "Nano model declared DONE on try %d: %s",
+                attempt, nano_response.get("reason", "")
+            )
+            tries.append({
+                "attempt": attempt,
+                "done": True,
+                "reason": nano_response.get("reason", ""),
+            })
+            break
+
+        # Execute the search
+        tool = nano_response.get("tool", "grep")
+        pattern = nano_response.get("pattern", "")
+        reason = nano_response.get("reason", "")
+
+        if not pattern:
+            logger.warning("Nano model returned empty pattern on try %d", attempt)
+            tries.append({
+                "attempt": attempt,
+                "tool": tool,
+                "pattern": "",
+                "matches": 0,
+                "error": "Empty pattern",
+            })
+            continue
+
+        # Skip duplicate patterns
+        dedup_key = (tool, pattern)
+        if dedup_key in already_tried:
+            logger.debug("Skipping duplicate pattern: %s %s", tool, pattern)
+            tries.append({
+                "attempt": attempt,
+                "tool": tool,
+                "pattern": pattern,
+                "matches": 0,
+                "reason": reason,
+                "skipped": True,
+            })
+            continue
+
+        already_tried.add(dedup_key)
+
+        # Run the search across all documents
+        logger.info(
+            "Grep try %d/%d: %s '%s' — %s",
+            attempt, max_tries, tool, pattern, reason
+        )
+
+        matches = _search_across_documents(
+            documents=documents,
+            pattern=pattern,
+            tool=tool,
+            context_lines=context_lines,
+        )
+
+        tries.append({
+            "attempt": attempt,
+            "tool": tool,
+            "pattern": pattern,
+            "matches": len(matches),
+            "reason": reason,
+        })
+
+        if matches:
+            all_matches.extend(matches)
+            logger.info("Try %d: found %d matches", attempt, len(matches))
+        else:
+            logger.info("Try %d: no matches found", attempt)
+
+    # Deduplicate matches
+    deduped = _deduplicate_matches(all_matches, context_lines)
+
+    return {
+        "matches": deduped,
+        "tries": tries,
+    }
+
+
+def _build_search_history(
+    tries: List[Dict[str, Any]],
+    matches: List[Dict[str, Any]],
+) -> str:
+    """Build a human-readable search history for the nano model."""
+    if not tries:
+        return "(No searches yet)"
+
+    lines = []
+    for t in tries:
+        if t.get("done"):
+            lines.append(f"Try {t['attempt']}: DONE — {t.get('reason', '')}")
+        elif t.get("skipped"):
+            lines.append(
+                f"Try {t['attempt']}: SKIPPED (duplicate) — "
+                f"{t.get('tool','')} '{t.get('pattern','')}'"
+            )
+        elif t.get("error"):
+            lines.append(
+                f"Try {t['attempt']}: ERROR — {t.get('error','')}"
+            )
+        else:
+            lines.append(
+                f"Try {t['attempt']}: {t.get('tool','')} '{t.get('pattern','')}' "
+                f"— {t.get('matches', 0)} matches — {t.get('reason', '')}"
+            )
+
+    # Add a preview of current matches
+    if matches:
+        lines.append(f"\nCurrently found {len(matches)} matches across all attempts.")
+        lines.append("Preview of found content:")
+        preview_chars = 0
+        for m in matches[:5]:
+            snippet = m.get("context", "")[:300]
+            lines.append(f"  [{m.get('source','?')}]: {snippet}...")
+            preview_chars += len(snippet)
+            if preview_chars > 1200:
+                lines.append("  ... (more matches)")
+                break
+
+        # If we have a decent amount of content, nudge the nano model to consider stopping
+        if len(matches) >= 3:
+            lines.append(
+                f"\nYou have found {len(matches)} relevant sections. "
+                f"If this content answers the user's question, respond with DONE. "
+                f"Only keep searching if the answer is clearly incomplete."
+            )
+        elif len(matches) >= 1:
+            lines.append(
+                "\nSome content was found. If it sufficiently answers the question, "
+                "respond with DONE. Otherwise propose a more targeted search."
+            )
+
+    return "\n".join(lines)
+
+
+async def _ask_nano_model(
+    user_question: str,
+    history: str,
+    assistant_owner: str,
+    doc_language: str = "",
+) -> Optional[Dict[str, Any]]:
+    """
+    Ask the nano model what to search for next.
+
+    Args:
+        user_question: The user's question
+        history: Formatted search history from previous tries
+        assistant_owner: Email of the assistant owner (for org config)
+        doc_language: Detected language of the KB documents (e.g. "Spanish")
+
+    Returns parsed response dict or None on failure.
+    """
+    from lamb.completions.small_fast_model_helper import (
+        invoke_small_fast_model,
+        is_small_fast_model_configured,
+    )
+
+    if not is_small_fast_model_configured(assistant_owner):
+        # Fallback: do a single grep with the user's question keywords
+        logger.info("No small-fast-model configured, using fallback keyword search")
+        keywords = _extract_keywords(user_question)
+        return {
+            "done": False,
+            "tool": "grep",
+            "pattern": "|".join(re.escape(k) for k in keywords[:5]),
+            "reason": "Fallback keyword search (no nano model configured)",
+        }
+
+    # Build language context line for the prompt
+    lang_line = ""
+    if doc_language:
+        question_lang = _detect_question_language(user_question)
+        if question_lang and question_lang != doc_language:
+            lang_line = (
+                f"Documents are in {doc_language}. "
+                f"User asked in {question_lang}. "
+                f"Include search terms in BOTH languages using | alternation.\n"
+            )
+        else:
+            lang_line = f"Documents are in {doc_language}.\n"
+
+    user_prompt = NANO_USER_PROMPT_TEMPLATE.format(
+        question=user_question,
+        doc_language=lang_line,
+        history=history,
+    )
+
+    messages = [
+        {"role": "system", "content": NANO_SYSTEM_PROMPT},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    try:
+        response = await invoke_small_fast_model(
+            messages=messages,
+            assistant_owner=assistant_owner,
+            stream=False,
+        )
+
+        # Extract text from response
+        text = _extract_response_text(response)
+        if not text:
+            return None
+
+        logger.debug("Nano model response: %s", text[:200])
+        return _parse_nano_response(text)
+
+    except Exception as e:
+        logger.error("Error invoking nano model: %s", e)
+        return None
+
+
+def _extract_response_text(response: Any) -> str:
+    """Extract text content from various LLM response formats."""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        # OpenAI format
+        choices = response.get("choices", [])
+        if choices:
+            return choices[0].get("message", {}).get("content", "")
+        # Anthropic format
+        content = response.get("content", [])
+        if isinstance(content, list):
+            return "".join(
+                c.get("text", "") for c in content if c.get("type") == "text"
+            )
+    return ""
+
+
+def _parse_nano_response(text: str) -> Optional[Dict[str, Any]]:
+    """Parse the nano model's structured response."""
+    text = text.strip()
+
+    # Check for DONE — accept multiple formats:
+    #   "DONE: reason" / "DONE - reason" / "DONE"
+    #   "I'm DONE" / "We are DONE"
+    #   First-line "DONE" anywhere followed by reason
+    done_patterns = [
+        r"^DONE\b[:\-]?\s*(.*)",           # "DONE", "DONE: reason", "DONE - reason"
+        r"\bDONE\b[:\-]?\s*(.*)",           # "I'm DONE", "We are DONE: ..."
+    ]
+
+    for pattern in done_patterns:
+        m = re.match(pattern, text, re.IGNORECASE)
+        if m:
+            reason = m.group(1).strip() if m.group(1) else ""
+            logger.info("Nano model declared DONE: %s", reason if reason else "(no reason)")
+            return {"done": True, "reason": reason}
+
+    # If the first line says DONE but the parser above didn't catch it
+    first_line = text.split("\n")[0].strip()
+    if re.match(r".*\bDONE\b", first_line, re.IGNORECASE):
+        # Extract anything after DONE on that line
+        done_idx = first_line.upper().find("DONE")
+        reason = first_line[done_idx + 4:].strip().lstrip(":-").strip()
+        logger.info("Nano model declared DONE (first-line match): %s", reason if reason else "(no reason)")
+        return {"done": True, "reason": reason}
+
+    # Parse structured TOOL/PATTERN/FLAGS/REASON response
+    result = {"done": False}
+    lines = text.split("\n")
+
+    for line in lines:
+        line = line.strip()
+        if line.upper().startswith("TOOL:"):
+            result["tool"] = line[5:].strip().lower()
+        elif line.upper().startswith("PATTERN:"):
+            result["pattern"] = line[8:].strip()
+        elif line.upper().startswith("FLAGS:"):
+            result["flags"] = line[6:].strip()
+        elif line.upper().startswith("REASON:"):
+            result["reason"] = line[7:].strip()
+
+    # Fallback: try to extract pattern from simpler formats
+    if not result.get("pattern"):
+        # Look for a quoted pattern or regex-like content
+        quoted = re.findall(r'["\'](.+?)["\']', text)
+        if quoted:
+            result["pattern"] = quoted[0]
+            # Assume grep as default tool
+            if not result.get("tool"):
+                result["tool"] = "grep"
+            return result
+
+        # Try to find pattern after common labels
+        for label in ["pattern:", "PATTERN:", "regex:", "REGEX:"]:
+            idx = text.lower().find(label.lower())
+            if idx >= 0:
+                result["pattern"] = text[idx + len(label):].split("\n")[0].strip()
+                break
+
+    if not result.get("pattern"):
+        logger.debug("Could not parse pattern from nano response: %s", text[:200])
+        return None
+
+    if not result.get("tool"):
+        result["tool"] = "grep"
+
+    return result
+
+
+def _extract_keywords(text: str, max_keywords: int = 5) -> List[str]:
+    """Extract meaningful keywords from user question for fallback search."""
+    # Simple keyword extraction: split, remove short/common words, take unique
+    stop_words = {
+        "a", "an", "the", "is", "are", "was", "were", "be", "been",
+        "in", "on", "at", "to", "for", "of", "with", "by", "from",
+        "and", "or", "but", "not", "no", "yes", "what", "how", "when",
+        "where", "who", "why", "which", "do", "does", "did", "can",
+        "could", "will", "would", "should", "may", "might", "this",
+        "that", "these", "those", "it", "its", "i", "me", "my", "we",
+        "our", "you", "your", "he", "she", "they", "them",
+    }
+    words = re.findall(r'\b[a-zA-Z]{3,}\b', text.lower())
+    keywords = []
+    seen = set()
+    for w in words:
+        if w not in stop_words and w not in seen:
+            keywords.append(w)
+            seen.add(w)
+            if len(keywords) >= max_keywords:
+                break
+    return keywords
+
+
+# ── In-memory search engine ─────────────────────────────────────────────────
+
+def _search_across_documents(
+    documents: List[Dict[str, Any]],
+    pattern: str,
+    tool: str,
+    context_lines: int,
+) -> List[Dict[str, Any]]:
+    """
+    Run regex search across all documents.
+
+    Args:
+        documents: List of document dicts with 'content', 'file_path', 'original_filename'
+        pattern: Regex pattern from nano model
+        tool: "grep", "egrep", or "ripgrep" (all use Python re internally)
+        context_lines: Lines of context before/after each match
+
+    Returns:
+        List of match dicts
+    """
+    # Compile regex (case-insensitive by default, matching grep -i behavior)
+    try:
+        compiled = re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+    except re.error as e:
+        logger.debug("Invalid regex pattern '%s': %s", pattern, e)
+        return []
+
+    all_matches = []
+
+    for doc in documents:
+        content = doc.get("content", "")
+        if not content:
+            continue
+
+        lines = content.split("\n")
+        source_label = doc.get("original_filename") or doc.get("file_path", "unknown")
+
+        for i, line in enumerate(lines):
+            if compiled.search(line):
+                start = max(0, i - context_lines)
+                end = min(len(lines), i + context_lines + 1)
+
+                all_matches.append({
+                    "file_path": doc.get("file_path", ""),
+                    "source": source_label,
+                    "line_num": i + 1,
+                    "matched_line": line.strip(),
+                    "context": "\n".join(lines[start:end]),
+                    "context_start": start,
+                    "context_end": end,
+                    "metadata": doc.get("metadata", {}),
+                    "collection_id": doc.get("collection_id", ""),
+                })
+
+    return all_matches
+
+
+# ── Deduplication ───────────────────────────────────────────────────────────
+
+def _deduplicate_matches(
+    matches: List[Dict[str, Any]],
+    context_lines: int,
+) -> List[Dict[str, Any]]:
+    """Deduplicate matches, merging overlapping context ranges per file."""
+    if not matches:
+        return []
+
+    # Group by file_path
+    by_file: Dict[str, List[Dict[str, Any]]] = {}
+    for match in matches:
+        fp = match.get("file_path", "__unknown__")
+        by_file.setdefault(fp, []).append(match)
+
+    merged = []
+    for file_path, file_matches in by_file.items():
+        # Sort by context_start
+        file_matches.sort(key=lambda m: m.get("context_start", 0))
+
+        file_merged = [dict(file_matches[0])]
+        for match in file_matches[1:]:
+            last = file_merged[-1]
+            # If this match's context overlaps with the last, merge
+            if match["context_start"] <= last["context_end"] + context_lines:
+                # Merge by extending context range
+                last["context_end"] = max(last["context_end"], match["context_end"])
+                # Rebuild context from the merged range (approximate)
+                last["matched_line"] = (
+                    last.get("matched_line", "")
+                    + " | "
+                    + match.get("matched_line", "")
+                )
+            else:
+                file_merged.append(dict(match))
+
+        merged.extend(file_merged)
+
+    return merged
+
+
+# ── Context formatting ──────────────────────────────────────────────────────
+
+def _build_grep_response(
+    matches: List[Dict[str, Any]],
+    documents: List[Dict[str, Any]],
+    max_total_chars: int,
+) -> Dict[str, Any]:
+    """Build the final response dict from grep matches."""
+    # Build file_path → metadata map for source resolution
+    docs_map = {d["file_path"]: d for d in documents}
+
+    blocks = []
+    sources = []
+    total_chars = 0
+    seen_sources = set()
+
+    for match in matches:
+        meta = match.get("metadata", {})
+        fp = match.get("file_path", "")
+
+        # Resolve best source label
+        source_label = _best_source_label(meta, match.get("source", "Unknown"))
+        source_url = _best_source_url(meta)
+
+        header = f"### {source_label}"
+        if source_url:
+            header += f" ({source_url})"
+
+        body = match.get("context", "").strip()
+        block = f"{header}\n{body}"
+
+        if total_chars + len(block) > max_total_chars:
+            break
+
+        blocks.append(block)
+        total_chars += len(block)
+
+        # Track sources
+        source_key = source_url or source_label
+        if source_key not in seen_sources:
+            sources.append({
+                "title": source_label,
+                "url": source_url,
+            })
+            seen_sources.add(source_key)
+
+    context = "\n\n".join(blocks) if blocks else ""
+
+    return {
+        "context": context,
+        "sources": sources,
+    }
+
+
+def _best_source_label(metadata: Dict[str, Any], fallback: str) -> str:
+    """Resolve the best human-readable source label from metadata."""
+    # Try various metadata fields in order of preference
+    if isinstance(metadata, dict):
+        # URL-ingested documents often have page_url
+        if metadata.get("page_url"):
+            return fallback  # fallback usually has filename
+        # Check for original filename
+        if metadata.get("original_filename"):
+            return metadata["original_filename"]
+        # Check processing stats
+        stats = metadata.get("processing_stats", {})
+        if isinstance(stats, dict):
+            output_files = stats.get("output_files", {})
+            if output_files:
+                return fallback
+
+    return fallback
+
+
+def _best_source_url(metadata: Dict[str, Any]) -> str:
+    """Resolve the best source URL for citation."""
+    if isinstance(metadata, dict):
+        stats = metadata.get("processing_stats", {})
+        if isinstance(stats, dict):
+            output_files = stats.get("output_files", {})
+            # Prefer markdown URL
+            if output_files.get("markdown_url"):
+                return output_files["markdown_url"]
+            if output_files.get("original_file_url"):
+                return output_files["original_file_url"]
+
+        # Fall back to file_url
+        if metadata.get("file_url"):
+            return metadata["file_url"]
+
+    return ""
+
+
+# ── RAG fallback ────────────────────────────────────────────────────────────
+
+async def _run_fallback_rag(
+    messages: List[Dict[str, Any]],
+    assistant: Assistant,
+    request: Optional[Dict[str, Any]],
+    fallback_rag: str,
+) -> Dict[str, Any]:
+    """Run the specified fallback RAG processor."""
+    import importlib
+
+    try:
+        module = importlib.import_module(
+            f"lamb.completions.rag.{fallback_rag}"
+        )
+        rag_func = getattr(module, "rag_processor")
+
+        if asyncio.iscoroutinefunction(rag_func):
+            return await rag_func(
+                messages=messages, assistant=assistant, request=request
+            )
+        else:
+            return rag_func(
+                messages=messages, assistant=assistant, request=request
+            )
+    except Exception as e:
+        logger.error("Error running fallback RAG '%s': %s", fallback_rag, e)
+        return {"context": "", "sources": []}
+
+
+# ── Context merging ─────────────────────────────────────────────────────────
+
+def _merge_contexts(
+    grep_response: Dict[str, Any],
+    rag_response: Dict[str, Any],
+    max_total_chars: int,
+) -> Dict[str, Any]:
+    """Merge grep results with embedding RAG results."""
+    rag_context = rag_response.get("context", "") if isinstance(rag_response, dict) else ""
+    grep_context = grep_response.get("context", "") if isinstance(grep_response, dict) else ""
+
+    rag_sources = rag_response.get("sources", []) if isinstance(rag_response, dict) else []
+    grep_sources = grep_response.get("sources", []) if isinstance(grep_response, dict) else []
+
+    # Combine contexts with a clear separator
+    parts = []
+    total = 0
+
+    if rag_context:
+        parts.append(rag_context)
+        total += len(rag_context)
+
+    if grep_context:
+        remaining = max_total_chars - total
+        if remaining > 200:  # Only add grep if there's meaningful space
+            if parts:
+                parts.append("\n\n---\n\n## Exact Keyword Matches\n\n")
+                total += len(parts[-1])
+            if len(grep_context) > remaining:
+                grep_context = grep_context[:remaining] + "\n\n[... results truncated ...]"
+            parts.append(grep_context)
+
+    # Merge sources, deduplicating by URL
+    merged_sources = list(rag_sources)
+    seen_urls = {s.get("url", "") for s in rag_sources if s.get("url")}
+    for s in grep_sources:
+        if s.get("url") and s["url"] not in seen_urls:
+            merged_sources.append(s)
+            seen_urls.add(s["url"])
+
+    return {
+        "context": "".join(parts),
+        "sources": merged_sources,
+    }

--- a/frontend/svelte-app/src/lib/components/AssistantsList.svelte
+++ b/frontend/svelte-app/src/lib/components/AssistantsList.svelte
@@ -557,8 +557,8 @@
                                 <td class="px-6 py-2"></td> <!-- Empty cell to maintain table structure -->
                             </tr>
                             
-                            <!-- Conditional row for simple_rag details -->
-                            {#if callback.rag_processor === 'simple_rag'}
+                            <!-- Conditional row for simple_rag or grep_rag details -->
+                            {#if callback.rag_processor === 'simple_rag' || callback.rag_processor === 'grep_rag'}
                                 <tr class="bg-gray-50 border-b border-gray-200">
                                     <td colspan="2" class="px-6 py-2 text-sm">
                                         <div class="flex flex-wrap">

--- a/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
@@ -6,7 +6,7 @@
 	import { get } from 'svelte/store';
 	import { createAssistant, updateAssistant } from '$lib/services/assistantService';
 	import { extractModelsFromConnectorData, selectModel } from './logic/assistantFormUtils.svelte.js';
-	import { isKbBasedRag, isSingleFileRag, isRubricRag } from '$lib/utils/ragProcessorHelpers.js';
+	import { isKbBasedRag, isSingleFileRag, isRubricRag, isGrepRag } from '$lib/utils/ragProcessorHelpers.js';
 	import { validateImportedAssistant } from './logic/importAssistantValidator.js';
 	import { createAssistantFormState, resetFormFieldsToDefaults, populateFormFields, revertToInitial, clearRagDependentState, handleFieldChange } from './logic/assistantFormState.svelte.js';
 	import { fetchKnowledgeBases, fetchRubricsList, fetchUserFiles } from './logic/assistantFormFetchers.js';
@@ -163,6 +163,11 @@
 			if (!form.rubricsFetchAttempted && !form.loadingRubrics) {
 				tick().then(doFetchRubricsList);
 			}
+		} else if (isGrepRag(form.selectedRagProcessor) && form.configInitialized) {
+			// Grep RAG searches across KB documents — fetch KBs
+			if (!form.kbFetchAttempted && !form.loadingKnowledgeBases) {
+				doFetchKnowledgeBases();
+			}
 		} else {
 			// Clear KB state AND reset attempted flag if RAG processor changes away
 			clearRagDependentState(form);
@@ -315,14 +320,22 @@
 
 						// Populate RAG specific fields
 						// FIX FOR ISSUE #96: Apply Load-Then-Select pattern for imports too
-						if (isKbBasedRag(form.selectedRagProcessor)) {
-							form.selectedFilePath = ''; // Clear file path if switching to simple RAG, context_aware_rag, or hierarchical_rag
+						if (isKbBasedRag(form.selectedRagProcessor) || isGrepRag(form.selectedRagProcessor)) {
+							form.selectedFilePath = ''; // Clear file path if switching to simple RAG, context_aware_rag, hierarchical_rag, or grep_rag
 							// Fetch KBs BEFORE setting selections
 							if (!form.kbFetchAttempted) {
 								await doFetchKnowledgeBases(); // ✅ WAIT for KBs to load
 							}
 							// NOW set selections when KB list is ready
 							form.selectedKnowledgeBases = parsedData.RAG_collections?.split(',').filter(Boolean) || [];
+							// Populate Grep RAG fields if applicable
+							if (isGrepRag(form.selectedRagProcessor)) {
+								form.grepMode = callbackData.grep_mode || 'hybrid';
+								form.grepFallbackRag = callbackData.grep_fallback_rag || 'simple_rag';
+								form.grepMaxTries = callbackData.grep_max_tries ?? 5;
+								form.grepContextLines = callbackData.grep_context_lines ?? 3;
+								form.grepMaxTotalChars = callbackData.grep_max_total_chars ?? 8000;
+							}
 						} else if (isSingleFileRag(form.selectedRagProcessor)) {
 							form.selectedKnowledgeBases = []; // Clear KBs if switching to single file RAG
 							// Fetch files BEFORE setting selection
@@ -459,6 +472,11 @@
 					fileError={form.fileError}
 					onFilesChanged={() => doFetchUserFiles(true)}
 					onchange={() => handleFieldChange(form)}
+					bind:grepMode={form.grepMode}
+					bind:grepFallbackRag={form.grepFallbackRag}
+					bind:grepMaxTries={form.grepMaxTries}
+					bind:grepContextLines={form.grepContextLines}
+					bind:grepMaxTotalChars={form.grepMaxTotalChars}
 				/>
 			</div>
 			</div>

--- a/frontend/svelte-app/src/lib/components/assistants/components/ConfigurationPanel.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/components/ConfigurationPanel.svelte
@@ -33,7 +33,13 @@
 		loadingFiles = false,
 		fileError = '',
 		onFilesChanged,
-		onchange
+		onchange,
+		// Grep RAG fields
+		grepMode = $bindable('hybrid'),
+		grepFallbackRag = $bindable('simple_rag'),
+		grepMaxTries = $bindable(5),
+		grepContextLines = $bindable(3),
+		grepMaxTotalChars = $bindable(8000)
 	} = $props();
 
 	let currentConnectorMetadata = $derived.by(() => {
@@ -208,6 +214,12 @@
 			fileError={fileError}
 			{formState}
 			{onFilesChanged}
+			{ragProcessors}
+			bind:grepMode
+			bind:grepFallbackRag
+			bind:grepMaxTries
+			bind:grepContextLines
+			bind:grepMaxTotalChars
 		/>
 	{/if}
 </fieldset>

--- a/frontend/svelte-app/src/lib/components/assistants/components/RagOptionsPanel.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/components/RagOptionsPanel.svelte
@@ -1,7 +1,7 @@
 <!-- src/lib/components/assistants/RagOptionsPanel.svelte -->
 <script>
 	import { _ } from '$lib/i18n';
-	import { isKbBasedRag, isSingleFileRag, isRubricRag } from '$lib/utils/ragProcessorHelpers.js';
+	import { isKbBasedRag, isSingleFileRag, isRubricRag, isGrepRag } from '$lib/utils/ragProcessorHelpers.js';
 	import KnowledgeBaseSelector from './KnowledgeBaseSelector.svelte';
 	import SingleFileSelector from './SingleFileSelector.svelte';
 
@@ -18,12 +18,20 @@
 		loadingFiles = false,
 		fileError = '',
 		formState,
-		onFilesChanged
+		onFilesChanged,
+		// Grep RAG fields
+		grepMode = $bindable('hybrid'),
+		grepFallbackRag = $bindable('simple_rag'),
+		grepMaxTries = $bindable(5),
+		grepContextLines = $bindable(3),
+		grepMaxTotalChars = $bindable(8000),
+		ragProcessors = []
 	} = $props();
 
-	let showKbSelector = $derived(isKbBasedRag(selectedRagProcessor));
+	let showKbSelector = $derived(isKbBasedRag(selectedRagProcessor) || isGrepRag(selectedRagProcessor));
 	let showFileSelector = $derived(isSingleFileRag(selectedRagProcessor));
-	let showTopK = $derived(isKbBasedRag(selectedRagProcessor));
+	let showTopK = $derived(isKbBasedRag(selectedRagProcessor) || isGrepRag(selectedRagProcessor));
+	let showGrepOptions = $derived(isGrepRag(selectedRagProcessor));
 </script>
 
 <div class="pt-4 border-t border-gray-200 space-y-4">
@@ -65,5 +73,81 @@
 			{formState}
 			{onFilesChanged}
 		/>
+	{/if}
+	{#if showGrepOptions}
+		<div class="space-y-3 p-3 bg-gray-50 border border-gray-200 rounded-md">
+			<h5 class="text-sm font-semibold text-gray-700">
+				{$_('assistants.form.grepRag.sectionTitle', { default: 'Grep RAG Configuration' })}
+			</h5>
+
+			<!-- Mode -->
+			<div>
+				<label for="grep-mode" class="block text-sm font-medium text-gray-700">
+					{$_('assistants.form.grepRag.mode.label', { default: 'Mode' })}
+				</label>
+				<select id="grep-mode" bind:value={grepMode}
+					class="mt-1 block w-full px-3 py-2 text-sm border border-gray-300 rounded-md bg-white text-gray-900">
+					<option value="hybrid">{$_('assistants.form.grepRag.mode.hybrid', { default: 'Hybrid (grep + RAG in parallel)' })}</option>
+					<option value="primary">{$_('assistants.form.grepRag.mode.primary', { default: 'Primary (grep first, RAG fallback)' })}</option>
+				</select>
+				<p class="mt-1 text-xs text-gray-500">
+					{$_('assistants.form.grepRag.mode.description', { default: 'How grep interacts with embedding-based RAG' })}
+				</p>
+			</div>
+
+			<!-- Fallback RAG (only relevant in primary mode) -->
+			{#if grepMode === 'primary'}
+			<div>
+				<label for="grep-fallback-rag" class="block text-sm font-medium text-gray-700">
+					{$_('assistants.form.grepRag.fallbackRag.label', { default: 'Fallback RAG' })}
+				</label>
+				<select id="grep-fallback-rag" bind:value={grepFallbackRag}
+					class="mt-1 block w-full px-3 py-2 text-sm border border-gray-300 rounded-md bg-white text-gray-900">
+					{#each ragProcessors.filter(p => isKbBasedRag(p)) as processor}
+						<option value={processor}>{processor.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())}</option>
+					{/each}
+				</select>
+				<p class="mt-1 text-xs text-gray-500">
+					{$_('assistants.form.grepRag.fallbackRag.description', { default: 'Embedding RAG to fall back to when grep finds no matches' })}
+				</p>
+			</div>
+			{/if}
+
+			<!-- Max Tries -->
+			<div>
+				<label for="grep-max-tries" class="block text-sm font-medium text-gray-700">
+					{$_('assistants.form.grepRag.maxTries.label', { default: 'Max Search Tries' })}
+				</label>
+				<input type="number" id="grep-max-tries" bind:value={grepMaxTries} min="1" max="10"
+					class="mt-1 block w-24 px-3 py-2 text-sm border border-gray-300 rounded-md bg-white text-gray-900">
+				<p class="mt-1 text-xs text-gray-500">
+					{$_('assistants.form.grepRag.maxTries.description', { default: 'Maximum number of search iterations (1-10)' })}
+				</p>
+			</div>
+
+			<!-- Context Lines -->
+			<div>
+				<label for="grep-context-lines" class="block text-sm font-medium text-gray-700">
+					{$_('assistants.form.grepRag.contextLines.label', { default: 'Context Lines' })}
+				</label>
+				<input type="number" id="grep-context-lines" bind:value={grepContextLines} min="1" max="10"
+					class="mt-1 block w-24 px-3 py-2 text-sm border border-gray-300 rounded-md bg-white text-gray-900">
+				<p class="mt-1 text-xs text-gray-500">
+					{$_('assistants.form.grepRag.contextLines.description', { default: 'Lines of context before/after each match (1-10)' })}
+				</p>
+			</div>
+
+			<!-- Max Total Chars -->
+			<div>
+				<label for="grep-max-chars" class="block text-sm font-medium text-gray-700">
+					{$_('assistants.form.grepRag.maxTotalChars.label', { default: 'Max Result Characters' })}
+				</label>
+				<input type="number" id="grep-max-chars" bind:value={grepMaxTotalChars} min="1000" max="32000" step="1000"
+					class="mt-1 block w-32 px-3 py-2 text-sm border border-gray-300 rounded-md bg-white text-gray-900">
+				<p class="mt-1 text-xs text-gray-500">
+					{$_('assistants.form.grepRag.maxTotalChars.description', { default: 'Max total characters of grep results sent to main LLM (1000-32000)' })}
+				</p>
+			</div>
+		</div>
 	{/if}
 </div>

--- a/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormFetchers.js
+++ b/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormFetchers.js
@@ -7,7 +7,7 @@
 import { getUserKnowledgeBases, getSharedKnowledgeBases } from '$lib/services/knowledgeBaseService';
 import { fetchAccessibleRubrics } from '$lib/services/rubricService';
 import { apiJson } from '$lib/services/apiClient';
-import { isKbBasedRag, isRubricRag } from '$lib/utils/ragProcessorHelpers.js';
+import { isKbBasedRag, isRubricRag, isGrepRag } from '$lib/utils/ragProcessorHelpers.js';
 import { getAssistantMetadataObject } from '$lib/utils/assistantData';
 
 /**
@@ -16,7 +16,7 @@ import { getAssistantMetadataObject } from '$lib/utils/assistantData';
  */
 export async function fetchKnowledgeBases(form) {
 	if (form.loadingKnowledgeBases || form.kbFetchAttempted) return;
-	if (!isKbBasedRag(form.selectedRagProcessor)) return;
+	if (!isKbBasedRag(form.selectedRagProcessor) && !isGrepRag(form.selectedRagProcessor)) return;
 
 	form.loadingKnowledgeBases = true;
 	form.knowledgeBaseError = '';

--- a/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormState.svelte.js
+++ b/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormState.svelte.js
@@ -16,7 +16,7 @@
 
 import { get } from 'svelte/store';
 import { assistantConfigStore } from '$lib/stores/assistantConfigStore';
-import { isKbBasedRag, isSingleFileRag, isRubricRag, normalizeRagProcessor } from '$lib/utils/ragProcessorHelpers.js';
+import { isKbBasedRag, isSingleFileRag, isRubricRag, isGrepRag, normalizeRagProcessor } from '$lib/utils/ragProcessorHelpers.js';
 import { loadRagPlaceholders, selectModel } from './assistantFormUtils.svelte.js';
 import { getAssistantMetadataObject } from '$lib/utils/assistantData';
 
@@ -83,6 +83,18 @@ export function createAssistantFormState() {
 		loadingRubrics: false,
 		rubricError: '',
 		rubricsFetchAttempted: false,
+
+		// --- Grep RAG state ---
+		/** @type {'hybrid' | 'primary'} */
+		grepMode: 'hybrid',
+		/** @type {string} */
+		grepFallbackRag: 'simple_rag',
+		/** @type {number} */
+		grepMaxTries: 5,
+		/** @type {number} */
+		grepContextLines: 3,
+		/** @type {number} */
+		grepMaxTotalChars: 8000,
 
 		// --- UI / loading state ---
 		formError: '',
@@ -187,6 +199,15 @@ export function populateFormFields(form, data, getAvailableModels, preserveDescr
 			}
 		}
 
+		// Grep RAG fields
+		if (isGrepRag(form.selectedRagProcessor)) {
+			form.grepMode = metadata?.grep_mode || 'hybrid';
+			form.grepFallbackRag = metadata?.grep_fallback_rag || 'simple_rag';
+			form.grepMaxTries = metadata?.grep_max_tries ?? 5;
+			form.grepContextLines = metadata?.grep_context_lines ?? 3;
+			form.grepMaxTotalChars = metadata?.grep_max_total_chars ?? 8000;
+		}
+
 		// Vision capability
 		try {
 			form.visionEnabled = metadata?.capabilities?.vision || false;
@@ -234,5 +255,13 @@ export function clearRagDependentState(form) {
 	if (!isRubricRag(form.selectedRagProcessor) && (form.selectedRubricId || form.accessibleRubrics.length > 0)) {
 		form.selectedRubricId = '';
 		form.rubricFormat = 'markdown';
+	}
+
+	if (!isGrepRag(form.selectedRagProcessor)) {
+		form.grepMode = 'hybrid';
+		form.grepFallbackRag = 'simple_rag';
+		form.grepMaxTries = 5;
+		form.grepContextLines = 3;
+		form.grepMaxTotalChars = 8000;
 	}
 }

--- a/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormSubmit.js
+++ b/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormSubmit.js
@@ -4,7 +4,7 @@
  * Extracted from AssistantForm.svelte to enable isolated testing.
  */
 
-import { isKbBasedRag, isSingleFileRag, isRubricRag } from '$lib/utils/ragProcessorHelpers.js';
+import { isKbBasedRag, isSingleFileRag, isRubricRag, isGrepRag } from '$lib/utils/ragProcessorHelpers.js';
 
 /**
  * Validates form data before submission.
@@ -42,13 +42,21 @@ export function buildAssistantPayload(form) {
 		metadataObj.rubric_format = form.rubricFormat;
 	}
 
+	if (isGrepRag(form.selectedRagProcessor)) {
+		metadataObj.grep_mode = form.grepMode;
+		metadataObj.grep_fallback_rag = form.grepFallbackRag;
+		metadataObj.grep_max_tries = form.grepMaxTries;
+		metadataObj.grep_context_lines = form.grepContextLines;
+		metadataObj.grep_max_total_chars = form.grepMaxTotalChars;
+	}
+
 	return {
 		name: form.name.trim(),
 		description: form.description,
 		system_prompt: form.system_prompt,
 		prompt_template: form.prompt_template,
 		RAG_Top_k: Number(form.RAG_Top_k) || 3,
-		RAG_collections: isKbBasedRag(form.selectedRagProcessor) ? form.selectedKnowledgeBases.join(',') : '',
+		RAG_collections: (isKbBasedRag(form.selectedRagProcessor) || isGrepRag(form.selectedRagProcessor)) ? form.selectedKnowledgeBases.join(',') : '',
 		metadata: JSON.stringify(metadataObj),
 		pre_retrieval_endpoint: '',
 		post_retrieval_endpoint: '',

--- a/frontend/svelte-app/src/lib/locales/ca.json
+++ b/frontend/svelte-app/src/lib/locales/ca.json
@@ -203,6 +203,31 @@
         "error": "Error en carregar arxius:",
         "noneFound": "No s'han trobat arxius. Si us plau puja un arxiu.",
         "required": "Si us plau selecciona un arxiu"
+      },
+      "grepRag": {
+        "sectionTitle": "Configuració de Grep RAG",
+        "mode": {
+          "label": "Mode",
+          "description": "Com interactua grep amb el RAG basat en embeddings",
+          "hybrid": "Híbrid (grep + RAG en paral·lel)",
+          "primary": "Principal (grep primer, RAG com a respatller)"
+        },
+        "fallbackRag": {
+          "label": "RAG de Respatller",
+          "description": "RAG d'embeddings per complementar o com a respatller"
+        },
+        "maxTries": {
+          "label": "Intents Màxims",
+          "description": "Nombre màxim d'iteracions de cerca (1-10)"
+        },
+        "contextLines": {
+          "label": "Línies de Context",
+          "description": "Línies de context abans/després de cada coincidència (1-10)"
+        },
+        "maxTotalChars": {
+          "label": "Caràcters Màxims",
+          "description": "Màxim total de caràcters de resultats enviats al LLM (1000-32000)"
+        }
       }
     },
     "noDescription": "Sense descripció",

--- a/frontend/svelte-app/src/lib/locales/en.json
+++ b/frontend/svelte-app/src/lib/locales/en.json
@@ -342,6 +342,31 @@
         "error": "Error loading files:",
         "noneFound": "No files found. Please upload a file.",
         "required": "Please select a file"
+      },
+      "grepRag": {
+        "sectionTitle": "Grep RAG Configuration",
+        "mode": {
+          "label": "Mode",
+          "description": "How grep interacts with embedding-based RAG",
+          "hybrid": "Hybrid (grep + RAG in parallel)",
+          "primary": "Primary (grep first, RAG fallback)"
+        },
+        "fallbackRag": {
+          "label": "Fallback RAG",
+          "description": "Embedding RAG to complement or fall back to"
+        },
+        "maxTries": {
+          "label": "Max Search Tries",
+          "description": "Maximum number of search iterations (1-10)"
+        },
+        "contextLines": {
+          "label": "Context Lines",
+          "description": "Lines of context before/after each match (1-10)"
+        },
+        "maxTotalChars": {
+          "label": "Max Result Characters",
+          "description": "Max total characters of grep results sent to main LLM (1000-32000)"
+        }
       }
     }
   },

--- a/frontend/svelte-app/src/lib/locales/es.json
+++ b/frontend/svelte-app/src/lib/locales/es.json
@@ -203,6 +203,31 @@
         "error": "Error al cargar archivos:",
         "noneFound": "No se encontraron archivos. Por favor sube un archivo.",
         "required": "Por favor selecciona un archivo"
+      },
+      "grepRag": {
+        "sectionTitle": "Configuración de Grep RAG",
+        "mode": {
+          "label": "Modo",
+          "description": "Cómo interactúa grep con el RAG basado en embeddings",
+          "hybrid": "Híbrido (grep + RAG en paralelo)",
+          "primary": "Principal (grep primero, RAG como respaldo)"
+        },
+        "fallbackRag": {
+          "label": "RAG de Respaldo",
+          "description": "RAG de embeddings para complementar o como respaldo"
+        },
+        "maxTries": {
+          "label": "Intentos Máximos",
+          "description": "Número máximo de iteraciones de búsqueda (1-10)"
+        },
+        "contextLines": {
+          "label": "Líneas de Contexto",
+          "description": "Líneas de contexto antes/después de cada coincidencia (1-10)"
+        },
+        "maxTotalChars": {
+          "label": "Caracteres Máximos",
+          "description": "Máximo total de caracteres de resultados enviados al LLM (1000-32000)"
+        }
       }
     },
     "noDescription": "Sin descripción",

--- a/frontend/svelte-app/src/lib/locales/eu.json
+++ b/frontend/svelte-app/src/lib/locales/eu.json
@@ -353,6 +353,31 @@
         "error": "Errorea fitxategiak kargatzean:",
         "noneFound": "Ez da fitxategirik aurkitu. Mesedez igo fitxategi bat.",
         "required": "Mesedez hautatu fitxategi bat"
+      },
+      "grepRag": {
+        "sectionTitle": "Grep RAG Konfigurazioa",
+        "mode": {
+          "label": "Modua",
+          "description": "Grepek embedding-etan oinarritutako RAGarekin nola elkarreragiten duen",
+          "hybrid": "Hibridoa (grep + RAG paraleloan)",
+          "primary": "Nagusia (grep lehenik, RAG ordezko gisa)"
+        },
+        "fallbackRag": {
+          "label": "Ordezko RAG",
+          "description": "Embedding RAG osagarri edo ordezko gisa"
+        },
+        "maxTries": {
+          "label": "Gehienezko Saiakerak",
+          "description": "Bilaketa iterazioen gehienezko kopurua (1-10)"
+        },
+        "contextLines": {
+          "label": "Testuinguru Lerroak",
+          "description": "Bat-etortze bakoitzaren aurretik/ondoren testuinguru lerroak (1-10)"
+        },
+        "maxTotalChars": {
+          "label": "Gehienezko Karaktereak",
+          "description": "LLM-ra bidalitako grep emaitzen gehienezko karaktereak (1000-32000)"
+        }
       }
     }
   },

--- a/frontend/svelte-app/src/lib/stores/assistantConfigStore.js
+++ b/frontend/svelte-app/src/lib/stores/assistantConfigStore.js
@@ -84,7 +84,7 @@ function getFallbackCapabilities() {
 	const capabilities = {
 		prompt_processors: ['simple_augment'],
 		connectors: {},
-		rag_processors: ['no_rag', 'simple_rag', 'context_aware_rag', 'single_file_rag']
+		rag_processors: ['no_rag', 'simple_rag', 'context_aware_rag', 'single_file_rag', 'grep_rag']
 	};
 	return capabilities;
 }

--- a/frontend/svelte-app/src/lib/utils/ragProcessorHelpers.js
+++ b/frontend/svelte-app/src/lib/utils/ragProcessorHelpers.js
@@ -19,6 +19,8 @@ export const RAG_TYPES = Object.freeze({
 	SINGLE_FILE: ['single_file_rag'],
 	/** RAG processor that uses rubrics */
 	RUBRIC: ['rubric_rag'],
+	/** RAG processor that uses iterative grep across KB documents */
+	GREP: ['grep_rag'],
 	/** No RAG processing */
 	NONE: ['no_rag']
 });
@@ -51,6 +53,15 @@ export function isRubricRag(processor) {
 }
 
 /**
+ * Returns true if the processor uses iterative grep across KB documents.
+ * @param {string} processor
+ * @returns {boolean}
+ */
+export function isGrepRag(processor) {
+	return RAG_TYPES.GREP.includes(processor);
+}
+
+/**
  * Returns true if no RAG processing is configured.
  * @param {string} processor
  * @returns {boolean}
@@ -66,6 +77,15 @@ export function isNoRag(processor) {
  */
 export function hasRagOptions(processor) {
 	return !!processor && !isNoRag(processor);
+}
+
+/**
+ * Returns true if the processor is grep-based and needs grep-specific UI.
+ * @param {string} processor
+ * @returns {boolean}
+ */
+export function isGrepBasedRag(processor) {
+	return isGrepRag(processor);
 }
 
 /**

--- a/frontend/svelte-app/src/routes/assistants/+page.svelte
+++ b/frontend/svelte-app/src/routes/assistants/+page.svelte
@@ -700,8 +700,8 @@
         const callbackData = getAssistantMetadataObject(selectedAssistantData);
         ragProcessor = callbackData.rag_processor || '';
 
-		if (ragProcessor !== 'simple_rag') {
-			console.log('Skipping KB fetch for detail view (not simple_rag)');
+		if (ragProcessor !== 'simple_rag' && ragProcessor !== 'grep_rag') {
+			console.log('Skipping KB fetch for detail view (not simple_rag or grep_rag)');
             accessibleKnowledgeBases = []; // Clear if not needed
             knowledgeBaseError = '';
             kbFetchTriggered = true; // Mark as checked for this load
@@ -1383,8 +1383,8 @@
                                                 </div>
                                             {/if}
 
-                                            <!-- Knowledge Bases (if simple_rag) -->
-                                            {#if apiCallback.rag_processor === 'simple_rag'}
+                                            <!-- Knowledge Bases (if simple_rag or grep_rag) -->
+                                            {#if apiCallback.rag_processor === 'simple_rag' || apiCallback.rag_processor === 'grep_rag'}
                                                 <div>
                                                     <div class="font-medium text-gray-700 mb-1">{$_('assistants.form.knowledgeBases.label', { default: 'Knowledge Bases' })}</div>
                                                     {#if loadingKnowledgeBases}
@@ -1418,6 +1418,35 @@
                                                     <div class="font-medium text-gray-700 mb-1">{$_('assistants.form.singleFile.selectedLabel', { default: 'Selected File' })}</div>
                                                     <div class="bg-white border border-gray-200 p-2 rounded break-all">
                                                         {apiCallback.file_path || (currentLocale ? $_('common.notSpecified', { default: 'Not specified' }) : 'Not specified')}
+                                                    </div>
+                                                </div>
+                                            {/if}
+
+                                            <!-- Grep RAG Configuration (if grep_rag) -->
+                                            {#if apiCallback.rag_processor === 'grep_rag'}
+                                                <div class="space-y-2 p-3 bg-gray-50 border border-gray-200 rounded-md">
+                                                    <h5 class="text-sm font-semibold text-gray-700">
+                                                        {$_('assistants.form.grepRag.sectionTitle', { default: 'Grep RAG Configuration' })}
+                                                    </h5>
+                                                    <div>
+                                                        <span class="text-xs text-gray-500">{$_('assistants.form.grepRag.mode.label', { default: 'Mode' })}: </span>
+                                                        <span class="text-sm font-medium">{apiCallback.grep_mode === 'primary' ? $_('assistants.form.grepRag.mode.primary', { default: 'Primary' }) : $_('assistants.form.grepRag.mode.hybrid', { default: 'Hybrid' })}</span>
+                                                    </div>
+                                                    <div>
+                                                        <span class="text-xs text-gray-500">{$_('assistants.form.grepRag.fallbackRag.label', { default: 'Fallback RAG' })}: </span>
+                                                        <span class="text-sm font-medium">{apiCallback.grep_fallback_rag || 'simple_rag'}</span>
+                                                    </div>
+                                                    <div>
+                                                        <span class="text-xs text-gray-500">{$_('assistants.form.grepRag.maxTries.label', { default: 'Max Tries' })}: </span>
+                                                        <span class="text-sm font-medium">{apiCallback.grep_max_tries ?? 5}</span>
+                                                    </div>
+                                                    <div>
+                                                        <span class="text-xs text-gray-500">{$_('assistants.form.grepRag.contextLines.label', { default: 'Context Lines' })}: </span>
+                                                        <span class="text-sm font-medium">{apiCallback.grep_context_lines ?? 3}</span>
+                                                    </div>
+                                                    <div>
+                                                        <span class="text-xs text-gray-500">{$_('assistants.form.grepRag.maxTotalChars.label', { default: 'Max Result Chars' })}: </span>
+                                                        <span class="text-sm font-medium">{apiCallback.grep_max_total_chars ?? 8000}</span>
                                                     </div>
                                                 </div>
                                             {/if}

--- a/testing/playwright/tests/grep_rag.spec.js
+++ b/testing/playwright/tests/grep_rag.spec.js
@@ -1,0 +1,690 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+require("dotenv").config({ path: path.join(__dirname, ".env"), quiet: true });
+
+/**
+ * Grep RAG Configuration & Chat Tests
+ *
+ * Covers the grep_rag assistant end-to-end flow:
+ *   1. Create a KB with ingest for grep_rag to search against
+ *   2. Create an assistant with grep_rag in hybrid mode
+ *   3. Configure all grep options (mode, max tries, context lines, max chars)
+ *   4. Select knowledge bases for grep_rag
+ *   5. Chat with the hybrid assistant — verify grep_rag responds at runtime
+ *   6. Verify grep settings persist on detail view and re-edit
+ *   7. Switch to primary mode, verify fallback RAG selector appears
+ *   8. Create a second assistant with grep_rag in primary mode
+ *   9. Chat with the primary mode assistant — verify grep_rag + fallback works
+ *  10. Verify primary mode settings persisted on re-edit
+ *  11. Cleanup: delete both assistants and the KB
+ *
+ * Prerequisites:
+ *   - Logged in as admin via global-setup.js
+ *   - Backend has grep_rag plugin available in backend/lamb/completions/rag/
+ */
+
+test.describe.serial("Grep RAG Configuration", () => {
+  const timestamp = Date.now();
+  const kbName = `pw_grep_rag_kb_${timestamp}`;
+  const hybridAssistantName = `pw_grep_hybrid_${timestamp}`;
+  const primaryAssistantName = `pw_grep_primary_${timestamp}`;
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Find an assistant row by name fragment
+  // ════════════════════════════════════════════════════════════════
+  async function findAssistantRow(page, nameFragment) {
+    await page.goto("assistants");
+    await page.waitForLoadState("networkidle");
+
+    const searchBox = page.locator('input[placeholder*="Search" i]');
+    if (await searchBox.count()) {
+      await searchBox.fill(nameFragment);
+      await page.waitForTimeout(500);
+    }
+
+    const row = page.locator(`tr:has-text("${nameFragment}")`).first();
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    return row;
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Open assistant detail view
+  // ════════════════════════════════════════════════════════════════
+  async function openAssistantDetail(page, nameFragment) {
+    const row = await findAssistantRow(page, nameFragment);
+
+    const viewButton = row.getByRole("button", { name: /view|edit/i }).first();
+    if (await viewButton.count()) {
+      await viewButton.click();
+    } else {
+      const nameButton = row
+        .getByRole("button", { name: new RegExp(nameFragment, "i") })
+        .first();
+      if (await nameButton.count()) {
+        await nameButton.click();
+      } else {
+        await row.click();
+      }
+    }
+
+    await page.waitForLoadState("networkidle");
+    await expect(
+      page.getByRole("heading", { name: /assistant/i }).first()
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByRole("button", { name: /^properties$/i }).first()
+    ).toBeVisible({ timeout: 10_000 });
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Navigate to assistant create form and wait for it
+  // ════════════════════════════════════════════════════════════════
+  async function openCreateForm(page) {
+    await page.goto("assistants?view=create");
+    await page.waitForLoadState("networkidle");
+
+    const createButton = page
+      .getByRole("button", { name: /create assistant/i })
+      .first();
+    await expect(createButton).toBeVisible({ timeout: 10_000 });
+    await createButton.click();
+
+    const form = page.locator("#assistant-form-main");
+    await expect(form).toBeVisible({ timeout: 30_000 });
+    return form;
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Fill basic assistant fields
+  // ════════════════════════════════════════════════════════════════
+  async function fillBasicFields(page, name, description, systemPrompt) {
+    await page.fill("#assistant-name", name);
+    await page.fill("#assistant-description", description);
+    await page.fill("#system-prompt", systemPrompt);
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Select RAG processor from dropdown
+  // ════════════════════════════════════════════════════════════════
+  async function selectRagProcessor(page, processorValue) {
+    const ragSelect = page.locator("#rag-processor");
+    await expect(ragSelect).toBeVisible({ timeout: 10_000 });
+    await ragSelect.selectOption(processorValue);
+    // Wait for dependent UI to render
+    await page.waitForTimeout(500);
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Save assistant and wait for redirect to list.
+  // Returns the created assistant ID from the API response.
+  // ════════════════════════════════════════════════════════════════
+  async function saveAssistant(page) {
+    let assistantId = null;
+
+    const createRequest = page.waitForResponse((response) => {
+      if (response.request().method() !== "POST") return false;
+      try {
+        const url = new URL(response.url());
+        return (
+          url.pathname.endsWith("/assistant/create_assistant") &&
+          response.status() >= 200 &&
+          response.status() < 300
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    const saveButton = page.locator(
+      'button[type="submit"][form="assistant-form-main"]'
+    );
+    await expect(saveButton).toBeEnabled({ timeout: 60_000 });
+
+    const form = page.locator("#assistant-form-main");
+    const [response] = await Promise.all([
+      createRequest,
+      form.evaluate((f) => f.requestSubmit()),
+    ]);
+
+    // Extract assistant ID from the creation response
+    try {
+      const body = await response.json();
+      assistantId = body?.id || body?.assistant?.id || body?.assistant_id || null;
+    } catch {
+      // Response may not be JSON; ID will be extracted from URL fallback
+    }
+
+    await page.waitForURL(/\/assistants(\?.*)?$/, { timeout: 30_000 });
+    return assistantId;
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Select a knowledge base by name in the assistant form.
+  // Finds the label containing the KB name and checks its checkbox.
+  // ════════════════════════════════════════════════════════════════
+  async function selectKnowledgeBase(page, kbName) {
+    // KB checkboxes are inside <label> elements with the KB name as text.
+    // The KnowledgeBaseSelector renders them under groups with
+    // aria-labelledby="kb-owned-group-label" / "kb-shared-group-label".
+    const kbLabel = page
+      .locator('label')
+      .filter({ hasText: kbName })
+      .first();
+    await expect(kbLabel).toBeVisible({ timeout: 10_000 });
+
+    const checkbox = kbLabel.locator('input[type="checkbox"]');
+    await checkbox.check();
+
+    // Verify it's actually checked
+    await expect(checkbox).toBeChecked({ timeout: 5_000 });
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Wait for KB ingestion to fully complete.
+  // After uploading a file, ingestion runs async. This polls the
+  // KB detail Files tab until the file shows status "completed".
+  // ════════════════════════════════════════════════════════════════
+  async function waitForKbIngestionComplete(page, kbName, fileName) {
+    await page.goto("knowledgebases");
+    await page.waitForLoadState("networkidle");
+
+    // Navigate to the KB detail
+    const kbRow = page.locator('tbody tr', { hasText: kbName });
+    await expect(kbRow).toBeVisible({ timeout: 10_000 });
+    await kbRow.getByRole('button', { name: kbName }).click();
+    await page.waitForLoadState("networkidle");
+
+    // Click the Files tab
+    const tabs = page.locator('nav[aria-label="Tabs"]');
+    const filesTab = tabs.getByRole('button', { name: 'Files' });
+    await expect(filesTab).toBeVisible({ timeout: 10_000 });
+    await filesTab.click();
+    await expect(filesTab).toHaveAttribute('aria-current', 'page', { timeout: 5_000 });
+
+    // Wait for the ingested file row to appear with "completed" status
+    const fileRow = page.locator('table tbody tr', { hasText: fileName });
+    await expect(fileRow).toBeVisible({ timeout: 120_000 });
+
+    // The status is in the 4th column (index 3), rendered as a button
+    await expect(
+      fileRow.locator('td').nth(3).getByRole('button')
+    ).toHaveText(/completed/i, { timeout: 120_000 });
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // Helper: Chat with an assistant and verify it responds.
+  // Navigates to detail page, opens Chat tab, sends a query,
+  // and waits for the completion response.
+  // ════════════════════════════════════════════════════════════════
+  async function chatWithAssistant(page, assistantId, query) {
+    await page.goto(`assistants?view=detail&id=${assistantId}`);
+    await page.waitForLoadState("networkidle");
+
+    // Click the "Chat with" tab
+    const chatTab = page.getByRole("button", { name: /Chat with/i });
+    await expect(chatTab).toBeVisible({ timeout: 10_000 });
+    await chatTab.click();
+
+    // Wait for chat input to appear
+    const input = page.getByPlaceholder(/Type your message/i);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the completion response concurrently with sending
+    const completionPromise = page.waitForResponse(
+      (response) => {
+        if (response.request().method() !== "POST") return false;
+        try {
+          const url = new URL(response.url());
+          return (
+            url.pathname.endsWith(
+              `/assistant/${assistantId}/chat/completions`
+            ) &&
+            response.status() >= 200 &&
+            response.status() < 300
+          );
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 90_000 }
+    );
+
+    await input.fill(query);
+    const sendButton = page.getByRole("button", { name: /^Send$/ });
+    await expect(sendButton).toBeVisible({ timeout: 5_000 });
+    await sendButton.click();
+
+    // Wait for the completion to finish
+    await completionPromise;
+
+    // Wait a moment for the response to render in the chat UI
+    await page.waitForTimeout(3_000);
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  // 1. Create a knowledge base for grep_rag to search against
+  // ════════════════════════════════════════════════════════════════
+  test("1. Create knowledge base for grep_rag tests", async ({ page }) => {
+    await page.goto("knowledgebases");
+    await page.waitForLoadState("networkidle");
+
+    const createButton = page.getByRole("button", {
+      name: /create knowledge base/i,
+    });
+    await expect(createButton).toBeVisible({ timeout: 10_000 });
+    await createButton.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    await page.getByLabel(/name\s*\*/i).fill(kbName);
+    await page.getByLabel(/description/i).fill("Playwright grep_rag test KB");
+
+    const submitButton = dialog.getByRole("button", {
+      name: /create knowledge base/i,
+    });
+    await expect(submitButton).toBeVisible({ timeout: 5_000 });
+    await submitButton.click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(kbName)).toBeVisible({ timeout: 30_000 });
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 2. Ingest a fixture file into the KB
+  // ════════════════════════════════════════════════════════════════
+  test("2. Ingest fixture file into grep KB", async ({ page }) => {
+    await page.goto("knowledgebases");
+    await page.getByText(kbName, { exact: false }).first().click();
+
+    await page.getByRole("button", { name: /ingest content/i }).click();
+
+    const fixturePath = path.join(
+      __dirname, "..", "fixtures", "ikasiker_fixture.txt"
+    );
+    await page.locator("#file-upload-input-inline").setInputFiles(fixturePath);
+
+    await expect(page.getByText("ikasiker_fixture.txt")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: /upload file/i }).click();
+
+    await expect(
+      page.getByText(/file uploaded and ingestion started successfully/i),
+    ).toBeVisible({ timeout: 60_000 });
+
+    // Wait for async ingestion to fully complete before creating assistants
+    await waitForKbIngestionComplete(page, kbName, "ikasiker_fixture.txt");
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 3. Create assistant with grep_rag in hybrid mode
+  // ════════════════════════════════════════════════════════════════
+  test("3. Create assistant with grep_rag hybrid mode", async ({ page }) => {
+    await openCreateForm(page);
+    await fillBasicFields(
+      page,
+      hybridAssistantName,
+      "Grep RAG hybrid mode test assistant",
+      "You are a helpful assistant for grep_rag Playwright tests."
+    );
+
+    // Select grep_rag processor
+    await selectRagProcessor(page, "grep_rag");
+
+    // Wait for grep config panel to appear
+    const grepSection = page.getByText(/Grep RAG Configuration/i);
+    await expect(grepSection).toBeVisible({ timeout: 10_000 });
+
+    // Verify hybrid mode is the default
+    const modeSelect = page.locator("#grep-mode");
+    await expect(modeSelect).toHaveValue("hybrid");
+
+    // Fallback RAG selector should NOT be visible in hybrid mode
+    const fallbackSelect = page.locator("#grep-fallback-rag");
+    await expect(fallbackSelect).not.toBeVisible();
+
+    // Configure grep options
+    await page.fill("#grep-max-tries", "7");
+    await page.fill("#grep-context-lines", "5");
+    await page.fill("#grep-max-chars", "12000");
+
+    // Set RAG Top K (shared with companion RAG)
+    await page.fill("#rag-top-k", "4");
+
+    // Select the knowledge base by name
+    await selectKnowledgeBase(page, kbName);
+
+    // Save and capture the assistant ID
+    const hybridAssistantId = await saveAssistant(page);
+
+    // Verify assistant appears in list
+    const row = await findAssistantRow(page, hybridAssistantName);
+    await expect(row).toBeVisible();
+
+    // Store ID for later chat tests
+    process.env.__HYBRID_ASSISTANT_ID = hybridAssistantId;
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 4. Chat with the hybrid grep_rag assistant
+  // ════════════════════════════════════════════════════════════════
+  test("4. Chat with hybrid grep_rag assistant", async ({ page }, testInfo) => {
+    const assistantId = process.env.__HYBRID_ASSISTANT_ID;
+    if (!assistantId) {
+      testInfo.skip(true, "Hybrid assistant ID not captured — skipping chat test");
+      return;
+    }
+
+    // Send a query that should trigger grep search against the Ikasiker KB
+    await chatWithAssistant(
+      page,
+      assistantId,
+      "¿Cuántas becas Ikasiker se convocan?"
+    );
+
+    // Verify the chat didn't error — the completion completed successfully
+    // and the page is still interactive
+    await expect(
+      page.getByPlaceholder(/Type your message/i)
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 5. Verify hybrid grep_rag settings in detail view
+  // ════════════════════════════════════════════════════════════════
+  test("5. Verify hybrid grep_rag settings persist in detail view", async ({
+    page,
+  }) => {
+    await openAssistantDetail(page, hybridAssistantName);
+
+    // The detail view should show grep_rag configuration.
+    // Look for the grep section title.
+    const grepSection = page.getByText(/Grep RAG Configuration/i);
+    // In detail (read-only) view, grep config may be rendered differently.
+    // At minimum, the assistant detail should be visible.
+    await expect(
+      page.getByRole("heading", { name: /assistant/i }).first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Check that KB info is displayed (grep_rag assistants show KBs in detail)
+    const kbInfo = page.getByText(/knowledge base/i);
+    // KB info may or may not be present depending on detail view layout;
+    // just verify the detail page loaded successfully
+    await expect(
+      page.getByRole("button", { name: /^properties$/i }).first()
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 6. Edit assistant to verify grep settings persisted correctly
+  // ════════════════════════════════════════════════════════════════
+  test("6. Edit assistant and verify grep settings are preserved", async ({
+    page,
+  }) => {
+    await openAssistantDetail(page, hybridAssistantName);
+
+    // Enter edit mode
+    const editButton = page.getByRole("button", { name: /^edit$/i }).first();
+    await expect(editButton).toBeVisible({ timeout: 10_000 });
+    await editButton.click();
+
+    // Wait for edit form
+    const form = page.locator("#assistant-form-main");
+    await expect(form).toBeVisible({ timeout: 30_000 });
+
+    // Verify grep config section is visible
+    const grepSection = page.getByText(/Grep RAG Configuration/i);
+    await expect(grepSection).toBeVisible({ timeout: 10_000 });
+
+    // Verify grep values persisted
+    await expect(page.locator("#grep-mode")).toHaveValue("hybrid");
+    await expect(page.locator("#grep-max-tries")).toHaveValue("7");
+    await expect(page.locator("#grep-context-lines")).toHaveValue("5");
+    await expect(page.locator("#grep-max-chars")).toHaveValue("12000");
+    await expect(page.locator("#rag-top-k")).toHaveValue("4");
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 7. Switch to primary mode and verify fallback RAG selector
+  // ════════════════════════════════════════════════════════════════
+  test("7. Switch to primary mode and verify fallback RAG appears", async ({
+    page,
+  }) => {
+    await openAssistantDetail(page, hybridAssistantName);
+
+    const editButton = page.getByRole("button", { name: /^edit$/i }).first();
+    await expect(editButton).toBeVisible({ timeout: 10_000 });
+    await editButton.click();
+
+    const form = page.locator("#assistant-form-main");
+    await expect(form).toBeVisible({ timeout: 30_000 });
+
+    // Switch to primary mode
+    await page.locator("#grep-mode").selectOption("primary");
+
+    // Fallback RAG selector should now be visible
+    const fallbackSelect = page.locator("#grep-fallback-rag");
+    await expect(fallbackSelect).toBeVisible({ timeout: 5_000 });
+
+    // Select a fallback RAG (should have KB-based RAG options)
+    const fallbackOptions = fallbackSelect.locator("option");
+    const optionCount = await fallbackOptions.count();
+    // Should have at least one KB-based RAG option
+    expect(optionCount).toBeGreaterThanOrEqual(1);
+
+    // Verify we can select an option
+    await fallbackSelect.selectOption({ index: 0 });
+
+    // Save changes
+    const updateRequest = page.waitForResponse((response) => {
+      if (
+        response.request().method() !== "POST" &&
+        response.request().method() !== "PUT"
+      )
+        return false;
+      try {
+        const url = new URL(response.url());
+        return (
+          url.pathname.includes("update_assistant") &&
+          response.status() >= 200 &&
+          response.status() < 300
+        );
+      } catch {
+        return false;
+      }
+    });
+
+    const saveButton = page.locator(
+      'button[type="submit"][form="assistant-form-main"]'
+    );
+    await expect(saveButton).toBeVisible({ timeout: 10_000 });
+    await Promise.all([updateRequest, saveButton.click()]);
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 8. Create assistant with grep_rag in primary mode from scratch
+  // ════════════════════════════════════════════════════════════════
+  test("8. Create assistant with grep_rag primary mode", async ({ page }) => {
+    await openCreateForm(page);
+    await fillBasicFields(
+      page,
+      primaryAssistantName,
+      "Grep RAG primary mode test assistant",
+      "You are a helpful assistant for grep_rag primary mode tests."
+    );
+
+    // Select grep_rag processor
+    await selectRagProcessor(page, "grep_rag");
+
+    // Wait for grep config panel
+    const grepSection = page.getByText(/Grep RAG Configuration/i);
+    await expect(grepSection).toBeVisible({ timeout: 10_000 });
+
+    // Switch to primary mode
+    await page.locator("#grep-mode").selectOption("primary");
+
+    // Verify fallback RAG appears
+    const fallbackSelect = page.locator("#grep-fallback-rag");
+    await expect(fallbackSelect).toBeVisible({ timeout: 5_000 });
+
+    // Select fallback RAG
+    const fallbackOptions = fallbackSelect.locator("option");
+    const optionCount = await fallbackOptions.count();
+    if (optionCount > 1) {
+      await fallbackSelect.selectOption({ index: 1 });
+    }
+
+    // Configure grep options for primary mode
+    await page.fill("#grep-max-tries", "3");
+    await page.fill("#grep-context-lines", "2");
+    await page.fill("#grep-max-chars", "5000");
+    await page.fill("#rag-top-k", "3");
+
+    // Select the knowledge base by name
+    await selectKnowledgeBase(page, kbName);
+
+    // Save and capture the assistant ID
+    const primaryAssistantId = await saveAssistant(page);
+
+    // Verify assistant appears in list
+    const row = await findAssistantRow(page, primaryAssistantName);
+    await expect(row).toBeVisible();
+
+    // Store ID for later chat test
+    process.env.__PRIMARY_ASSISTANT_ID = primaryAssistantId;
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 9. Chat with the primary mode grep_rag assistant
+  // ════════════════════════════════════════════════════════════════
+  test("9. Chat with primary mode grep_rag assistant", async ({ page }, testInfo) => {
+    const assistantId = process.env.__PRIMARY_ASSISTANT_ID;
+    if (!assistantId) {
+      testInfo.skip(true, "Primary assistant ID not captured — skipping chat test");
+      return;
+    }
+
+    // Send a query that should trigger grep search;
+    // in primary mode, if grep finds nothing, fallback RAG should kick in
+    await chatWithAssistant(
+      page,
+      assistantId,
+      "¿Qué requisitos tienen las becas Ikasiker?"
+    );
+
+    // Verify chat UI is still responsive (no crash)
+    await expect(
+      page.getByPlaceholder(/Type your message/i)
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 10. Verify primary mode settings persisted on re-edit
+  // ════════════════════════════════════════════════════════════════
+  test("10. Verify primary mode settings persist", async ({ page }) => {
+    await openAssistantDetail(page, primaryAssistantName);
+
+    const editButton = page.getByRole("button", { name: /^edit$/i }).first();
+    await expect(editButton).toBeVisible({ timeout: 10_000 });
+    await editButton.click();
+
+    const form = page.locator("#assistant-form-main");
+    await expect(form).toBeVisible({ timeout: 30_000 });
+
+    // Verify primary mode persisted
+    await expect(page.locator("#grep-mode")).toHaveValue("primary");
+
+    // Fallback RAG should be visible
+    await expect(page.locator("#grep-fallback-rag")).toBeVisible();
+
+    // Verify other values persisted
+    await expect(page.locator("#grep-max-tries")).toHaveValue("3");
+    await expect(page.locator("#grep-context-lines")).toHaveValue("2");
+    await expect(page.locator("#grep-max-chars")).toHaveValue("5000");
+    await expect(page.locator("#rag-top-k")).toHaveValue("3");
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 11. Cleanup: delete both test assistants
+  // ════════════════════════════════════════════════════════════════
+  test("11. Cleanup: delete test assistants", async ({ page }) => {
+    for (const name of [hybridAssistantName, primaryAssistantName]) {
+      const row = await findAssistantRow(page, name);
+
+      const deleteButton = row.getByRole("button", { name: /delete/i }).first();
+      await expect(deleteButton).toBeVisible({ timeout: 10_000 });
+      await deleteButton.click();
+
+      const modal = page.getByRole("dialog");
+      await expect(modal).toBeVisible({ timeout: 10_000 });
+
+      const confirmDelete = modal
+        .getByRole("button", { name: /^delete$/i })
+        .first();
+      await expect(confirmDelete).toBeVisible({ timeout: 5_000 });
+
+      // Wait for the delete request
+      const deleteRequest = page.waitForResponse((response) => {
+        if (response.request().method() !== "DELETE" && response.request().method() !== "POST") return false;
+        try {
+          const url = new URL(response.url());
+          return (
+            url.pathname.includes("delete_assistant") &&
+            response.status() >= 200 &&
+            response.status() < 300
+          );
+        } catch {
+          return false;
+        }
+      });
+
+      await Promise.all([deleteRequest, confirmDelete.click()]);
+      await page.waitForTimeout(500);
+    }
+  });
+
+  // ════════════════════════════════════════════════════════════════
+  // 12. Cleanup: delete test KB
+  // ════════════════════════════════════════════════════════════════
+  test("12. Cleanup: delete test knowledge base", async ({ page }) => {
+    await page.goto("knowledgebases");
+    await page.waitForLoadState("networkidle");
+
+    const searchBox = page.locator('input[placeholder*="Search" i]');
+    if (await searchBox.count()) {
+      await searchBox.fill(kbName);
+      await page.waitForTimeout(500);
+    }
+
+    const kbRow = page.locator(`tr:has-text("${kbName}")`);
+    await expect(kbRow).toBeVisible({ timeout: 10_000 });
+
+    const deleteButton = kbRow
+      .locator("button.text-red-600", { hasText: /delete/i });
+    if (await deleteButton.count()) {
+      await deleteButton.click();
+    } else {
+      // Fallback: any delete button in the row
+      const anyDelete = kbRow
+        .getByRole("button", { name: /delete/i })
+        .first();
+      await anyDelete.click();
+    }
+
+    // Wait for confirmation modal
+    const modal = page.getByRole("dialog");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Find and click the confirm delete button
+    const confirmButton = modal
+      .getByRole("button")
+      .filter({ hasText: /delete|confirm|yes/i })
+      .first();
+    await confirmButton.click();
+
+    // Wait for deletion to complete
+    await page.waitForTimeout(1000);
+  });
+});


### PR DESCRIPTION
# Grep RAG — Implementation

---

## Overview

Grep RAG is a complementary search layer that works alongside any embedding-based RAG processor. A **nano LLM** (small-fast-model) drives iterative `grep`/`egrep`/`ripgrep` searches across all files in the assistant's knowledge bases. All searches run in-memory via Python's `re` module — no shelling out.

While embeddings find semantically similar chunks, grep finds **exact keyword matches** — including terms the embedding model might miss, synonyms the nano model iteratively discovers, and content in rarely-accessed sections of the KB.

### Two Operating Modes

| Mode | Behavior | Companion RAG |
|------|----------|---------------|
| **`hybrid`** | Run grep AND simple_rag in parallel, merge results | Always `simple_rag` (hardcoded — grep handles precision; simple semantic coverage suffices) |
| **`primary`** | Grep runs first. If zero matches after max tries → fall back to user-selected RAG | User picks from KB-based RAGs (`simple_rag`, `context_aware_rag`, `hierarchical_rag`) |

---

## Backend: `grep_rag.py`

### Architecture

```
rag_processor(messages, assistant, request)
  │
  ├─ _parse_config()           → Read grep_mode, max_tries, etc. from metadata JSON
  ├─ _extract_user_question()  → Get last user message from conversation
  ├─ _resolve_kb_documents()   → Fetch KB file list + content via KB Server API
  │
  ├─ MODE: primary
  │   ├─ _run_grep_search()    → Iterative nano LLM + regex loop
  │   ├─ matches found?        → _build_grep_response()
  │   └─ no matches?           → _run_fallback_rag(fallback_rag_name)
  │
  └─ MODE: hybrid
      ├─ _run_grep_search()    → Async grep loop
      ├─ _run_fallback_rag("simple_rag") → Parallel embedding RAG (always simple_rag)
      └─ _merge_contexts()     → Combine both result sets
```

### Key Functions

#### `_resolve_kb_documents(assistant)`

1. Calls `GET /collections/{id}/files` on the KB server for each attached KB
2. For each file entry, tries to fetch content from:
   - `processing_stats.output_files.markdown_url` (converted markdown)
   - `file_url` (original file, may be binary)
   - `processing_stats.markdown_preview` (first ~2000 chars, last resort)
3. Filters out binary content via `_is_text_content()` heuristic
4. Returns list of `{file_path, original_filename, content, metadata, collection_id}`

#### `_fetch_text_content(url, headers)`

Handles three URL types:
- **`localhost:*` URLs** — Docker container can't reach them. Tries local filesystem first, then rewrites to `kb:9090` (KB server's internal Docker hostname)
- **Relative URLs** (`/static/...`) — prefixed with KB server base URL
- **Absolute URLs** — fetched directly via HTTP

#### `_run_grep_search(user_question, documents, ...)`

The nano model search loop:

```
For each attempt (1..grep_max_tries):
  1. _ask_nano_model()         → LLM proposes TOOL + PATTERN + FLAGS + REASON
  2. Skip duplicate (tool, pattern) combos
  3. _search_across_documents() → Python re.search across all KB file content
  4. Accumulate matches
  5. If nano says DONE → break
```

**Fallback when no nano model configured:** single grep with user-question keyword extraction.

#### `_search_across_documents(documents, pattern, tool, context_lines)`

- Compiles regex with `re.IGNORECASE | re.MULTILINE` (matching `grep -i`)
- All three tools (`grep`, `egrep`, `ripgrep`) use Python `re` internally — no shelling out
- Invalid regex → caught, returns `[]`, nano model retries
- Context lines extracted around each match

#### `_deduplicate_matches(matches, context_lines)`

- Groups matches by `file_path`
- Merges overlapping context ranges within each file
- Cross-file matches kept separate

#### `_build_grep_response(matches, documents, max_total_chars)`

Formats grep results as markdown blocks with source headers:
```markdown
### {source_label} ({source_url})
{context_lines}
```

Truncates if total exceeds `grep_max_total_chars`.

#### `_merge_contexts(grep_response, rag_response, max_total_chars)`

In hybrid mode, concatenates RAG chunks first, then appends grep results under:
```
---
## Exact Keyword Matches
```

Deduplicates sources by URL.

### Nano Model Prompts

**System prompt:** Instructs the nano model to respond with structured `TOOL:`, `PATTERN:`, `FLAGS:`, `REASON:` lines, or `DONE:` when satisfied. Provides regex tips and tool selection guidance.

**User prompt:** Includes the user's question and a formatted search history showing previous tries, match counts, and content previews.

### Configuration (assistant metadata)

```json
{
    "rag_processor": "grep_rag",
    "grep_mode": "hybrid",
    "grep_fallback_rag": "simple_rag",
    "grep_max_tries": 5,
    "grep_context_lines": 3,
    "grep_max_total_chars": 8000
}
```

| Field | Default | Description |
|-------|---------|-------------|
| `grep_mode` | `"hybrid"` | `"hybrid"` or `"primary"` |
| `grep_fallback_rag` | `"simple_rag"` | Used only in primary mode; hybrid always uses `simple_rag` |
| `grep_max_tries` | 5 | Max search iterations (1 LLM call each) |
| `grep_context_lines` | 3 | Lines of context before/after each match |
| `grep_max_total_chars` | 8000 | Max total chars sent to main LLM |

### Plugin Auto-Discovery

No changes to `main.py` needed. The existing `load_plugins('rag')` system auto-discovers `.py` files in `backend/lamb/completions/rag/`. The function `rag_processor()` is detected as async and awaited accordingly.

### Edge Cases

| Case | Behavior |
|------|----------|
| No KBs attached | Returns error, falls back to embedding RAG |
| No small-fast-model | Single grep with keyword extraction |
| Nano returns garbage | Only structured responses parsed; invalid ignored |
| Max tries exhausted (primary) | Falls back to configured `grep_fallback_rag` |
| Max tries exhausted (hybrid) | Returns found matches + RAG results |
| No matches at all | Primary → fallback RAG; Hybrid → RAG only |
| Invalid regex from nano | `re.error` caught → nano retries |
| Duplicate pattern | Tracked (tool, pattern) set → skipped |
| Results > max chars | Truncated |
| Binary content | Filtered by `_is_text_content()` |
| localhost URLs in Docker | Rewritten to `kb:9090` |
| File deleted from KB | Handled gracefully |

---

## Frontend

### Files Changed

| File | Changes |
|------|---------|
| `src/lib/utils/ragProcessorHelpers.js` | Added `GREP: ['grep_rag']` type, `isGrepRag()`, `isGrepBasedRag()` helpers |
| `src/lib/stores/assistantConfigStore.js` | Added `grep_rag` to fallback capabilities |
| `src/lib/components/assistants/logic/assistantFormState.svelte.js` | 5 grep state fields + populate/clear logic + `isGrepRag` import |
| `src/lib/components/assistants/logic/assistantFormSubmit.js` | Serializes grep config into metadata; sends `RAG_collections` for grep_rag |
| `src/lib/components/assistants/logic/assistantFormFetchers.js` | KB fetch also triggered for `grep_rag` |
| `src/lib/components/assistants/components/RagOptionsPanel.svelte` | Full grep config UI + conditional fallback selector |
| `src/lib/components/assistants/components/ConfigurationPanel.svelte` | Passes grep props through |
| `src/lib/components/assistants/AssistantForm.svelte` | Wires grep state; KB fetch on grep_rag select; import handler for grep_rag |
| `src/routes/assistants/+page.svelte` | Detail view shows grep config + KBs; hides Top K for single_file_rag/rubric_rag |
| `src/lib/components/AssistantsList.svelte` | Table expansion shows KB info for grep_rag |
| `src/lib/locales/{en,es,ca,eu}.json` | 11 new i18n keys under `assistants.form.grepRag.*` |

### RAG Processor Classification (`ragProcessorHelpers.js`)

```js
export const RAG_TYPES = Object.freeze({
    KB_BASED:   ['simple_rag', 'context_aware_rag', 'hierarchical_rag'],
    SINGLE_FILE: ['single_file_rag'],
    RUBRIC:      ['rubric_rag'],
    GREP:        ['grep_rag'],        // ← NEW
    NONE:        ['no_rag']
});

export function isGrepRag(processor)   { return RAG_TYPES.GREP.includes(processor); }
export function isGrepBasedRag(processor) { return isGrepRag(processor); }
```

### Form State (`assistantFormState.svelte.js`)

Five new reactive fields added to the form state object:

```js
grepMode:          'hybrid',       // 'hybrid' | 'primary'
grepFallbackRag:   'simple_rag',   // Used only in primary mode
grepMaxTries:      5,              // 1-10
grepContextLines:  3,              // 1-10
grepMaxTotalChars: 8000,           // 1000-32000
```

- **`populateFormFields()`** — reads grep metadata when editing an existing assistant
- **`clearRagDependentState()`** — resets grep fields to defaults when switching away from grep_rag

### Form Submission (`assistantFormSubmit.js`)

When `isGrepRag()` returns true:
- Serializes all 5 grep fields into `metadataObj`
- Sends `RAG_collections` (KBs are shared with the companion RAG)

### KB Fetching (`assistantFormFetchers.js`)

Guard updated so KB fetching also triggers for `grep_rag`:
```js
if (!isKbBasedRag(form.selectedRagProcessor) && !isGrepRag(form.selectedRagProcessor)) return;
```

### Configuration UI (`RagOptionsPanel.svelte`)

When `grep_rag` is selected, shows:

| Field | Control | Visibility |
|-------|---------|------------|
| Mode | Dropdown: Hybrid / Primary | Always |
| Fallback RAG | Dropdown (KB-based RAGs only) | Only in Primary mode |
| Max Search Tries | Number input (1–10) | Always |
| Context Lines | Number input (1–10) | Always |
| Max Result Characters | Number input (1000–32000, step 1000) | Always |

Additionally, **KB selector** and **RAG Top K** are shown (shared with companion RAG).

### Detail View (`+page.svelte`)

In the read-only detail view:
- Knowledge bases displayed for `grep_rag` (same as `simple_rag`)
- RAG Top K shown (companion RAG uses it)
- Grep configuration section displays mode, fallback RAG, max tries, context lines, max chars

### Knowledge Bases Integration

When `grep_rag` is selected:
- KB fetching is triggered (same flow as `simple_rag`)
- KB selections are stored in `RAG_collections` (same DB field)
- The detail view renders KB names

### i18n Strings

11 new keys added in all 4 locale files:

| Key | English |
|-----|---------|
| `assistants.form.grepRag.sectionTitle` | "Grep RAG Configuration" |
| `assistants.form.grepRag.mode.label` | "Mode" |
| `assistants.form.grepRag.mode.description` | "How grep interacts with embedding-based RAG" |
| `assistants.form.grepRag.mode.hybrid` | "Hybrid (grep + RAG in parallel)" |
| `assistants.form.grepRag.mode.primary` | "Primary (grep first, RAG fallback)" |
| `assistants.form.grepRag.fallbackRag.label` | "Fallback RAG" |
| `assistants.form.grepRag.fallbackRag.description` | "Embedding RAG to fall back to when grep finds no matches" |
| `assistants.form.grepRag.maxTries.label` | "Max Search Tries" |
| `assistants.form.grepRag.maxTries.description` | "Maximum number of search iterations (1-10)" |
| `assistants.form.grepRag.contextLines.label` | "Context Lines" |
| `assistants.form.grepRag.contextLines.description` | "Lines of context before/after each match (1-10)" |
| `assistants.form.grepRag.maxTotalChars.label` | "Max Result Characters" |
| `assistants.form.grepRag.maxTotalChars.description` | "Max total characters of grep results sent to main LLM (1000-32000)" |

---

## Testing

### Automated E2E (Playwright)

An end-to-end Playwright test lives at `testing/playwright/tests/grep_rag.spec.js`. It covers the full lifecycle in 12 serial tests:

| # | Test | What it verifies |
|---|------|-----------------|
| 1 | Create KB | Creates a knowledge base for grep_rag to search against |
| 2 | Ingest + await completion | Uploads `ikasiker_fixture.txt` and polls the KB Files tab until ingestion reaches `completed` status |
| 3 | Create hybrid assistant | Creates assistant with `grep_rag` hybrid mode, configures all options, selects KB by name |
| 4 | Chat with hybrid | Opens Chat tab, sends a query, waits for `POST /assistant/{id}/chat/completions` to return 2xx |
| 5 | Detail view | Verifies assistant detail page loads correctly for a grep_rag assistant |
| 6 | Edit & persistence | Re-edits and confirms all grep settings (mode, tries, context lines, max chars, Top K) persisted |
| 7 | Switch to primary | Toggles to primary mode, verifies fallback RAG dropdown appears and is selectable |
| 8 | Create primary assistant | Creates a second assistant directly in primary mode with fallback RAG configured |
| 9 | Chat with primary | Sends a query against primary mode assistant, verifies completion succeeds |
| 10 | Primary persistence | Confirms primary-mode fields (mode, fallback RAG) persisted on re-edit |
| 11 | Cleanup assistants | Deletes both test assistants via confirmation modal |
| 12 | Cleanup KB | Deletes the test knowledge base |

Run it:
```bash
cd testing/playwright
npx playwright test tests/grep_rag.spec.js
```

Key helpers used in the test:

- **`selectKnowledgeBase(page, kbName)`** — finds the KB checkbox by its label text, checks it, and asserts it's checked
- **`waitForKbIngestionComplete(page, kbName, fileName)`** — navigates to KB detail → Files tab, waits up to 120s for the file row to show `completed` status
- **`chatWithAssistant(page, assistantId, query)`** — opens the Chat tab, types a message, clicks Send, and waits for the chat completions POST to return 2xx
- **`saveAssistant(page)`** — submits the form and extracts the created assistant ID from the API response
