### PR TITLE
feat(#430): emit inline [N] citations in Knowledge Store RAG answers

### DIFF
--- a/backend/lamb/completions/pps/kvcache_augment.py
+++ b/backend/lamb/completions/pps/kvcache_augment.py
@@ -19,6 +19,55 @@ DEFAULT_RAG_PROMPT_TEMPLATE = (
     "Context:\n{context}\n\nQuestion: {user_input}"
 )
 
+CITATION_INSTRUCTION = (
+    "When you use information from the context above, cite the supporting "
+    "source inline using its bracketed number, e.g. [1] or [2][3]. Place the "
+    "citation immediately after the statement it supports. Only cite numbers "
+    "that appear in the context; do not invent citations."
+)
+
+
+def _format_sources_block(sources: List[Dict[str, Any]]) -> str:
+    """Render a numbered ``## Available Sources`` markdown block.
+
+    Each source is labelled with its citation number ``n`` (assigned by the
+    KS RAG processor so it aligns with the ``[N]`` markers in the context). A
+    relevance score is shown when available.
+    """
+    if not sources:
+        return ""
+    lines = ["\n\n## Available Sources\n"]
+    for i, source in enumerate(sources, 1):
+        n = source.get("n", i)
+        title = source.get("title", "Unknown")
+        url = source.get("url", "")
+        score = source.get("score")
+        score_str = (
+            f" (relevance: {score:.3f})" if isinstance(score, (int, float)) else ""
+        )
+        if url:
+            lines.append(f"[{n}] [{title}]({url}){score_str}")
+        else:
+            lines.append(f"[{n}] {title}{score_str}")
+    return "\n".join(lines)
+
+
+def _build_full_context(rag_context: Any) -> str:
+    """Combine retrieved context, the numbered sources block, and the inline
+    citation instruction into the text that replaces ``{context}``.
+
+    The citation instruction is only appended when there are sources to cite,
+    so answers without retrieved context are never told to fabricate markers.
+    """
+    if not isinstance(rag_context, dict):
+        return str(rag_context) if rag_context else ""
+    context = rag_context.get("context", "") or ""
+    sources = rag_context.get("sources", []) or []
+    sources_block = _format_sources_block(sources)
+    if sources_block:
+        return context + sources_block + "\n\n" + CITATION_INSTRUCTION
+    return context
+
 
 def _has_vision_capability(assistant: Assistant) -> bool:
     if not assistant:
@@ -101,18 +150,7 @@ def prompt_processor(
                 augmented_text = assistant.prompt_template.replace("{user_input}", "\n\n" + user_input_text + "\n\n")
 
                 if rag_context:
-                    context = rag_context.get("context", "") if isinstance(rag_context, dict) else str(rag_context)
-                    sources_text = ""
-                    if isinstance(rag_context, dict) and "sources" in rag_context:
-                        sources = rag_context["sources"]
-                        if sources:
-                            sources_text = "\n\n## Available Sources\n\n"
-                            for i, source in enumerate(sources, 1):
-                                title = source.get("title", "Unknown")
-                                url = source.get("url", "")
-                                similarity = source.get("similarity", 0)
-                                sources_text += f"{i}. [{title}]({url}) (similarity: {similarity:.3f})\n"
-                    full_context = context + sources_text
+                    full_context = _build_full_context(rag_context)
                     augmented_text = augmented_text.replace("{context}", "\n\n" + full_context + "\n\n")
                 else:
                     augmented_text = augmented_text.replace("{context}", "")
@@ -140,18 +178,7 @@ def prompt_processor(
                 prompt = assistant.prompt_template.replace("{user_input}", "\n\n" + user_input_text + "\n\n")
 
                 if rag_context:
-                    context = rag_context.get("context", "") if isinstance(rag_context, dict) else str(rag_context)
-                    sources_text = ""
-                    if isinstance(rag_context, dict) and "sources" in rag_context:
-                        sources = rag_context["sources"]
-                        if sources:
-                            sources_text = "\n\n## Available Sources\n\n"
-                            for i, source in enumerate(sources, 1):
-                                title = source.get("title", "Unknown")
-                                url = source.get("url", "")
-                                similarity = source.get("similarity", 0)
-                                sources_text += f"{i}. [{title}]({url}) (similarity: {similarity:.3f})\n"
-                    full_context = context + sources_text
+                    full_context = _build_full_context(rag_context)
                     prompt = prompt.replace("{context}", "\n\n" + full_context + "\n\n")
                 else:
                     prompt = prompt.replace("{context}", "")
@@ -182,8 +209,8 @@ def prompt_processor(
                     user_input_text = str(last_message)
 
                 prompt = effective_template.replace("{user_input}", "\n\n" + user_input_text + "\n\n")
-                context = rag_context.get("context", "") if isinstance(rag_context, dict) else str(rag_context)
-                prompt = prompt.replace("{context}", "\n\n" + context + "\n\n")
+                full_context = _build_full_context(rag_context)
+                prompt = prompt.replace("{context}", "\n\n" + full_context + "\n\n")
 
                 processed_messages.append({
                     "role": messages[-1]['role'],

--- a/backend/lamb/completions/rag/_ks_query_helpers.py
+++ b/backend/lamb/completions/rag/_ks_query_helpers.py
@@ -77,36 +77,69 @@ async def query_one_ks(
         return {"status": "error", "error": str(e)}
 
 
+def _build_source(ks_id: str, chunk: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a single LAMB-side ``source`` dict from one KB Server chunk."""
+    meta = chunk.get("metadata", {}) or {}
+    source: Dict[str, Any] = {
+        "knowledge_store_id": ks_id,
+        "title": meta.get("source_title")
+                 or meta.get("title")
+                 or meta.get("library_name")
+                 or "Source",
+        "score": chunk.get("score"),
+        "source_item_id": meta.get("source_item_id"),
+    }
+    for key in ("permalink_original", "permalink_markdown", "permalink_page"):
+        if meta.get(key):
+            source[key] = meta[key]
+    if meta.get("library_id"):
+        source["library_id"] = meta["library_id"]
+    if meta.get("library_name"):
+        source["library_name"] = meta["library_name"]
+    primary = (
+        meta.get("permalink_page")
+        or meta.get("permalink_markdown")
+        or meta.get("permalink_original")
+    )
+    if primary:
+        source["url"] = primary
+    return source
+
+
 def _extract_sources(
     ks_id: str,
     results: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     """Build the LAMB-side ``sources`` list from KB Server query results."""
+    return [_build_source(ks_id, chunk) for chunk in results]
+
+
+def build_context_and_sources(
+    ks_results: List[tuple],
+) -> tuple:
+    """Build the numbered RAG context and an aligned ``sources`` list.
+
+    ``ks_results`` is a list of ``(ks_id, chunks)`` pairs for the Knowledge
+    Stores that returned successfully. Every chunk that carries text is given
+    a stable 1-based citation number ``n``: its context block is prefixed with
+    ``[n]`` and the matching source dict carries the same ``n``. This lets the
+    LLM cite inline with ``[N]`` markers while the caller renders a numbered
+    sources list that lines up exactly with those markers.
+
+    Returns ``(combined_context, sources)``.
+    """
+    context_parts: List[str] = []
     sources: List[Dict[str, Any]] = []
-    for chunk in results:
-        meta = chunk.get("metadata", {}) or {}
-        source: Dict[str, Any] = {
-            "knowledge_store_id": ks_id,
-            "title": meta.get("source_title")
-                     or meta.get("title")
-                     or meta.get("library_name")
-                     or "Source",
-            "score": chunk.get("score"),
-            "source_item_id": meta.get("source_item_id"),
-        }
-        for key in ("permalink_original", "permalink_markdown", "permalink_page"):
-            if meta.get(key):
-                source[key] = meta[key]
-        if meta.get("library_id"):
-            source["library_id"] = meta["library_id"]
-        if meta.get("library_name"):
-            source["library_name"] = meta["library_name"]
-        primary = (
-            meta.get("permalink_page")
-            or meta.get("permalink_markdown")
-            or meta.get("permalink_original")
-        )
-        if primary:
-            source["url"] = primary
-        sources.append(source)
-    return sources
+    n = 0
+    for ks_id, chunks in ks_results:
+        for chunk in chunks or []:
+            text = (chunk.get("text") or "").strip()
+            if not text:
+                continue
+            n += 1
+            context_parts.append(f"[{n}] {text}")
+            source = _build_source(ks_id, chunk)
+            source["n"] = n
+            sources.append(source)
+    combined_context = "\n\n".join(context_parts) if context_parts else ""
+    return combined_context, sources

--- a/backend/lamb/completions/rag/knowledge_store_rag.py
+++ b/backend/lamb/completions/rag/knowledge_store_rag.py
@@ -28,7 +28,7 @@ from lamb.logging_config import get_logger
 from lamb.completions.rag._ks_query_helpers import (
     serialize_assistant,
     query_one_ks,
-    _extract_sources,
+    build_context_and_sources,
 )
 
 logger = get_logger(__name__, component="RAG")
@@ -93,8 +93,7 @@ async def _run(
     )
 
     all_responses: Dict[str, Any] = {}
-    sources: List[Dict[str, Any]] = []
-    contexts: List[str] = []
+    successful: List[tuple] = []
 
     for ks_id, result in zip(ks_ids, raw_responses):
         all_responses[ks_id] = result
@@ -102,15 +101,11 @@ async def _run(
             data = result.get("data", {}) or {}
             chunks = data.get("results", []) or []
             logger.info(f"KS {ks_id}: {len(chunks)} chunks returned")
-            sources.extend(_extract_sources(ks_id, chunks))
-            for chunk in chunks:
-                text = chunk.get("text") or ""
-                if text:
-                    contexts.append(text)
+            successful.append((ks_id, chunks))
         else:
             logger.warning(f"KS {ks_id}: {result.get('error', 'unknown error')}")
 
-    combined_context = "\n\n".join(contexts) if contexts else ""
+    combined_context, sources = build_context_and_sources(successful)
 
     return {
         "context": combined_context,

--- a/backend/lamb/completions/rag/query_rewriting_ks_rag.py
+++ b/backend/lamb/completions/rag/query_rewriting_ks_rag.py
@@ -24,7 +24,7 @@ from lamb.logging_config import get_logger
 from lamb.completions.rag._ks_query_helpers import (
     serialize_assistant,
     query_one_ks,
-    _extract_sources,
+    build_context_and_sources,
 )
 from lamb.completions.rag._query_rewriting_helper import generate_optimal_query
 
@@ -86,8 +86,7 @@ async def _run(
     )
 
     all_responses: Dict[str, Any] = {}
-    sources: List[Dict[str, Any]] = []
-    contexts: List[str] = []
+    successful: List[tuple] = []
 
     for ks_id, result in zip(ks_ids, raw_responses):
         all_responses[ks_id] = result
@@ -95,15 +94,11 @@ async def _run(
             data = result.get("data", {}) or {}
             chunks = data.get("results", []) or []
             logger.info(f"KS {ks_id}: {len(chunks)} chunks returned")
-            sources.extend(_extract_sources(ks_id, chunks))
-            for chunk in chunks:
-                text = chunk.get("text") or ""
-                if text:
-                    contexts.append(text)
+            successful.append((ks_id, chunks))
         else:
             logger.warning(f"KS {ks_id}: {result.get('error', 'unknown error')}")
 
-    combined_context = "\n\n".join(contexts) if contexts else ""
+    combined_context, sources = build_context_and_sources(successful)
 
     return {
         "context": combined_context,

--- a/backend/tests/test_ks_query_helpers.py
+++ b/backend/tests/test_ks_query_helpers.py
@@ -1,5 +1,8 @@
 import pytest
-from lamb.completions.rag._ks_query_helpers import _extract_sources
+from lamb.completions.rag._ks_query_helpers import (
+    _extract_sources,
+    build_context_and_sources,
+)
 
 
 class TestExtractSources:
@@ -60,3 +63,48 @@ class TestExtractSources:
         sources = _extract_sources("ks-1", results)
         assert len(sources) == 1
         assert sources[0]["title"] == "Source"
+
+
+class TestBuildContextAndSources:
+    def test_empty_input_returns_empty(self):
+        context, sources = build_context_and_sources([])
+        assert context == ""
+        assert sources == []
+
+    def test_numbers_chunks_and_aligns_sources(self):
+        ks_results = [
+            ("ks-1", [
+                {"text": "first chunk", "score": 0.9, "metadata": {"source_title": "Doc A"}},
+                {"text": "second chunk", "score": 0.8, "metadata": {"source_title": "Doc B"}},
+            ]),
+        ]
+        context, sources = build_context_and_sources(ks_results)
+        # Context blocks are prefixed with their 1-based citation number.
+        assert context == "[1] first chunk\n\n[2] second chunk"
+        # Each source carries the matching n.
+        assert [s["n"] for s in sources] == [1, 2]
+        assert sources[0]["title"] == "Doc A"
+        assert sources[1]["title"] == "Doc B"
+
+    def test_numbering_is_continuous_across_knowledge_stores(self):
+        ks_results = [
+            ("ks-1", [{"text": "a", "score": 0.9, "metadata": {}}]),
+            ("ks-2", [{"text": "b", "score": 0.7, "metadata": {}}]),
+        ]
+        context, sources = build_context_and_sources(ks_results)
+        assert context == "[1] a\n\n[2] b"
+        assert sources[0]["n"] == 1 and sources[0]["knowledge_store_id"] == "ks-1"
+        assert sources[1]["n"] == 2 and sources[1]["knowledge_store_id"] == "ks-2"
+
+    def test_empty_text_chunks_are_skipped(self):
+        ks_results = [
+            ("ks-1", [
+                {"text": "", "score": 0.9, "metadata": {}},
+                {"text": "   ", "score": 0.9, "metadata": {}},
+                {"text": "real", "score": 0.9, "metadata": {}},
+            ]),
+        ]
+        context, sources = build_context_and_sources(ks_results)
+        assert context == "[1] real"
+        assert len(sources) == 1
+        assert sources[0]["n"] == 1

--- a/backend/tests/test_kvcache_augment.py
+++ b/backend/tests/test_kvcache_augment.py
@@ -1,0 +1,105 @@
+"""Tests for the inline-citation rendering in the kvcache_augment PPS."""
+
+from lamb.completions.pps.kvcache_augment import (
+    CITATION_INSTRUCTION,
+    _build_full_context,
+    _format_sources_block,
+    prompt_processor,
+)
+from lamb.lamb_classes import Assistant
+
+
+def _make_assistant(**overrides):
+    defaults = {
+        "id": 1,
+        "name": "Test",
+        "description": "",
+        "system_prompt": "You are helpful.",
+        "prompt_template": "",
+        "RAG_collections": "ks-1",
+        "RAG_Top_k": 3,
+        "owner": "user@test.com",
+        "api_callback": "",
+        "pre_retrieval_endpoint": "",
+        "post_retrieval_endpoint": "",
+        "RAG_endpoint": "",
+    }
+    defaults.update(overrides)
+    return Assistant(**defaults)
+
+
+class TestFormatSourcesBlock:
+    def test_empty_sources_returns_empty(self):
+        assert _format_sources_block([]) == ""
+
+    def test_uses_citation_number_and_renders_score(self):
+        sources = [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.873}]
+        block = _format_sources_block(sources)
+        assert "## Available Sources" in block
+        assert "[1] [Doc A](/docs/a.md)" in block
+        # The relevance score (the KS `score` field) renders — not 0.000.
+        assert "relevance: 0.873" in block
+
+    def test_missing_score_is_omitted_gracefully(self):
+        sources = [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": None}]
+        block = _format_sources_block(sources)
+        assert "[1] [Doc A](/docs/a.md)" in block
+        assert "relevance" not in block
+
+    def test_falls_back_to_enumeration_when_n_absent(self):
+        sources = [{"title": "Doc A", "url": ""}]
+        block = _format_sources_block(sources)
+        assert "[1] Doc A" in block
+
+
+class TestBuildFullContext:
+    def test_appends_sources_block_and_instruction(self):
+        rag_context = {
+            "context": "[1] some retrieved text",
+            "sources": [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.9}],
+        }
+        full = _build_full_context(rag_context)
+        assert "[1] some retrieved text" in full
+        assert "## Available Sources" in full
+        assert CITATION_INSTRUCTION in full
+
+    def test_no_sources_means_no_citation_instruction(self):
+        rag_context = {"context": "plain context", "sources": []}
+        full = _build_full_context(rag_context)
+        assert full == "plain context"
+        assert CITATION_INSTRUCTION not in full
+
+    def test_non_dict_context_is_stringified(self):
+        assert _build_full_context("raw") == "raw"
+        assert _build_full_context(None) == ""
+
+
+class TestPromptProcessorInjection:
+    def test_no_template_branch_injects_sources_and_instruction(self):
+        """Even without a prompt_template, the sources block + citation
+        instruction must reach the model."""
+        assistant = _make_assistant(prompt_template="")
+        request = {"messages": [{"role": "user", "content": "What is X?"}]}
+        rag_context = {
+            "context": "[1] X is a thing.",
+            "sources": [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.9}],
+        }
+        out = prompt_processor(request, assistant=assistant, rag_context=rag_context)
+        user_msg = out[-1]["content"]
+        assert "## Available Sources" in user_msg
+        assert CITATION_INSTRUCTION in user_msg
+        assert "[1] X is a thing." in user_msg
+
+    def test_template_branch_injects_sources_and_instruction(self):
+        assistant = _make_assistant(
+            prompt_template="Context:\n{context}\n\nQ: {user_input}"
+        )
+        request = {"messages": [{"role": "user", "content": "What is X?"}]}
+        rag_context = {
+            "context": "[1] X is a thing.",
+            "sources": [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.9}],
+        }
+        out = prompt_processor(request, assistant=assistant, rag_context=rag_context)
+        user_msg = out[-1]["content"]
+        assert "## Available Sources" in user_msg
+        assert CITATION_INSTRUCTION in user_msg


### PR DESCRIPTION
## Purpose

LAMB never emitted inline `[N]` citations in RAG answers, even when retrieved Knowledge Store context was used (#430). The model was not instructed to cite, retrieved chunks were not numbered, and the sources block was injected inconsistently with a field bug that always printed `0.000` relevance.

## Changes

- **`_ks_query_helpers.py`** — add `build_context_and_sources(ks_results)`, which assigns each retrieved chunk a stable 1-based `n`, prefixes its context block with `[n]`, and stamps the same `n` on the matching source dict so the markers and the sources list line up. Refactor `_extract_sources` to delegate to a shared `_build_source` (behavior unchanged).
- **`knowledge_store_rag.py` / `query_rewriting_ks_rag.py`** — collect the successful `(ks_id, chunks)` results and build context + sources via the shared helper, replacing the two previously-uncorrelated loops.
- **`pps/kvcache_augment.py`** — add `CITATION_INSTRUCTION` telling the model to cite inline with `[N]`; render the numbered `## Available Sources` block and instruction through a single `_build_full_context` helper used by all three branches (vision-template, text-template, and the no-`prompt_template` fallback, which previously dropped the sources block); fix the `similarity` → `score` field bug so relevance renders.

Streaming-safe: connectors still pass `delta.content` through untouched — no answer post-processing. The instruction is only injected when sources exist, so non-RAG answers are never told to fabricate markers. The legacy `simple_rag`/`simple_augment` path is untouched.

## Verification

- `backend/tests/` — new `TestBuildContextAndSources` (numbering, cross-KS continuity, empty-chunk skip, source alignment) and new `test_kvcache_augment.py` (sources block + instruction injected in both template and no-template branches, `score` renders not `0.000`). Existing `test_ks_query_helpers.py` / `test_query_rewriting_ks_rag.py` still green.
- `pytest -k "rag or augment or knowledge_store or ks_query or completion"` → 51 passed.

## Related

- Closes #430