### PR TITLE
refactor(#436): remove dead artifacts from the legacy Create Knowledge wizard

### DIFF
--- a/frontend/svelte-app/src/lib/components/knowledge/CreateKnowledgeWizard.svelte
+++ b/frontend/svelte-app/src/lib/components/knowledge/CreateKnowledgeWizard.svelte
@@ -61,8 +61,8 @@
 	 * @property {boolean} libraryIsShared
 	 * @property {{ pluginName: string, params: Object }} libraryImportConfig
 	 * @property {File[]} pendingFiles
+	 * @property {Record<string, unknown>[]} pendingFileParams
 	 * @property {Array<{ type: 'url'|'youtube', url: string, title?: string, language?: string }>} pendingUrlSources
-	 * @property {Array<{ id: string, title: string }>} uploadedItems
 	 * @property {'existing'|'new'} ksPath
 	 * @property {string} existingKsId
 	 * @property {string} ksName
@@ -88,8 +88,8 @@
 		libraryIsShared: false,
 		libraryImportConfig: { pluginName: '', params: {} },
 		pendingFiles: [],
+		pendingFileParams: [],
 		pendingUrlSources: [],
-		uploadedItems: [],
 		ksPath: 'new',
 		existingKsId: '',
 		ksName: '',

--- a/frontend/svelte-app/src/lib/components/knowledge/wizard/StepLibrarySetup.svelte
+++ b/frontend/svelte-app/src/lib/components/knowledge/wizard/StepLibrarySetup.svelte
@@ -1,11 +1,11 @@
 <!--
   @component StepLibrarySetup
-  Combined Step 1 of the 5-step wizard.
+  Step 1 of the 5-step wizard.
   Radio: "Create new library" / "Use existing library".
 
-  When "Use existing": shows library dropdown (from former Step0).
+  When "Use existing": shows library dropdown.
   When "Create new": shows name + description + sharing toggle + collapsible
-    "Advanced: import plugin & params" (from former Step2).
+    "Advanced: import plugin & params".
 
   Emits:
     - update: partial WizardState patch

--- a/frontend/svelte-app/src/lib/locales/ca.json
+++ b/frontend/svelte-app/src/lib/locales/ca.json
@@ -1257,9 +1257,6 @@
 			"next": "Següent",
 			"back": "Enrere",
 			"skip": "Ometre",
-			"create": "Crear",
-			"cancel": "Cancel·lar",
-			"abort": "Avortar",
 			"useExisting": "Utilitzar un d'existent",
 			"createNew": "Crear-ne un de nou",
 			"advancedLabel": "Configuració avançada",
@@ -1273,57 +1270,9 @@
 				"title": "Aquests ajustos no es poden canviar més tard.",
 				"body": "L'estratègia de fragmentació, el proveïdor/model d'embeddings i la base de dades vectorial queden bloquejats en crear l'Emmagatzematge de Coneixement. Per canviar-los, crea un nou Emmagatzematge."
 			},
-			"editDefaults": "Editar valors per defecte",
-			"progress": "Pas {current} de {total}",
-			"step0": {
-				"title": "Tria una Biblioteca",
-				"description": "Utilitza una Biblioteca existent o crea'n una de nova.",
-				"newLibrary": "Crear una nova Biblioteca",
-				"existingLibrary": "Utilitzar una Biblioteca existent",
-				"pickLibrary": "Tria una Biblioteca"
-			},
-			"step1": {
-				"title": "Detalls de la Biblioteca",
-				"description": "Posa un nom a la teva Biblioteca i una descripció opcional.",
-				"nameLabel": "Nom de la Biblioteca",
-				"descriptionLabel": "Descripció (opcional)",
-				"sharedLabel": "Compartir amb l'organització"
-			},
-			"step2": {
-				"title": "Configuració d'importació de la Biblioteca",
-				"description": "Els valors per defecte funcionen per a la majoria de casos. Expandeix per personalitzar els plugins d'importació.",
-				"defaultPluginLabel": "Plugin d'importació per defecte"
-			},
-			"step3": {
-				"title": "Afegir contingut inicial",
-				"description": "Opcionalment, puja un o més fitxers ara. Sempre en podràs afegir més més tard.",
-				"uploadHint": "Arrossega els fitxers aquí o fes clic per examinar",
-				"uploaded": "pujat",
-				"processing": "processant",
-				"ready": "a punt",
-				"failed": "fallit"
-			},
-			"step4": {
-				"title": "Tria un Magatzem de Coneixement",
-				"description": "Utilitza un Magatzem de Coneixement existent o crea'n un de nou.",
-				"newKs": "Crear un nou Magatzem de Coneixement",
-				"existingKs": "Utilitzar un Magatzem de Coneixement existent",
-				"pickKs": "Tria un Magatzem de Coneixement"
-			},
-			"step5": {
-				"title": "Detalls del Magatzem de Coneixement",
-				"description": "Nom i descripció opcional per al Magatzem de Coneixement.",
-				"nameLabel": "Nom del Magatzem de Coneixement",
-				"descriptionLabel": "Descripció (opcional)",
-				"sharedLabel": "Compartir amb l'organització"
-			},
 			"step6": {
-				"title": "Knowledge Store configuration",
-				"description": "These choices control chunking and embedding. They are LOCKED after creation.",
 				"chunkingLabel": "Chunking strategy",
 				"vectorDbLabel": "Vector DB backend",
-				"embeddingVendorLabel": "Embedding vendor",
-				"embeddingModelLabel": "Embedding model",
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
@@ -1331,22 +1280,16 @@
 			},
 			"step7": {
 				"title": "Tria elements per ingerir",
-				"description": "Tria quins elements de la biblioteca indexar al Magatzem de Coneixement.",
-				"allItems": "Tots els elements"
+				"description": "Tria quins elements de la biblioteca indexar al Magatzem de Coneixement."
 			},
 			"step8": {
 				"title": "Review & create",
 				"description": "Review your choices below. Click Create to proceed.",
 				"libraryHeading": "Library",
 				"ksHeading": "Knowledge Store",
-				"itemsHeading": "Items to ingest",
 				"itemsToIngest": "Elements a ingerir",
 				"submit": "Create",
-				"submitting": "Creating...",
 				"heading": "Review & create",
-				"ingestionHeading": "Ingestion",
-				"ingestionCount": "{n} item(s) will be ingested",
-				"libraryPlugin": "Import plugin: {plugin}",
 				"libraryFileCount": "{n} file(s) to upload",
 				"libraryUrlCount": "{n} URL/YouTube source(s) to import",
 				"progressLibrary": "Creating library...",
@@ -1358,25 +1301,17 @@
 				"retry": "Torna a intentar"
 			},
 			"step9": {
-				"title": "Tot llest",
 				"heading": "Tot a punt",
 				"description": "La teva Biblioteca i el Magatzem de Coneixement estan a punt. La ingesta s'executa en segon pla — pots veure el progrés a la pàgina del Magatzem de Coneixement.",
-				"openKs": "Obrir Magatzem de Coneixement",
 				"openLibrary": "Obrir Biblioteca",
 				"createAnother": "Crear-ne un altre",
 				"toast": "Magatzem de Coneixement creat."
 			},
-			"stepProgress": "Pas {n} de {total}",
 			"creating": "Creant...",
 			"draft": {
 				"banner": "Tens un esborrany sense acabar de {time}.",
 				"resume": "Reprendre",
-				"discard": "Descartar",
-				"savePrompt": {
-					"title": "Desar com a esborrany?",
-					"body": "El teu progrés es guardarà fins que tanquis la sessió o la pestanya.",
-					"save": "Desar esborrany"
-				}
+				"discard": "Descartar"
 			},
 			"libraryStep": {
 				"title": "Configuració de Biblioteca",
@@ -1393,22 +1328,15 @@
 				"shareHint": "Ho pots canviar més tard des de la vista de detall de la Biblioteca.",
 				"advancedLabel": "Avançat: complement d'importació i paràmetres",
 				"noPlugins": "No hi ha complements d'importació disponibles.",
-				"pluginLabel": "Complement d'importació",
-				"pluginNote": "Els paràmetres per complement es poden personalitzar més tard des de la vista de detall de la biblioteca."
+				"pluginLabel": "Complement d'importació"
 			},
 			"libraryContent": {
 				"title": "Contingut de Biblioteca",
 				"heading": "Contingut inicial",
-				"description": "Afegeix contingut a la teva nova Biblioteca ara (opcional). També pots ometre-ho i afegir contingut més tard.",
-				"sourceTypeFiles": "Fitxers",
-				"sourceTypeUrl": "URL",
-				"sourceTypeYouTube": "YouTube",
-				"pickLabel": "Seleccionar fitxers",
 				"invalidUrl": "Es requereix una URL HTTP(S) vàlida.",
 				"invalidYoutubeUrl": "Es requereix una URL de YouTube vàlida.",
 				"titleOptional": "Títol (opcional)",
 				"youtubeUrl": "URL de YouTube",
-				"ytLanguage": "Idioma de la transcripció",
 				"addUrl": "+ Afegir URL",
 				"addYouTube": "+ Afegir YouTube",
 				"queuedLabel": "Fonts a la cua",

--- a/frontend/svelte-app/src/lib/locales/en.json
+++ b/frontend/svelte-app/src/lib/locales/en.json
@@ -1257,9 +1257,6 @@
 			"next": "Next",
 			"back": "Back",
 			"skip": "Skip",
-			"create": "Create",
-			"cancel": "Cancel",
-			"abort": "Abort",
 			"useExisting": "Use an existing",
 			"createNew": "Create new",
 			"advancedLabel": "Advanced settings",
@@ -1273,57 +1270,9 @@
 				"title": "These settings cannot be changed later.",
 				"body": "Chunking strategy, embedding vendor / model, and vector DB are locked once the Knowledge Store is created. To change them, create a new Knowledge Store."
 			},
-			"editDefaults": "Edit defaults",
-			"progress": "Step {current} of {total}",
-			"step0": {
-				"title": "Choose a Library",
-				"description": "Use an existing Library or create a new one.",
-				"newLibrary": "Create a new Library",
-				"existingLibrary": "Use an existing Library",
-				"pickLibrary": "Pick a Library"
-			},
-			"step1": {
-				"title": "Library details",
-				"description": "Give your Library a name and an optional description.",
-				"nameLabel": "Library name",
-				"descriptionLabel": "Description (optional)",
-				"sharedLabel": "Share with organization"
-			},
-			"step2": {
-				"title": "Library import settings",
-				"description": "Defaults work for most cases. Expand to customise import plugins.",
-				"defaultPluginLabel": "Default import plugin"
-			},
-			"step3": {
-				"title": "Add initial content",
-				"description": "Optionally upload one or more files now. You can always add more later.",
-				"uploadHint": "Drop files here or click to browse",
-				"uploaded": "uploaded",
-				"processing": "processing",
-				"ready": "ready",
-				"failed": "failed"
-			},
-			"step4": {
-				"title": "Choose a Knowledge Store",
-				"description": "Use an existing Knowledge Store or create a new one.",
-				"newKs": "Create a new Knowledge Store",
-				"existingKs": "Use an existing Knowledge Store",
-				"pickKs": "Pick a Knowledge Store"
-			},
-			"step5": {
-				"title": "Knowledge Store details",
-				"description": "Name and optional description for the Knowledge Store.",
-				"nameLabel": "Knowledge Store name",
-				"descriptionLabel": "Description (optional)",
-				"sharedLabel": "Share with organization"
-			},
 			"step6": {
-				"title": "Knowledge Store configuration",
-				"description": "These choices control chunking and embedding. They are LOCKED after creation.",
 				"chunkingLabel": "Chunking strategy",
 				"vectorDbLabel": "Vector DB backend",
-				"embeddingVendorLabel": "Embedding vendor",
-				"embeddingModelLabel": "Embedding model",
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
@@ -1331,22 +1280,16 @@
 			},
 			"step7": {
 				"title": "Pick items to index",
-				"description": "Choose which library items to index in the Knowledge Store.",
-				"allItems": "All items"
+				"description": "Choose which library items to index in the Knowledge Store."
 			},
 			"step8": {
 				"title": "Review & create",
 				"description": "Review your choices below. Click Create to proceed.",
 				"libraryHeading": "Library",
 				"ksHeading": "Knowledge Store",
-				"itemsHeading": "Items to index",
 				"itemsToIngest": "Items to index",
 				"submit": "Create",
-				"submitting": "Creating...",
 				"heading": "Review & create",
-				"ingestionHeading": "Ingestion",
-				"ingestionCount": "{n} item(s) will be ingested",
-				"libraryPlugin": "Import plugin: {plugin}",
 				"libraryFileCount": "{n} file(s) to upload",
 				"libraryUrlCount": "{n} URL/YouTube source(s) to import",
 				"progressLibrary": "Creating library...",
@@ -1358,25 +1301,17 @@
 				"retry": "Retry"
 			},
 			"step9": {
-				"title": "All done",
 				"heading": "You're all set",
 				"description": "Your Library and Knowledge Store are ready. Ingestion runs in the background — you can check progress on the Knowledge Store page.",
-				"openKs": "Open Knowledge Store",
 				"openLibrary": "Open Library",
 				"createAnother": "Create another",
 				"toast": "Knowledge Store created."
 			},
-			"stepProgress": "Step {n} of {total}",
 			"creating": "Creating...",
 			"draft": {
 				"banner": "You have an unfinished draft from {time}.",
 				"resume": "Resume",
-				"discard": "Discard",
-				"savePrompt": {
-					"title": "Save as draft?",
-					"body": "Your progress will be saved until you log out or close the tab.",
-					"save": "Save draft"
-				}
+				"discard": "Discard"
 			},
 			"libraryStep": {
 				"title": "Library Setup",
@@ -1393,22 +1328,15 @@
 				"shareHint": "You can change this later from the Library detail view.",
 				"advancedLabel": "Advanced: import plugin & params",
 				"noPlugins": "No import plugins available.",
-				"pluginLabel": "Import plugin",
-				"pluginNote": "Per-plugin parameters can be customized later from the library detail view."
+				"pluginLabel": "Import plugin"
 			},
 			"libraryContent": {
 				"title": "Library Content",
 				"heading": "Initial content",
-				"description": "Optionally add content to your new Library now. You can also skip this and add content later.",
-				"sourceTypeFiles": "Files",
-				"sourceTypeUrl": "URL",
-				"sourceTypeYouTube": "YouTube",
-				"pickLabel": "Pick files",
 				"invalidUrl": "A valid HTTP(S) URL is required.",
 				"invalidYoutubeUrl": "A valid YouTube URL is required.",
 				"titleOptional": "Title (optional)",
 				"youtubeUrl": "YouTube URL",
-				"ytLanguage": "Transcript language",
 				"addUrl": "+ Add URL",
 				"addYouTube": "+ Add YouTube",
 				"queuedLabel": "Queued sources",

--- a/frontend/svelte-app/src/lib/locales/es.json
+++ b/frontend/svelte-app/src/lib/locales/es.json
@@ -1257,9 +1257,6 @@
 			"next": "Siguiente",
 			"back": "Atrás",
 			"skip": "Omitir",
-			"create": "Crear",
-			"cancel": "Cancelar",
-			"abort": "Abortar",
 			"useExisting": "Usar uno existente",
 			"createNew": "Crear nuevo",
 			"advancedLabel": "Configuración avanzada",
@@ -1273,57 +1270,9 @@
 				"title": "Estos ajustes no se pueden cambiar después.",
 				"body": "La estrategia de fragmentación, el proveedor/modelo de embeddings y la base de datos vectorial quedan bloqueados al crear el Almacén de Conocimiento. Para cambiarlos, crea un nuevo Almacén."
 			},
-			"editDefaults": "Editar valores por defecto",
-			"progress": "Paso {current} de {total}",
-			"step0": {
-				"title": "Elige una Biblioteca",
-				"description": "Usa una Biblioteca existente o crea una nueva.",
-				"newLibrary": "Crear una nueva Biblioteca",
-				"existingLibrary": "Usar una Biblioteca existente",
-				"pickLibrary": "Elige una Biblioteca"
-			},
-			"step1": {
-				"title": "Detalles de la Biblioteca",
-				"description": "Dale un nombre a tu Biblioteca y una descripción opcional.",
-				"nameLabel": "Nombre de la Biblioteca",
-				"descriptionLabel": "Descripción (opcional)",
-				"sharedLabel": "Compartir con la organización"
-			},
-			"step2": {
-				"title": "Configuración de importación de la Biblioteca",
-				"description": "Los valores por defecto funcionan en la mayoría de los casos. Expande para personalizar los plugins de importación.",
-				"defaultPluginLabel": "Plugin de importación por defecto"
-			},
-			"step3": {
-				"title": "Añadir contenido inicial",
-				"description": "Opcionalmente, sube uno o varios archivos ahora. Siempre podrás añadir más más tarde.",
-				"uploadHint": "Arrastra archivos aquí o haz clic para examinar",
-				"uploaded": "subido",
-				"processing": "procesando",
-				"ready": "listo",
-				"failed": "fallido"
-			},
-			"step4": {
-				"title": "Elige un Almacén de Conocimiento",
-				"description": "Usa un Almacén de Conocimiento existente o crea uno nuevo.",
-				"newKs": "Crear un nuevo Almacén de Conocimiento",
-				"existingKs": "Usar un Almacén de Conocimiento existente",
-				"pickKs": "Elige un Almacén de Conocimiento"
-			},
-			"step5": {
-				"title": "Detalles del Almacén de Conocimiento",
-				"description": "Nombre y descripción opcional para el Almacén de Conocimiento.",
-				"nameLabel": "Nombre del Almacén de Conocimiento",
-				"descriptionLabel": "Descripción (opcional)",
-				"sharedLabel": "Compartir con la organización"
-			},
 			"step6": {
-				"title": "Knowledge Store configuration",
-				"description": "These choices control chunking and embedding. They are LOCKED after creation.",
 				"chunkingLabel": "Chunking strategy",
 				"vectorDbLabel": "Vector DB backend",
-				"embeddingVendorLabel": "Embedding vendor",
-				"embeddingModelLabel": "Embedding model",
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
@@ -1331,22 +1280,16 @@
 			},
 			"step7": {
 				"title": "Elige elementos para ingerir",
-				"description": "Elige qué elementos de la biblioteca indexar en el Almacén de Conocimiento.",
-				"allItems": "Todos los elementos"
+				"description": "Elige qué elementos de la biblioteca indexar en el Almacén de Conocimiento."
 			},
 			"step8": {
 				"title": "Review & create",
 				"description": "Review your choices below. Click Create to proceed.",
 				"libraryHeading": "Library",
 				"ksHeading": "Knowledge Store",
-				"itemsHeading": "Items to ingest",
 				"itemsToIngest": "Elementos a ingerir",
 				"submit": "Create",
-				"submitting": "Creating...",
 				"heading": "Review & create",
-				"ingestionHeading": "Ingestion",
-				"ingestionCount": "{n} item(s) will be ingested",
-				"libraryPlugin": "Import plugin: {plugin}",
 				"libraryFileCount": "{n} file(s) to upload",
 				"libraryUrlCount": "{n} URL/YouTube source(s) to import",
 				"progressLibrary": "Creating library...",
@@ -1358,25 +1301,17 @@
 				"retry": "Reintentar"
 			},
 			"step9": {
-				"title": "Todo listo",
 				"heading": "¡Todo listo!",
 				"description": "Tu Biblioteca y Almacén de Conocimiento están listos. La ingesta se ejecuta en segundo plano — puedes ver el progreso en la página del Almacén de Conocimiento.",
-				"openKs": "Abrir Almacén de Conocimiento",
 				"openLibrary": "Abrir Biblioteca",
 				"createAnother": "Crear otro",
 				"toast": "Almacén de Conocimiento creado."
 			},
-			"stepProgress": "Paso {n} de {total}",
 			"creating": "Creando...",
 			"draft": {
 				"banner": "Tienes un borrador sin terminar de {time}.",
 				"resume": "Retomar",
-				"discard": "Descartar",
-				"savePrompt": {
-					"title": "¿Guardar como borrador?",
-					"body": "Tu progreso se guardará hasta que cierres sesión o la pestaña.",
-					"save": "Guardar borrador"
-				}
+				"discard": "Descartar"
 			},
 			"libraryStep": {
 				"title": "Configuración de Biblioteca",
@@ -1393,22 +1328,15 @@
 				"shareHint": "Puedes cambiarlo más tarde desde la vista de detalle de la Biblioteca.",
 				"advancedLabel": "Avanzado: plugin de importación y parámetros",
 				"noPlugins": "No hay plugins de importación disponibles.",
-				"pluginLabel": "Plugin de importación",
-				"pluginNote": "Los parámetros por plugin se pueden personalizar más tarde desde la vista de detalle de la biblioteca."
+				"pluginLabel": "Plugin de importación"
 			},
 			"libraryContent": {
 				"title": "Contenido de Biblioteca",
 				"heading": "Contenido inicial",
-				"description": "Añade contenido a tu nueva Biblioteca ahora (opcional). También puedes omitir esto y añadir contenido más tarde.",
-				"sourceTypeFiles": "Archivos",
-				"sourceTypeUrl": "URL",
-				"sourceTypeYouTube": "YouTube",
-				"pickLabel": "Seleccionar archivos",
 				"invalidUrl": "Se requiere una URL HTTP(S) válida.",
 				"invalidYoutubeUrl": "Se requiere una URL de YouTube válida.",
 				"titleOptional": "Título (opcional)",
 				"youtubeUrl": "URL de YouTube",
-				"ytLanguage": "Idioma de la transcripción",
 				"addUrl": "+ Añadir URL",
 				"addYouTube": "+ Añadir YouTube",
 				"queuedLabel": "Fuentes en cola",

--- a/frontend/svelte-app/src/lib/locales/eu.json
+++ b/frontend/svelte-app/src/lib/locales/eu.json
@@ -1257,9 +1257,6 @@
 			"next": "Hurrengoa",
 			"back": "Atzera",
 			"skip": "Saltatu",
-			"create": "Sortu",
-			"cancel": "Utzi",
-			"abort": "Bertan behera utzi",
 			"useExisting": "Erabili lehendik dagoen bat",
 			"createNew": "Sortu berri bat",
 			"advancedLabel": "Ezarpen aurreratuak",
@@ -1273,57 +1270,9 @@
 				"title": "Ezarpen hauek ezin dira geroago aldatu.",
 				"body": "Zatiketa-estrategia, txertaketa-hornitzaile/eredua eta datu-base bektoriala Knowledge Store sortzen denean blokeatzen dira. Aldatzeko, sortu Knowledge Store berri bat."
 			},
-			"editDefaults": "Lehenetsiak editatu",
-			"progress": "{current}. urratsa, {total}etik",
-			"step0": {
-				"title": "Aukeratu Liburutegi bat",
-				"description": "Erabili lehendik dagoen Liburutegi bat edo sortu berri bat.",
-				"newLibrary": "Sortu Liburutegi berri bat",
-				"existingLibrary": "Erabili lehendik dagoen Liburutegi bat",
-				"pickLibrary": "Aukeratu Liburutegi bat"
-			},
-			"step1": {
-				"title": "Liburutegiaren xehetasunak",
-				"description": "Eman izen bat zure Liburutegiari eta deskribapen aukerakoa.",
-				"nameLabel": "Liburutegiaren izena",
-				"descriptionLabel": "Deskribapena (aukerakoa)",
-				"sharedLabel": "Erakundearekin partekatu"
-			},
-			"step2": {
-				"title": "Liburutegiaren inportazio-ezarpenak",
-				"description": "Lehenetsiak kasu gehienetan funtzionatzen dute. Zabaldu inportazio-pluginak pertsonalizatzeko.",
-				"defaultPluginLabel": "Inportazio-plugin lehenetsia"
-			},
-			"step3": {
-				"title": "Hasierako edukia gehitu",
-				"description": "Aukeran, igo fitxategi bat edo gehiago orain. Beti gehiago gehi ditzakezu geroago.",
-				"uploadHint": "Jaregin fitxategiak hemen edo egin klik arakatzeko",
-				"uploaded": "igota",
-				"processing": "prozesatzen",
-				"ready": "prest",
-				"failed": "huts egin du"
-			},
-			"step4": {
-				"title": "Aukeratu Ezagutza-biltegi bat",
-				"description": "Erabili lehendik dagoen Ezagutza-biltegi bat edo sortu berri bat.",
-				"newKs": "Sortu Ezagutza-biltegi berri bat",
-				"existingKs": "Erabili lehendik dagoen Ezagutza-biltegi bat",
-				"pickKs": "Aukeratu Ezagutza-biltegi bat"
-			},
-			"step5": {
-				"title": "Ezagutza-biltegiaren xehetasunak",
-				"description": "Ezagutza-biltegiaren izena eta deskribapen aukerakoa.",
-				"nameLabel": "Ezagutza-biltegiaren izena",
-				"descriptionLabel": "Deskribapena (aukerakoa)",
-				"sharedLabel": "Erakundearekin partekatu"
-			},
 			"step6": {
-				"title": "Knowledge Store configuration",
-				"description": "These choices control chunking and embedding. They are LOCKED after creation.",
 				"chunkingLabel": "Chunking strategy",
 				"vectorDbLabel": "Vector DB backend",
-				"embeddingVendorLabel": "Embedding vendor",
-				"embeddingModelLabel": "Embedding model",
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
@@ -1331,22 +1280,16 @@
 			},
 			"step7": {
 				"title": "Aukeratu ingeritzeko elementuak",
-				"description": "Aukeratu zein liburutegiko elementu indexatu Ezagutza-biltegian.",
-				"allItems": "Elementu guztiak"
+				"description": "Aukeratu zein liburutegiko elementu indexatu Ezagutza-biltegian."
 			},
 			"step8": {
 				"title": "Review & create",
 				"description": "Review your choices below. Click Create to proceed.",
 				"libraryHeading": "Library",
 				"ksHeading": "Knowledge Store",
-				"itemsHeading": "Items to ingest",
 				"itemsToIngest": "Ingeritzeko elementuak",
 				"submit": "Create",
-				"submitting": "Creating...",
 				"heading": "Review & create",
-				"ingestionHeading": "Ingestion",
-				"ingestionCount": "{n} item(s) will be ingested",
-				"libraryPlugin": "Import plugin: {plugin}",
 				"libraryFileCount": "{n} file(s) to upload",
 				"libraryUrlCount": "{n} URL/YouTube source(s) to import",
 				"progressLibrary": "Creating library...",
@@ -1358,25 +1301,17 @@
 				"retry": "Saiatu berriro"
 			},
 			"step9": {
-				"title": "Dena prest",
 				"heading": "Dena prest dago",
 				"description": "Zure Liburutegia eta Ezagutza-biltegia prest daude. Ingestioa atzeko planoan exekutatzen da — aurrerapena Ezagutza-biltegiaren orrian ikus dezakezu.",
-				"openKs": "Ezagutza-biltegia ireki",
 				"openLibrary": "Liburutegia ireki",
 				"createAnother": "Beste bat sortu",
 				"toast": "Ezagutza-biltegia sortuta."
 			},
-			"stepProgress": "{n}. urratsa {total}etik",
 			"creating": "Sortzen...",
 			"draft": {
 				"banner": "Bukaeratu gabeko zirriborro bat duzu {time}tik.",
 				"resume": "Jarraitu",
-				"discard": "Baztertu",
-				"savePrompt": {
-					"title": "Zirriborro gisa gorde?",
-					"body": "Zure aurrerapena gordeta egongo da saioa edo fitxa itxi arte.",
-					"save": "Zirriborroa gorde"
-				}
+				"discard": "Baztertu"
 			},
 			"libraryStep": {
 				"title": "Liburutegiaren konfigurazioa",
@@ -1393,22 +1328,15 @@
 				"shareHint": "Geroago alda dezakezu Liburutegiaren xehetasun ikuspegitik.",
 				"advancedLabel": "Aurreratua: inportazio plugina eta parametroak",
 				"noPlugins": "Ez dago inportazio pluginik.",
-				"pluginLabel": "Inportazio plugina",
-				"pluginNote": "Plugin bakoitzeko parametroak geroago pertsonaliza daitezke liburutegiaren xehetasun ikuspegitik."
+				"pluginLabel": "Inportazio plugina"
 			},
 			"libraryContent": {
 				"title": "Liburutegiaren edukia",
 				"heading": "Hasierako edukia",
-				"description": "Gehitu edukia zure Liburutegi berriari orain (aukerakoa). Edukia geroago ere gehi dezakezu.",
-				"sourceTypeFiles": "Fitxategiak",
-				"sourceTypeUrl": "URL",
-				"sourceTypeYouTube": "YouTube",
-				"pickLabel": "Fitxategiak hautatu",
 				"invalidUrl": "HTTP(S) URL baliodun bat behar da.",
 				"invalidYoutubeUrl": "YouTube URL baliodun bat behar da.",
 				"titleOptional": "Izenburua (aukerakoa)",
 				"youtubeUrl": "YouTube URL",
-				"ytLanguage": "Transkripzioaren hizkuntza",
 				"addUrl": "+ URL gehitu",
 				"addYouTube": "+ YouTube gehitu",
 				"queuedLabel": "Iturri ilarakoak",


### PR DESCRIPTION
## Purpose

The "Create Knowledge" wizard was once a longer multi-step flow and is now a 5-step (3–5 visible) state machine. This removes the leftover dead artifacts (#436) so the wizard's i18n and state reflect what's actually rendered.

## Changes

- **Locales (`en/es/ca/eu.json`)** — remove 58 orphaned `knowledge.wizard.*` keys: the entire `step0`–`step5` namespaces, dead leaves in `step6`–`step9`/`libraryContent`/`libraryStep`/`draft.savePrompt`, and stale top-level keys (`abort`, `cancel`, `create`, `editDefaults`, `progress`, `stepProgress`). The dead set was computed as *defined-in-en minus referenced-in-code* (no dynamic key construction exists), then removed from all four locales. Only the `knowledge.wizard` block is rewritten — every other byte of each file is preserved, so the diff is just the removed keys + trailing-comma rebalancing.
- **`CreateKnowledgeWizard.svelte`** — drop the dead `uploadedItems` field (declared but never read/written) and declare the used-but-undeclared `pendingFileParams` (used by `StepLibraryContent` + `Step8_ReviewCreate`).
- **`StepLibrarySetup.svelte`** — fix stale comments referencing "former Step0/Step2".

No behavior change; no live key removed.

## Verification

- Confirmed no dynamic `knowledge.wizard.*` key construction, so static reference analysis is complete.
- All four locale files re-validate as JSON; diff touches only the wizard block.
- `npx vitest run StepKSContent.svelte.test.js` → 5 passed.
- `svelte-check`: no new errors/warnings in the changed files (project-wide pre-existing errors unchanged).
- `prettier --check` clean on both changed `.svelte` files. (The locale JSON files already fail `prettier --check` on the integration branch — a pre-existing, unrelated formatting state — so this PR deliberately preserves their existing indentation rather than reformatting.)

## Related

- Closes #436