### PR TITLE
fix(#438): localize Create Knowledge wizard and KS UI (es/ca/eu)

### DIFF
--- a/frontend/svelte-app/src/lib/locales/ca.json
+++ b/frontend/svelte-app/src/lib/locales/ca.json
@@ -367,6 +367,8 @@
 		"close": "Tancar"
 	},
 	"common": {
+		"close": "Tancar",
+		"next": "Següent",
 		"loading": "Carregant...",
 		"error": "S'ha produït un error",
 		"success": "Èxit!",
@@ -1224,7 +1226,17 @@
 			"itemsIngested": "elements ingerits",
 			"runInBackground": "Continuar en segon pla",
 			"retry": "Tornar a intentar la ingestió",
-			"backgroundToast": "La ingestió continua en segon pla. Pots seguir el progrés a la pàgina del Magatzem de Coneixement."
+			"backgroundToast": "La ingestió continua en segon pla. Pots seguir el progrés a la pàgina del Magatzem de Coneixement.",
+			"done": "Indexació completada",
+			"etaHeuristic": "~1–2 min per element",
+			"etaMinutes": "~{n} min restants",
+			"etaSeconds": "~{n}s restants",
+			"ingesting": "indexant",
+			"ofConnector": "de",
+			"processing": "Processant contingut…",
+			"retryComingSoon": "La funció de reintentar estarà disponible aviat.",
+			"retryQueued": "Reintent a la cua.",
+			"viewKs": "Veure el Magatzem de Coneixement"
 		},
 		"removeModal": {
 			"title": "Treure del Magatzem de Coneixement",
@@ -1243,7 +1255,54 @@
 			"noItems": "Selecciona almenys un element.",
 			"noItems2": "Aquesta biblioteca no té elements a punt per ingerir.",
 			"submit": "Afegir al Magatzem de Coneixement",
-			"submitting": "Afegint..."
+			"submitting": "Afegint...",
+			"duplicateWarning1": "1 element ja és en aquest Magatzem de Coneixement i s'ometrà.",
+			"duplicateWarningN": "{n} elements ja són en aquest Magatzem de Coneixement i s'ometran.",
+			"emptyTag": "(buit — res a afegir)",
+			"fromLibrary": "De la biblioteca:",
+			"itemPlural": "elements",
+			"itemSingular": "element",
+			"libraryAllFailedHint": "Tots els elements d'aquesta biblioteca han fallat en importar-se. Torna enrere i tria una altra biblioteca.",
+			"libraryEmptyHint": "Aquesta biblioteca no té elements a punt per indexar. Torna enrere i tria una altra biblioteca, o importa-hi contingut primer.",
+			"libraryHint": "Tria la biblioteca que conté els elements a indexar.",
+			"libraryRequired": "Tria una biblioteca per continuar.",
+			"reviewHint": "Revisa què s'indexarà i després fes clic a Afegir.",
+			"reviewItems": "Elements a indexar",
+			"stepItems": "Elements",
+			"stepLibrary": "Biblioteca",
+			"stepReview": "Revisar"
+		},
+		"addDescription": "Afegir descripció",
+		"chunkingParams": "Paràmetres de fragmentació",
+		"collapseDetail": "Amaga la configuració bloquejada",
+		"deletedSuffix": "(eliminat)",
+		"editDescription": "Edita la descripció",
+		"editName": "Edita el nom",
+		"expandDetail": "Mostra la configuració bloquejada",
+		"filterLibrary": "Biblioteca",
+		"filterLibraryAll": "Totes les biblioteques",
+		"filterLibraryClear": "Esborra el filtre",
+		"lockedConfigHint": "La configuració es bloqueja després de la creació",
+		"nameRequired": "El nom és obligatori.",
+		"noContentForLibrary": "Cap element de la biblioteca seleccionada no està vinculat a aquest Magatzem de Coneixement.",
+		"results": "Resultats",
+		"totalChunks": "Total de fragments",
+		"viewItem": "Veure l'element",
+		"items": {
+			"title": "Elements"
+		},
+		"options": {
+			"unavailableBody": "Servidor de Magatzems de Coneixement no disponible. Assegura't que lamb-kb-server s'estigui executant i torna-ho a provar.",
+			"unavailableTitle": "Servidor de Magatzems de Coneixement no disponible"
+		},
+		"params": {
+			"editButton": "Edita",
+			"editNotice": "Els canvis només s'apliquen al contingut indexat després de desar; els fragments existents conserven els paràmetres amb què es van crear.",
+			"noParams": "Aquesta estratègia no té paràmetres editables.",
+			"saveFailed": "No s'han pogut actualitzar els paràmetres de fragmentació.",
+			"saved": "Paràmetres de fragmentació actualitzats. Només s'apliquen a les noves indexacions.",
+			"schemaFailed": "No s'ha pogut carregar l'esquema de paràmetres de fragmentació. Torna-ho a provar més tard.",
+			"usingDefaults": "Utilitzant els valors per defecte de l'estratègia."
 		}
 	},
 	"knowledge": {
@@ -1268,7 +1327,8 @@
 			},
 			"lockedConfigNotice": {
 				"title": "Aquests ajustos no es poden canviar més tard.",
-				"body": "L'estratègia de fragmentació, el proveïdor/model d'embeddings i la base de dades vectorial queden bloquejats en crear l'Emmagatzematge de Coneixement. Per canviar-los, crea un nou Emmagatzematge."
+				"body": "L'estratègia de fragmentació, el proveïdor/model d'embeddings i la base de dades vectorial queden bloquejats en crear l'Emmagatzematge de Coneixement. Per canviar-los, crea un nou Emmagatzematge.",
+				"paramsBody": "Els paràmetres de fragmentació es poden editar més tard, però els canvis només s'apliquen al contingut acabat d'indexar; els fragments existents conserven els paràmetres amb què es van crear originalment."
 			},
 			"step6": {
 				"chunkingLabel": "Chunking strategy",
@@ -1276,11 +1336,15 @@
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
-				"noVendorConfigured": "La teva organització no té proveïdors d'embeddings configurats. Demana a un administrador que afegeixi una clau d'API a la configuració de l'organització."
+				"noVendorConfigured": "La teva organització no té proveïdors d'embeddings configurats. Demana a un administrador que afegeixi una clau d'API a la configuració de l'organització.",
+				"modelRequired": "L'API no ha retornat cap model per a aquest proveïdor; escriu un nom de model per continuar."
 			},
 			"step7": {
 				"title": "Tria elements per ingerir",
-				"description": "Tria quins elements de la biblioteca indexar al Magatzem de Coneixement."
+				"description": "Tria quins elements de la biblioteca indexar al Magatzem de Coneixement.",
+				"heading": "Selecciona elements per indexar",
+				"newBadge": "NOU",
+				"noItems": "Aquesta biblioteca no té elements a punt. Pots ometre aquest pas i afegir contingut més tard."
 			},
 			"step8": {
 				"title": "Review & create",
@@ -1298,14 +1362,19 @@
 				"progressImportUrl": "Importing {url} ({n}/{total})...",
 				"progressKS": "Creating Knowledge Store...",
 				"progressIngest": "Queuing {n} item(s) for ingestion...",
-				"retry": "Torna a intentar"
+				"retry": "Torna a intentar",
+				"ksNameTaken": "Ja existeix un Magatzem de Coneixement anomenat \"{name}\".",
+				"libraryNameTaken": "Ja existeix una biblioteca anomenada \"{name}\".",
+				"pluginAuto": "Seleccionat automàticament",
+				"submitAdd": "Afegir"
 			},
 			"step9": {
 				"heading": "Tot a punt",
 				"description": "La teva Biblioteca i el Magatzem de Coneixement estan a punt. La ingesta s'executa en segon pla — pots veure el progrés a la pàgina del Magatzem de Coneixement.",
 				"openLibrary": "Obrir Biblioteca",
 				"createAnother": "Crear-ne un altre",
-				"toast": "Magatzem de Coneixement creat."
+				"toast": "Magatzem de Coneixement creat.",
+				"openKS": "Obrir Magatzem de Coneixement"
 			},
 			"creating": "Creant...",
 			"draft": {
@@ -1328,7 +1397,10 @@
 				"shareHint": "Ho pots canviar més tard des de la vista de detall de la Biblioteca.",
 				"advancedLabel": "Avançat: complement d'importació i paràmetres",
 				"noPlugins": "No hi ha complements d'importació disponibles.",
-				"pluginLabel": "Complement d'importació"
+				"pluginLabel": "Complement d'importació",
+				"descriptionLabel": "Descripció",
+				"pluginParamsHint": "Els valors per defecte provenen del connector i funcionen per a la majoria de documents; canvia'ls només si cal.",
+				"pluginParamsLabel": "Paràmetres del connector"
 			},
 			"libraryContent": {
 				"title": "Contingut de Biblioteca",
@@ -1343,7 +1415,14 @@
 				"queuedSources": "Fonts a la cua",
 				"optionalHint": "Afegir contingut aquí és opcional — també pots afegir fitxers, URLs o transcripcions de YouTube més tard des de la vista de detall de la Biblioteca. Nota: un Knowledge Store només pot ingerir elements que existeixin a la seva Biblioteca, per tant el que ometis ara hauràs d'afegir-ho abans a la Biblioteca.",
 				"uploadNote": "El contingut s'importarà quan facis clic a \"Crear\" al pas de Revisió.",
-				"emptyHint": "No hi ha contingut a la cua. Pots ometre aquest pas."
+				"emptyHint": "No hi ha contingut a la cua. Pots ometre aquest pas.",
+				"dropHint": "Pots afegir diversos fitxers; s'importaran quan facis clic a Crear.",
+				"dropTitle": "Deixa anar fitxers aquí o fes clic per pujar-los",
+				"noPlugins": "No hi ha cap connector d'importació habilitat actualment.",
+				"perFileParams": "Paràmetres del connector per fitxer",
+				"pluginLabel": "Connector d'importació",
+				"pluginParamsHint": "Els valors per defecte provenen del connector i funcionen per a la majoria de documents; canvia'ls només si cal.",
+				"pluginParamsLabel": "Paràmetres del connector"
 			},
 			"ksStep": {
 				"title": "Configuració d'Emmagatzematge de Coneixement",
@@ -1360,8 +1439,15 @@
 				"shareHint": "Ho pots canviar més tard des de la vista de detall de l'Emmagatzematge de Coneixement.",
 				"vectorIndexingLabel": "Indexació vectorial: fragmentació, proveïdor/model d'embeddings, base de dades vectorial",
 				"otherIndexingLabel": "Una altra estratègia d'indexació (properament)",
-				"otherIndexingHint": "En una versió futura es podran seleccionar aquí altres estratègies d'indexació (més enllà de la vectorial)."
-			}
+				"otherIndexingHint": "En una versió futura es podran seleccionar aquí altres estratègies d'indexació (més enllà de la vectorial).",
+				"chunkingHeading": "Fragmentació",
+				"chunkingParamsHint": "Els valors per defecte funcionen per a la majoria de documents; ajusta'ls només si tens un motiu. Pots canviar-los més tard des de la vista de detall del Magatzem de Coneixement, però els canvis només s'apliquen al contingut indexat després de l'edició.",
+				"embeddingHeading": "Embedding",
+				"storageHeading": "Emmagatzematge",
+				"advancedLabel": "Avançat: fragmentació, proveïdor/model d'embedding, vector DB"
+			},
+			"adding": "Afegint...",
+			"titleAddContent": "Afegir contingut"
 		}
 	},
 	"capability": {

--- a/frontend/svelte-app/src/lib/locales/en.json
+++ b/frontend/svelte-app/src/lib/locales/en.json
@@ -367,6 +367,8 @@
 		"close": "Close"
 	},
 	"common": {
+		"close": "Close",
+		"next": "Next",
 		"loading": "Loading...",
 		"error": "Error",
 		"success": "Success!",
@@ -1224,7 +1226,17 @@
 			"itemsIngested": "items ingested",
 			"runInBackground": "Run in background",
 			"retry": "Retry ingestion",
-			"backgroundToast": "Ingestion continues in the background. Track progress on the Knowledge Store page."
+			"backgroundToast": "Ingestion continues in the background. Track progress on the Knowledge Store page.",
+			"done": "Ingestion complete",
+			"etaHeuristic": "~1–2 min per item",
+			"etaMinutes": "~{n} min remaining",
+			"etaSeconds": "~{n}s remaining",
+			"ingesting": "ingesting",
+			"ofConnector": "of",
+			"processing": "Processing content…",
+			"retryComingSoon": "Retry feature coming soon.",
+			"retryQueued": "Retry queued.",
+			"viewKs": "View Knowledge Store"
 		},
 		"removeModal": {
 			"title": "Remove from Knowledge Store",
@@ -1243,7 +1255,54 @@
 			"noItems": "Select at least one item.",
 			"noItems2": "This library has no ready items to index.",
 			"submit": "Add to Knowledge Store",
-			"submitting": "Adding..."
+			"submitting": "Adding...",
+			"duplicateWarning1": "1 item is already in this Knowledge Store and will be skipped.",
+			"duplicateWarningN": "{n} items are already in this Knowledge Store and will be skipped.",
+			"emptyTag": "(empty — nothing to add)",
+			"fromLibrary": "From library:",
+			"itemPlural": "items",
+			"itemSingular": "item",
+			"libraryAllFailedHint": "All items in this library have failed to import. Go back and choose a different library.",
+			"libraryEmptyHint": "This library has no items ready to index. Go back and choose a different library, or import content into this one first.",
+			"libraryHint": "Pick the library that contains the items to index.",
+			"libraryRequired": "Pick a library to continue.",
+			"reviewHint": "Review what will be indexed, then click Add.",
+			"reviewItems": "Items to index",
+			"stepItems": "Items",
+			"stepLibrary": "Library",
+			"stepReview": "Review"
+		},
+		"addDescription": "Add description",
+		"chunkingParams": "Chunking parameters",
+		"collapseDetail": "Hide locked configuration",
+		"deletedSuffix": "(deleted)",
+		"editDescription": "Edit description",
+		"editName": "Edit name",
+		"expandDetail": "Show locked configuration",
+		"filterLibrary": "Library",
+		"filterLibraryAll": "All libraries",
+		"filterLibraryClear": "Clear filter",
+		"lockedConfigHint": "Configuration is locked after creation",
+		"nameRequired": "Name is required.",
+		"noContentForLibrary": "No items from the selected library are linked to this Knowledge Store.",
+		"results": "Results",
+		"totalChunks": "Total chunks",
+		"viewItem": "View item",
+		"items": {
+			"title": "Items"
+		},
+		"options": {
+			"unavailableBody": "Knowledge Store server unavailable. Please ensure lamb-kb-server is running and retry.",
+			"unavailableTitle": "Knowledge Store server unavailable"
+		},
+		"params": {
+			"editButton": "Edit",
+			"editNotice": "Changes apply only to content indexed after saving — existing chunks keep the parameters they were created with.",
+			"noParams": "This strategy has no editable parameters.",
+			"saveFailed": "Failed to update chunking parameters.",
+			"saved": "Chunking parameters updated. Applies to new ingestions only.",
+			"schemaFailed": "Could not load chunking parameter schema. Try again later.",
+			"usingDefaults": "Using the strategy defaults."
 		}
 	},
 	"knowledge": {
@@ -1268,7 +1327,8 @@
 			},
 			"lockedConfigNotice": {
 				"title": "These settings cannot be changed later.",
-				"body": "Chunking strategy, embedding vendor / model, and vector DB are locked once the Knowledge Store is created. To change them, create a new Knowledge Store."
+				"body": "Chunking strategy, embedding vendor / model, and vector DB are locked once the Knowledge Store is created. To change them, create a new Knowledge Store.",
+				"paramsBody": "Chunking parameters can be edited later, but changes only apply to newly indexed content — existing chunks keep the parameters they were originally created with."
 			},
 			"step6": {
 				"chunkingLabel": "Chunking strategy",
@@ -1276,11 +1336,15 @@
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
-				"noVendorConfigured": "Your organization has no embedding providers configured. Ask an admin to add an API key in the organization settings."
+				"noVendorConfigured": "Your organization has no embedding providers configured. Ask an admin to add an API key in the organization settings.",
+				"modelRequired": "No models returned by the API for this vendor — type a model name to continue."
 			},
 			"step7": {
 				"title": "Pick items to index",
-				"description": "Choose which library items to index in the Knowledge Store."
+				"description": "Choose which library items to index in the Knowledge Store.",
+				"heading": "Pick items to index",
+				"newBadge": "NEW",
+				"noItems": "This library has no ready items. You can skip this step and add content later."
 			},
 			"step8": {
 				"title": "Review & create",
@@ -1298,14 +1362,19 @@
 				"progressImportUrl": "Importing {url} ({n}/{total})...",
 				"progressKS": "Creating Knowledge Store...",
 				"progressIngest": "Queuing {n} item(s) for ingestion...",
-				"retry": "Retry"
+				"retry": "Retry",
+				"ksNameTaken": "A Knowledge Store named \"{name}\" already exists.",
+				"libraryNameTaken": "A library named \"{name}\" already exists.",
+				"pluginAuto": "Auto-selected",
+				"submitAdd": "Add"
 			},
 			"step9": {
 				"heading": "You're all set",
 				"description": "Your Library and Knowledge Store are ready. Ingestion runs in the background — you can check progress on the Knowledge Store page.",
 				"openLibrary": "Open Library",
 				"createAnother": "Create another",
-				"toast": "Knowledge Store created."
+				"toast": "Knowledge Store created.",
+				"openKS": "Open Knowledge Store"
 			},
 			"creating": "Creating...",
 			"draft": {
@@ -1328,7 +1397,10 @@
 				"shareHint": "You can change this later from the Library detail view.",
 				"advancedLabel": "Advanced: import plugin & params",
 				"noPlugins": "No import plugins available.",
-				"pluginLabel": "Import plugin"
+				"pluginLabel": "Import plugin",
+				"descriptionLabel": "Description",
+				"pluginParamsHint": "Defaults come from the plugin and work for most documents — override only if needed.",
+				"pluginParamsLabel": "Plugin parameters"
 			},
 			"libraryContent": {
 				"title": "Library Content",
@@ -1343,7 +1415,14 @@
 				"queuedSources": "Queued sources",
 				"optionalHint": "Adding content here is optional — you can also add files, URLs, or YouTube transcripts later from the Library detail page. Note: a Knowledge Store can only ingest items that exist in its Library, so anything you skip now must be added to the Library before it can land in the Knowledge Store.",
 				"uploadNote": "Content will be imported when you click \"Create\" in the Review step.",
-				"emptyHint": "No content queued. You can skip this step."
+				"emptyHint": "No content queued. You can skip this step.",
+				"dropHint": "You can add multiple files; they will be imported when you click Create.",
+				"dropTitle": "Drop files here or click to upload",
+				"noPlugins": "No import plugins are currently enabled.",
+				"perFileParams": "Per-file plugin parameters",
+				"pluginLabel": "Import plugin",
+				"pluginParamsHint": "Defaults come from the plugin and work for most documents — override only if needed.",
+				"pluginParamsLabel": "Plugin parameters"
 			},
 			"ksStep": {
 				"title": "Knowledge Store Setup",
@@ -1358,8 +1437,14 @@
 				"nameTooLong": "Name must be less than 100 characters",
 				"shareLabel": "Share with my organization",
 				"shareHint": "You can change this later from the Knowledge Store detail view.",
-				"advancedLabel": "Advanced: chunking, embedding vendor/model, vector DB"
-			}
+				"advancedLabel": "Advanced: chunking, embedding vendor/model, vector DB",
+				"chunkingHeading": "Chunking",
+				"chunkingParamsHint": "Defaults work for most documents — adjust only if you have a reason to. You can change these later from the Knowledge Store detail view, but changes only apply to content indexed after the edit.",
+				"embeddingHeading": "Embedding",
+				"storageHeading": "Storage"
+			},
+			"adding": "Adding...",
+			"titleAddContent": "Add Content"
 		}
 	},
 	"capability": {

--- a/frontend/svelte-app/src/lib/locales/es.json
+++ b/frontend/svelte-app/src/lib/locales/es.json
@@ -367,6 +367,8 @@
 		"close": "Cerrar"
 	},
 	"common": {
+		"close": "Cerrar",
+		"next": "Siguiente",
 		"loading": "Cargando...",
 		"error": "Error",
 		"success": "Éxito",
@@ -1224,7 +1226,17 @@
 			"itemsIngested": "elementos ingeridos",
 			"runInBackground": "Continuar en segundo plano",
 			"retry": "Reintentar ingestión",
-			"backgroundToast": "La ingestión continúa en segundo plano. Sigue el progreso en la página del Almacén de Conocimiento."
+			"backgroundToast": "La ingestión continúa en segundo plano. Sigue el progreso en la página del Almacén de Conocimiento.",
+			"done": "Indexación completada",
+			"etaHeuristic": "~1–2 min por elemento",
+			"etaMinutes": "~{n} min restantes",
+			"etaSeconds": "~{n}s restantes",
+			"ingesting": "indexando",
+			"ofConnector": "de",
+			"processing": "Procesando contenido…",
+			"retryComingSoon": "La función de reintentar estará disponible pronto.",
+			"retryQueued": "Reintento en cola.",
+			"viewKs": "Ver Almacén de Conocimiento"
 		},
 		"removeModal": {
 			"title": "Quitar del Almacén de Conocimiento",
@@ -1243,7 +1255,54 @@
 			"noItems": "Selecciona al menos un elemento.",
 			"noItems2": "Esta biblioteca no tiene elementos listos para ingerir.",
 			"submit": "Añadir al Almacén de Conocimiento",
-			"submitting": "Añadiendo..."
+			"submitting": "Añadiendo...",
+			"duplicateWarning1": "1 elemento ya está en este Almacén de Conocimiento y se omitirá.",
+			"duplicateWarningN": "{n} elementos ya están en este Almacén de Conocimiento y se omitirán.",
+			"emptyTag": "(vacío — nada que añadir)",
+			"fromLibrary": "De la biblioteca:",
+			"itemPlural": "elementos",
+			"itemSingular": "elemento",
+			"libraryAllFailedHint": "Todos los elementos de esta biblioteca han fallado al importarse. Vuelve atrás y elige otra biblioteca.",
+			"libraryEmptyHint": "Esta biblioteca no tiene elementos listos para indexar. Vuelve atrás y elige otra biblioteca, o importa contenido en esta primero.",
+			"libraryHint": "Elige la biblioteca que contiene los elementos a indexar.",
+			"libraryRequired": "Elige una biblioteca para continuar.",
+			"reviewHint": "Revisa lo que se indexará y luego haz clic en Añadir.",
+			"reviewItems": "Elementos a indexar",
+			"stepItems": "Elementos",
+			"stepLibrary": "Biblioteca",
+			"stepReview": "Revisar"
+		},
+		"addDescription": "Añadir descripción",
+		"chunkingParams": "Parámetros de fragmentación",
+		"collapseDetail": "Ocultar configuración bloqueada",
+		"deletedSuffix": "(eliminado)",
+		"editDescription": "Editar descripción",
+		"editName": "Editar nombre",
+		"expandDetail": "Mostrar configuración bloqueada",
+		"filterLibrary": "Biblioteca",
+		"filterLibraryAll": "Todas las bibliotecas",
+		"filterLibraryClear": "Borrar filtro",
+		"lockedConfigHint": "La configuración se bloquea tras la creación",
+		"nameRequired": "El nombre es obligatorio.",
+		"noContentForLibrary": "Ningún elemento de la biblioteca seleccionada está vinculado a este Almacén de Conocimiento.",
+		"results": "Resultados",
+		"totalChunks": "Total de fragmentos",
+		"viewItem": "Ver elemento",
+		"items": {
+			"title": "Elementos"
+		},
+		"options": {
+			"unavailableBody": "Servidor de Almacenes de Conocimiento no disponible. Asegúrate de que lamb-kb-server esté en ejecución e inténtalo de nuevo.",
+			"unavailableTitle": "Servidor de Almacenes de Conocimiento no disponible"
+		},
+		"params": {
+			"editButton": "Editar",
+			"editNotice": "Los cambios solo se aplican al contenido indexado tras guardar; los fragmentos existentes conservan los parámetros con los que se crearon.",
+			"noParams": "Esta estrategia no tiene parámetros editables.",
+			"saveFailed": "No se pudieron actualizar los parámetros de fragmentación.",
+			"saved": "Parámetros de fragmentación actualizados. Solo se aplican a las nuevas indexaciones.",
+			"schemaFailed": "No se pudo cargar el esquema de parámetros de fragmentación. Inténtalo más tarde.",
+			"usingDefaults": "Usando los valores por defecto de la estrategia."
 		}
 	},
 	"knowledge": {
@@ -1268,7 +1327,8 @@
 			},
 			"lockedConfigNotice": {
 				"title": "Estos ajustes no se pueden cambiar después.",
-				"body": "La estrategia de fragmentación, el proveedor/modelo de embeddings y la base de datos vectorial quedan bloqueados al crear el Almacén de Conocimiento. Para cambiarlos, crea un nuevo Almacén."
+				"body": "La estrategia de fragmentación, el proveedor/modelo de embeddings y la base de datos vectorial quedan bloqueados al crear el Almacén de Conocimiento. Para cambiarlos, crea un nuevo Almacén.",
+				"paramsBody": "Los parámetros de fragmentación se pueden editar más tarde, pero los cambios solo se aplican al contenido recién indexado; los fragmentos existentes conservan los parámetros con los que se crearon originalmente."
 			},
 			"step6": {
 				"chunkingLabel": "Chunking strategy",
@@ -1276,11 +1336,15 @@
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
-				"noVendorConfigured": "Tu organización no tiene proveedores de embeddings configurados. Pide a un administrador que añada una clave de API en la configuración de la organización."
+				"noVendorConfigured": "Tu organización no tiene proveedores de embeddings configurados. Pide a un administrador que añada una clave de API en la configuración de la organización.",
+				"modelRequired": "La API no devolvió modelos para este proveedor; escribe un nombre de modelo para continuar."
 			},
 			"step7": {
 				"title": "Elige elementos para ingerir",
-				"description": "Elige qué elementos de la biblioteca indexar en el Almacén de Conocimiento."
+				"description": "Elige qué elementos de la biblioteca indexar en el Almacén de Conocimiento.",
+				"heading": "Selecciona elementos para indexar",
+				"newBadge": "NUEVO",
+				"noItems": "Esta biblioteca no tiene elementos listos. Puedes omitir este paso y añadir contenido más tarde."
 			},
 			"step8": {
 				"title": "Review & create",
@@ -1298,14 +1362,19 @@
 				"progressImportUrl": "Importing {url} ({n}/{total})...",
 				"progressKS": "Creating Knowledge Store...",
 				"progressIngest": "Queuing {n} item(s) for ingestion...",
-				"retry": "Reintentar"
+				"retry": "Reintentar",
+				"ksNameTaken": "Ya existe un Almacén de Conocimiento llamado \"{name}\".",
+				"libraryNameTaken": "Ya existe una biblioteca llamada \"{name}\".",
+				"pluginAuto": "Seleccionado automáticamente",
+				"submitAdd": "Añadir"
 			},
 			"step9": {
 				"heading": "¡Todo listo!",
 				"description": "Tu Biblioteca y Almacén de Conocimiento están listos. La ingesta se ejecuta en segundo plano — puedes ver el progreso en la página del Almacén de Conocimiento.",
 				"openLibrary": "Abrir Biblioteca",
 				"createAnother": "Crear otro",
-				"toast": "Almacén de Conocimiento creado."
+				"toast": "Almacén de Conocimiento creado.",
+				"openKS": "Abrir Almacén de Conocimiento"
 			},
 			"creating": "Creando...",
 			"draft": {
@@ -1328,7 +1397,10 @@
 				"shareHint": "Puedes cambiarlo más tarde desde la vista de detalle de la Biblioteca.",
 				"advancedLabel": "Avanzado: plugin de importación y parámetros",
 				"noPlugins": "No hay plugins de importación disponibles.",
-				"pluginLabel": "Plugin de importación"
+				"pluginLabel": "Plugin de importación",
+				"descriptionLabel": "Descripción",
+				"pluginParamsHint": "Los valores por defecto provienen del plugin y funcionan para la mayoría de documentos; cámbialos solo si es necesario.",
+				"pluginParamsLabel": "Parámetros del plugin"
 			},
 			"libraryContent": {
 				"title": "Contenido de Biblioteca",
@@ -1343,7 +1415,14 @@
 				"queuedSources": "Fuentes en cola",
 				"optionalHint": "Añadir contenido aquí es opcional — también puedes añadir archivos, URLs o transcripciones de YouTube más tarde desde la vista de detalle de la Biblioteca. Nota: un Knowledge Store solo puede ingerir elementos que existan en su Biblioteca, así que lo que omitas ahora deberás añadirlo antes a la Biblioteca.",
 				"uploadNote": "El contenido se importará cuando hagas clic en \"Crear\" en el paso de Revisión.",
-				"emptyHint": "No hay contenido en cola. Puedes omitir este paso."
+				"emptyHint": "No hay contenido en cola. Puedes omitir este paso.",
+				"dropHint": "Puedes añadir varios archivos; se importarán cuando hagas clic en Crear.",
+				"dropTitle": "Suelta archivos aquí o haz clic para subir",
+				"noPlugins": "No hay plugins de importación habilitados actualmente.",
+				"perFileParams": "Parámetros del plugin por archivo",
+				"pluginLabel": "Plugin de importación",
+				"pluginParamsHint": "Los valores por defecto provienen del plugin y funcionan para la mayoría de documentos; cámbialos solo si es necesario.",
+				"pluginParamsLabel": "Parámetros del plugin"
 			},
 			"ksStep": {
 				"title": "Configuración de Almacén de Conocimiento",
@@ -1360,8 +1439,15 @@
 				"shareHint": "Puedes cambiarlo más tarde desde la vista de detalle del Almacén de Conocimiento.",
 				"vectorIndexingLabel": "Indexación vectorial: fragmentación, proveedor/modelo de embeddings, base de datos vectorial",
 				"otherIndexingLabel": "Otra estrategia de indexación (próximamente)",
-				"otherIndexingHint": "En una versión futura se podrán seleccionar aquí otras estrategias de indexación (más allá de la vectorial)."
-			}
+				"otherIndexingHint": "En una versión futura se podrán seleccionar aquí otras estrategias de indexación (más allá de la vectorial).",
+				"chunkingHeading": "Fragmentación",
+				"chunkingParamsHint": "Los valores por defecto funcionan para la mayoría de documentos; ajústalos solo si tienes un motivo. Puedes cambiarlos más tarde desde la vista de detalle del Almacén de Conocimiento, pero los cambios solo se aplican al contenido indexado después de la edición.",
+				"embeddingHeading": "Embedding",
+				"storageHeading": "Almacenamiento",
+				"advancedLabel": "Avanzado: fragmentación, proveedor/modelo de embedding, vector DB"
+			},
+			"adding": "Añadiendo...",
+			"titleAddContent": "Añadir contenido"
 		}
 	},
 	"capability": {

--- a/frontend/svelte-app/src/lib/locales/eu.json
+++ b/frontend/svelte-app/src/lib/locales/eu.json
@@ -367,6 +367,8 @@
 		"close": "Itxi"
 	},
 	"common": {
+		"close": "Itxi",
+		"next": "Hurrengoa",
 		"loading": "Kargatzen...",
 		"error": "Errorea",
 		"success": "Arrakasta",
@@ -1224,7 +1226,17 @@
 			"itemsIngested": "elementu sartu dira",
 			"runInBackground": "Bigarren mailan jarraitu",
 			"retry": "Sartzea berriz saiatu",
-			"backgroundToast": "Sartzea bigarren mailan jarraitzen du. Aurrerapena Ezagutza-biltegiaren orrian ikus dezakezu."
+			"backgroundToast": "Sartzea bigarren mailan jarraitzen du. Aurrerapena Ezagutza-biltegiaren orrian ikus dezakezu.",
+			"done": "Indexazioa osatuta",
+			"etaHeuristic": "~1–2 min elementuko",
+			"etaMinutes": "~{n} min geratzen dira",
+			"etaSeconds": "~{n}s geratzen dira",
+			"ingesting": "indexatzen",
+			"ofConnector": "/",
+			"processing": "Edukia prozesatzen…",
+			"retryComingSoon": "Berriz saiatzeko funtzioa laster egongo da erabilgarri.",
+			"retryQueued": "Berriz saiatzea ilaran.",
+			"viewKs": "Ikusi Ezagutza-biltegia"
 		},
 		"removeModal": {
 			"title": "Ezagutza-biltegitik Kendu",
@@ -1243,7 +1255,54 @@
 			"noItems": "Hautatu gutxienez elementu bat.",
 			"noItems2": "Liburutegi honek ez du ingeritzeko prest dagoen elementurik.",
 			"submit": "Ezagutza-biltegira Gehitu",
-			"submitting": "Gehitzen..."
+			"submitting": "Gehitzen...",
+			"duplicateWarning1": "Elementu 1 jada Ezagutza-biltegi honetan dago eta saltatu egingo da.",
+			"duplicateWarningN": "{n} elementu jada Ezagutza-biltegi honetan daude eta saltatu egingo dira.",
+			"emptyTag": "(hutsik — ezer gehitzeko)",
+			"fromLibrary": "Liburutegitik:",
+			"itemPlural": "elementu",
+			"itemSingular": "elementu",
+			"libraryAllFailedHint": "Liburutegi honetako elementu guztiek huts egin dute inportatzean. Itzuli eta aukeratu beste liburutegi bat.",
+			"libraryEmptyHint": "Liburutegi honek ez du indexatzeko prest dagoen elementurik. Itzuli eta aukeratu beste liburutegi bat, edo inportatu edukia hona lehenik.",
+			"libraryHint": "Aukeratu indexatu beharreko elementuak dituen liburutegia.",
+			"libraryRequired": "Aukeratu liburutegi bat jarraitzeko.",
+			"reviewHint": "Berrikusi zer indexatuko den eta egin klik Gehitu botoian.",
+			"reviewItems": "Indexatzeko elementuak",
+			"stepItems": "Elementuak",
+			"stepLibrary": "Liburutegia",
+			"stepReview": "Berrikusi"
+		},
+		"addDescription": "Gehitu deskribapena",
+		"chunkingParams": "Zatiketa-parametroak",
+		"collapseDetail": "Ezkutatu blokeatutako konfigurazioa",
+		"deletedSuffix": "(ezabatua)",
+		"editDescription": "Editatu deskribapena",
+		"editName": "Editatu izena",
+		"expandDetail": "Erakutsi blokeatutako konfigurazioa",
+		"filterLibrary": "Liburutegia",
+		"filterLibraryAll": "Liburutegi guztiak",
+		"filterLibraryClear": "Garbitu iragazkia",
+		"lockedConfigHint": "Konfigurazioa sortu ondoren blokeatzen da",
+		"nameRequired": "Izena beharrezkoa da.",
+		"noContentForLibrary": "Hautatutako liburutegiko elementurik ez dago Ezagutza-biltegi honi lotuta.",
+		"results": "Emaitzak",
+		"totalChunks": "Zatiak guztira",
+		"viewItem": "Ikusi elementua",
+		"items": {
+			"title": "Elementuak"
+		},
+		"options": {
+			"unavailableBody": "Ezagutza-biltegien zerbitzaria ez dago erabilgarri. Ziurtatu lamb-kb-server martxan dagoela eta saiatu berriro.",
+			"unavailableTitle": "Ezagutza-biltegien zerbitzaria ez dago erabilgarri"
+		},
+		"params": {
+			"editButton": "Editatu",
+			"editNotice": "Aldaketak gorde ondoren indexatutako edukiari soilik aplikatzen zaizkio; lehendik dauden zatiek sortu zituzten parametroak mantentzen dituzte.",
+			"noParams": "Estrategia honek ez du parametro editagarririk.",
+			"saveFailed": "Ezin izan dira zatiketa-parametroak eguneratu.",
+			"saved": "Zatiketa-parametroak eguneratuta. Indexazio berriei soilik aplikatzen zaizkie.",
+			"schemaFailed": "Ezin izan da zatiketa-parametroen eskema kargatu. Saiatu berriro geroago.",
+			"usingDefaults": "Estrategiaren balio lehenetsiak erabiltzen."
 		}
 	},
 	"knowledge": {
@@ -1268,7 +1327,8 @@
 			},
 			"lockedConfigNotice": {
 				"title": "Ezarpen hauek ezin dira geroago aldatu.",
-				"body": "Zatiketa-estrategia, txertaketa-hornitzaile/eredua eta datu-base bektoriala Knowledge Store sortzen denean blokeatzen dira. Aldatzeko, sortu Knowledge Store berri bat."
+				"body": "Zatiketa-estrategia, txertaketa-hornitzaile/eredua eta datu-base bektoriala Knowledge Store sortzen denean blokeatzen dira. Aldatzeko, sortu Knowledge Store berri bat.",
+				"paramsBody": "Zatiketa-parametroak geroago edita daitezke, baina aldaketak indexatu berri den edukiari soilik aplikatzen zaizkio; lehendik dauden zatiek hasieran sortu zituzten parametroak mantentzen dituzte."
 			},
 			"step6": {
 				"chunkingLabel": "Chunking strategy",
@@ -1276,11 +1336,15 @@
 				"vendorLabel": "Embedding vendor",
 				"modelLabel": "Embedding model",
 				"endpointLabel": "Embedding endpoint (optional)",
-				"noVendorConfigured": "Zure erakundeak ez du embedding hornitzailerik konfiguratuta. Eskatu administratzaile bati API gako bat gehitzeko erakundearen ezarpenetan."
+				"noVendorConfigured": "Zure erakundeak ez du embedding hornitzailerik konfiguratuta. Eskatu administratzaile bati API gako bat gehitzeko erakundearen ezarpenetan.",
+				"modelRequired": "APIak ez du modelorik itzuli hornitzaile honentzat; idatzi modelo-izen bat jarraitzeko."
 			},
 			"step7": {
 				"title": "Aukeratu ingeritzeko elementuak",
-				"description": "Aukeratu zein liburutegiko elementu indexatu Ezagutza-biltegian."
+				"description": "Aukeratu zein liburutegiko elementu indexatu Ezagutza-biltegian.",
+				"heading": "Hautatu indexatzeko elementuak",
+				"newBadge": "BERRIA",
+				"noItems": "Liburutegi honek ez du prest dagoen elementurik. Urrats hau saltatu eta edukia geroago gehi dezakezu."
 			},
 			"step8": {
 				"title": "Review & create",
@@ -1298,14 +1362,19 @@
 				"progressImportUrl": "Importing {url} ({n}/{total})...",
 				"progressKS": "Creating Knowledge Store...",
 				"progressIngest": "Queuing {n} item(s) for ingestion...",
-				"retry": "Saiatu berriro"
+				"retry": "Saiatu berriro",
+				"ksNameTaken": "Jada badago \"{name}\" izeneko Ezagutza-biltegi bat.",
+				"libraryNameTaken": "Jada badago \"{name}\" izeneko liburutegi bat.",
+				"pluginAuto": "Automatikoki hautatua",
+				"submitAdd": "Gehitu"
 			},
 			"step9": {
 				"heading": "Dena prest dago",
 				"description": "Zure Liburutegia eta Ezagutza-biltegia prest daude. Ingestioa atzeko planoan exekutatzen da — aurrerapena Ezagutza-biltegiaren orrian ikus dezakezu.",
 				"openLibrary": "Liburutegia ireki",
 				"createAnother": "Beste bat sortu",
-				"toast": "Ezagutza-biltegia sortuta."
+				"toast": "Ezagutza-biltegia sortuta.",
+				"openKS": "Ireki Ezagutza-biltegia"
 			},
 			"creating": "Sortzen...",
 			"draft": {
@@ -1328,7 +1397,10 @@
 				"shareHint": "Geroago alda dezakezu Liburutegiaren xehetasun ikuspegitik.",
 				"advancedLabel": "Aurreratua: inportazio plugina eta parametroak",
 				"noPlugins": "Ez dago inportazio pluginik.",
-				"pluginLabel": "Inportazio plugina"
+				"pluginLabel": "Inportazio plugina",
+				"descriptionLabel": "Deskribapena",
+				"pluginParamsHint": "Balio lehenetsiak pluginetik datoz eta dokumentu gehienetan funtzionatzen dute; aldatu beharrezkoa bada soilik.",
+				"pluginParamsLabel": "Pluginaren parametroak"
 			},
 			"libraryContent": {
 				"title": "Liburutegiaren edukia",
@@ -1343,7 +1415,14 @@
 				"queuedSources": "Iturri zerrendatuak",
 				"optionalHint": "Eduki gehitzea hemen aukerakoa da — fitxategiak, URLak edo YouTubeko transkripzioak ere geroago gehi ditzakezu Bibliotekaren xehetasun-ikuspegitik. Oharra: Knowledge Store batek soilik bere Bibliotekan dauden elementuak ingeritu ditzake; beraz, orain saltatzen duzuna Bibliotekara gehitu beharko duzu lehenik.",
 				"uploadNote": "Edukia inportatuko da \"Sortu\" sakatzean Berrikuspena urratsean.",
-				"emptyHint": "Ez dago iturririk ilaran. Urrats hau saltatu dezakezu."
+				"emptyHint": "Ez dago iturririk ilaran. Urrats hau saltatu dezakezu.",
+				"dropHint": "Hainbat fitxategi gehi ditzakezu; Sortu sakatzean inportatuko dira.",
+				"dropTitle": "Jaregin fitxategiak hemen edo egin klik kargatzeko",
+				"noPlugins": "Une honetan ez dago inportazio-pluginik gaituta.",
+				"perFileParams": "Fitxategi bakoitzeko pluginaren parametroak",
+				"pluginLabel": "Inportazio-plugina",
+				"pluginParamsHint": "Balio lehenetsiak pluginetik datoz eta dokumentu gehienetan funtzionatzen dute; aldatu beharrezkoa bada soilik.",
+				"pluginParamsLabel": "Pluginaren parametroak"
 			},
 			"ksStep": {
 				"title": "Knowledge Store konfigurazioa",
@@ -1360,8 +1439,15 @@
 				"shareHint": "Geroago alda dezakezu Knowledge Store xehetasun ikuspegitik.",
 				"vectorIndexingLabel": "Bektore-indexazioa: zatiketa, txertaketa hornitzaile/eredua, datu-base bektoriala",
 				"otherIndexingLabel": "Beste indexazio-estrategia bat (laster)",
-				"otherIndexingHint": "Etorkizuneko bertsio batean, beste indexazio-estrategia batzuk (bektorialaz haratago) hemen hautatu ahal izango dira."
-			}
+				"otherIndexingHint": "Etorkizuneko bertsio batean, beste indexazio-estrategia batzuk (bektorialaz haratago) hemen hautatu ahal izango dira.",
+				"chunkingHeading": "Zatiketa",
+				"chunkingParamsHint": "Balio lehenetsiek dokumentu gehienetan funtzionatzen dute; egokitu arrazoiren bat baduzu soilik. Geroago alda ditzakezu Ezagutza-biltegiaren xehetasun-ikuspegitik, baina aldaketak edizioaren ondoren indexatutako edukiari soilik aplikatzen zaizkio.",
+				"embeddingHeading": "Embedding",
+				"storageHeading": "Biltegiratzea",
+				"advancedLabel": "Aurreratua: zatiketa, embedding hornitzailea/modeloa, vector DB"
+			},
+			"adding": "Gehitzen...",
+			"titleAddContent": "Gehitu edukia"
 		}
 	},
 	"capability": {


### PR DESCRIPTION
## Purpose

The "Create Knowledge" wizard and Knowledge Store UI referenced ~80 i18n keys missing from all four locales, so es/ca/eu rendered the whole flow in English via inline `{ default }` fallbacks (#438).

> **Stacked on #437** (wizard cleanup). Base is `refactor/knowledge-wizard-cleanup` so this PR's diff stays limited to the localization; merge #437 first.

## Changes

- Add **80 keys** to `en/es/ca/eu.json` across `common`, `knowledge.wizard.*` (ksStep, libraryContent, libraryStep, step6–9, lockedConfigNotice), and `knowledgeStores.*` (addContentModal, ingestionProgress, items, options, params).
- `en` values mirror the existing inline defaults verbatim; es/ca/eu are translated using the conventions already in the files (`biblioteca`, `fragmentación`/`fragmentació`/`zatiketa`, `Almacén`/`Magatzem`/`Ezagutza-biltegia`, `embedding`, `Vector DB`) and the project's **"index"** terminology for the Knowledge Store step.
- Only the `knowledge`/`knowledgeStores` blocks are re-serialized (they were already canonically tab-formatted) and the two `common` keys are inserted surgically, so every other byte of each locale file is preserved — the diff is purely the added keys plus trailing-comma rebalancing.

The inline `{ default: '…' }` fallbacks in the components are intentionally **kept** as a safety net — once a key exists in a locale, `svelte-i18n` returns the translation and the default is unused. This avoids a large, error-prone component edit for no functional gain.

## Verification

- Reference analysis confirms **0** referenced-with-default keys remain missing from any of the four locales (full parity).
- All four files re-validate as JSON; diff touches only the three intended top-level blocks.
- No component files changed.

## Related

- Closes #438