### PR TITLE
feat(#440): implement KS indexing retry with in-memory credential retention

### DIFF
--- a/backend/creator_interface/knowledge_store_client.py
+++ b/backend/creator_interface/knowledge_store_client.py
@@ -434,6 +434,24 @@ class KnowledgeStoreClient:
         config = self._get_ks_config(creator_user)
         return await self._request("POST", f"/jobs/{job_id}/cancel", config)
 
+    async def retry_job(self, job_id: str,
+                        creator_user: Dict[str, Any] = None) -> Dict:
+        """Retry a failed ingestion job, reusing its cached credentials.
+
+        The KB Server keeps the document payload and embedding credentials in
+        memory across attempts, so the retry does not re-send them. Raises an
+        ``HTTPException`` with the KB Server's status code on 404/409/410 (job
+        missing, not retryable / exhausted, or credentials expired).
+        """
+        config = self._get_ks_config(creator_user)
+        return await self._request("POST", f"/jobs/{job_id}/retry", config)
+
+    async def get_job_retry_available(self, job_id: str,
+                                      creator_user: Dict[str, Any] = None) -> Dict:
+        """Report whether a failed job can still be retried in place."""
+        config = self._get_ks_config(creator_user)
+        return await self._request("GET", f"/jobs/{job_id}/retry-available", config)
+
     # ------------------------------------------------------------------
     # Org-level discovery (for the UI options endpoint)
     # ------------------------------------------------------------------

--- a/backend/creator_interface/knowledge_store_router.py
+++ b/backend/creator_interface/knowledge_store_router.py
@@ -622,6 +622,56 @@ async def get_content_link(
     return link
 
 
+@router.post("/{ks_id}/content/{library_item_id}/retry")
+async def retry_content(
+    ks_id: str,
+    library_item_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """Retry a failed indexing job for a single content link.
+
+    The KB Server retains the document payload and embedding credentials in
+    memory across attempts, so the retry re-uses them — nothing is re-sent.
+    Propagates the KB Server's response:
+
+    - 404 if the link or job is unknown,
+    - 409 if the job is not failed or has exhausted its retries,
+    - 410 if the retention window elapsed (the user must re-add the content).
+    """
+    auth.require_knowledge_store_access(ks_id, level="owner")
+    link = _db.get_kb_content_link(ks_id, library_item_id)
+    if not link:
+        raise HTTPException(status_code=404, detail="Content link not found")
+
+    job_id = link.get("kb_job_id")
+    if not job_id:
+        raise HTTPException(
+            status_code=409,
+            detail="This content has no indexing job to retry.",
+        )
+
+    job = await _client.retry_job(job_id, creator_user=auth.user)
+
+    # The KB Server flipped the job back to pending; mirror that on the link so
+    # the UI shows the spinner again and resumes polling.
+    # Pass an empty string (not None) so the previous error is actually
+    # cleared — update_kb_content_link_status skips fields that are None.
+    _db.update_kb_content_link_status(
+        link_id=link["id"],
+        status="pending",
+        error_message="",
+    )
+    _audit(auth, "knowledge_store.retry_content", "knowledge_store", ks_id, {
+        "library_item_id": library_item_id,
+        "kb_job_id": job_id,
+    })
+    return {
+        "message": "Indexing retry queued.",
+        "job_id": job_id,
+        "status": job.get("status", "pending"),
+    }
+
+
 @router.delete("/{ks_id}/content/{library_item_id}")
 async def remove_content(
     ks_id: str,

--- a/frontend/svelte-app/src/lib/components/knowledgeStores/IngestionProgressModal.svelte
+++ b/frontend/svelte-app/src/lib/components/knowledgeStores/IngestionProgressModal.svelte
@@ -9,9 +9,9 @@
     * Top progress strip showing "{completedCount} of {total} items
       ingested" + ETA (heuristic until ≥1 completes, then derived).
     * Status badges via shared `statusBadgeProps`.
-    * Failed items expose a `<IconButton icon={RefreshCw}>` retry — the
-      backend endpoint is not implemented yet, so the stub surfaces a
-      `toast.info("Coming soon.")`.
+    * Failed items expose a `<IconButton icon={RefreshCw}>` retry that
+      re-queues the indexing job (the KB Server reuses the cached payload
+      and credentials); the item optimistically flips back to processing.
     * Footer: ghost "Close" or "Run in background" + primary "View
       Knowledge Store". "Run in background" fires a `toast.info`.
     * Polling continues after close so the parent list can show a
@@ -204,14 +204,9 @@
 				})
 			);
 		} catch (/** @type {any} */ err) {
-			if (err?.code === 'not_implemented') {
-				toast.info(
-					$_('knowledgeStores.ingestionProgress.retryComingSoon', {
-						default: 'Retry feature coming soon.'
-					})
-				);
-				return;
-			}
+			// The optimistic flip only runs after a successful queue, so the
+			// item is still 'failed' here — just surface the backend message
+			// (e.g. a 410 when the retry window has elapsed).
 			toast.error(err?.message || 'Retry failed.');
 		}
 	}

--- a/frontend/svelte-app/src/lib/services/knowledgeStoreService.js
+++ b/frontend/svelte-app/src/lib/services/knowledgeStoreService.js
@@ -322,29 +322,32 @@ export async function queryKnowledgeStore(ksId, data) {
 }
 
 /**
- * Retry a failed ingestion for a single content link.
+ * Retry a failed indexing job for a single content link.
  *
- * NOTE: the backend does not yet expose a dedicated retry endpoint —
- * this stub currently throws a `not_implemented` error. The
- * IngestionProgressModal surfaces a `toast.info("Coming soon.")` when
- * this rejects with that code, keeping the affordance discoverable
- * without blocking the user. When the backend endpoint lands, replace
- * the body of this function with the corresponding axios call.
+ * The KB Server keeps the document payload and embedding credentials in memory
+ * across attempts, so nothing is re-sent. On failure the backend's detail
+ * message is surfaced via the thrown error (e.g. a 410 when the retention
+ * window has elapsed and the content must be re-added).
  *
  * @param {string} ksId
  * @param {string} libraryItemId
- * @returns {Promise<{ message: string }>}
+ * @returns {Promise<{ message: string, job_id: string, status: string }>}
  */
 export async function retryIngestion(ksId, libraryItemId) {
 	if (!browser) throw new Error('Browser only.');
-	// Touch the params so lint stays happy until the backend wires up.
-	void ksId;
-	void libraryItemId;
-	const err = /** @type {Error & { code?: string }} */ (
-		new Error('Retry ingestion is not yet supported by the backend.')
-	);
-	err.code = 'not_implemented';
-	throw err;
+	const url = getApiUrl(`/knowledge-stores/${ksId}/content/${libraryItemId}/retry`);
+	try {
+		const response = await axios.post(url, {}, { headers: authHeaders() });
+		return response.data;
+	} catch (/** @type {any} */ err) {
+		const detail = err?.response?.data?.detail;
+		if (detail) {
+			const e = /** @type {Error & { status?: number }} */ (new Error(detail));
+			e.status = err?.response?.status;
+			throw e;
+		}
+		throw err;
+	}
 }
 
 /**

--- a/lamb-kb-server/backend/config.py
+++ b/lamb-kb-server/backend/config.py
@@ -38,6 +38,14 @@ MAX_EMBED_CHARS: int = int(os.getenv("MAX_EMBED_CHARS", "30000"))
 RESPLIT_CHUNK_SIZE: int = int(os.getenv("RESPLIT_CHUNK_SIZE", "4000"))
 RESPLIT_OVERLAP: int = 200
 MAX_JOB_ATTEMPTS: int = int(os.getenv("KB_MAX_JOB_ATTEMPTS", "3"))
+# How long (minutes) to retain a failed job's embedding credentials in memory
+# so it can be retried without the client re-sending them. Sized to span the
+# initial attempt plus the remaining retries (≈ MAX_JOB_ATTEMPTS × the task
+# timeout). After this window the credentials are purged and a retry requires
+# a fresh add-content request (ADR-4: credentials are never persisted).
+RETRY_CACHE_TTL_MINUTES: int = int(
+    os.getenv("KB_RETRY_CACHE_TTL_MINUTES", "90")
+)
 
 # --- Payload limits ---
 # Hard cap on add-content request bodies. Default 200 MB.

--- a/lamb-kb-server/backend/routers/jobs.py
+++ b/lamb-kb-server/backend/routers/jobs.py
@@ -2,13 +2,15 @@
 
 import logging
 
+from config import MAX_JOB_ATTEMPTS
 from database.connection import get_session
 from database.models import IngestionJob
 from dependencies import verify_token
 from fastapi import APIRouter, Depends, HTTPException, status
-from schemas.jobs import JobStatusResponse
+from schemas.jobs import JobStatusResponse, RetryAvailability
 from services.ingestion_service import cancel_job as cancel_job_service
 from sqlalchemy.orm import Session
+from tasks.worker import retry_available
 
 logger = logging.getLogger(__name__)
 
@@ -62,4 +64,87 @@ async def cancel_job(
     row is returned unchanged.
     """
     job = cancel_job_service(db, job_id)
+    return JobStatusResponse.model_validate(job)
+
+
+def _load_job(db: Session, job_id: str) -> IngestionJob:
+    job = db.query(IngestionJob).filter(IngestionJob.id == job_id).first()
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job '{job_id}' not found.",
+        )
+    return job
+
+
+@router.get("/{job_id}/retry-available", response_model=RetryAvailability)
+async def get_retry_available(
+    job_id: str,
+    db: Session = Depends(get_session),
+) -> RetryAvailability:
+    """Report whether a failed job can still be retried in place.
+
+    A retry is possible only while the job is ``failed``, has attempts left,
+    and its embedding credentials are still cached in memory (within the
+    retention window and since the last restart). The UI uses this to decide
+    whether to show a Retry affordance.
+    """
+    job = _load_job(db, job_id)
+    available = (
+        job.status == "failed"
+        and job.attempts < MAX_JOB_ATTEMPTS
+        and retry_available(job_id)
+    )
+    return RetryAvailability(
+        available=available,
+        attempts=job.attempts,
+        max_attempts=MAX_JOB_ATTEMPTS,
+    )
+
+
+@router.post("/{job_id}/retry", response_model=JobStatusResponse)
+async def retry_job(
+    job_id: str,
+    db: Session = Depends(get_session),
+) -> JobStatusResponse:
+    """Retry a failed ingestion job, reusing its cached credentials.
+
+    The document payload is already persisted in the job row, and the
+    embedding credentials are kept in memory across attempts, so a retry does
+    not require the client to re-send anything. The job is flipped back to
+    ``pending`` and the worker picks it up on the next poll.
+
+    Errors:
+        404 — job not found.
+        409 — job is not ``failed``, or has exhausted ``MAX_JOB_ATTEMPTS``.
+        410 — credentials are no longer cached (retention window elapsed or
+              the service restarted); the client must re-submit add-content.
+    """
+    job = _load_job(db, job_id)
+
+    if job.status != "failed":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Only failed jobs can be retried (status='{job.status}').",
+        )
+    if job.attempts >= MAX_JOB_ATTEMPTS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Job has exhausted its retries ({MAX_JOB_ATTEMPTS} attempts).",
+        )
+    if not retry_available(job_id):
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=(
+                "Retry window expired — credentials are no longer held. "
+                "Re-submit the content to index it again."
+            ),
+        )
+
+    job.status = "pending"
+    job.error_message = None
+    job.completed_at = None
+    db.commit()
+    db.refresh(job)
+    logger.info("Job %s queued for retry (attempt %d)", job_id, job.attempts + 1)
     return JobStatusResponse.model_validate(job)

--- a/lamb-kb-server/backend/schemas/jobs.py
+++ b/lamb-kb-server/backend/schemas/jobs.py
@@ -22,3 +22,11 @@ class JobStatusResponse(BaseModel):
     updated_at: datetime
     started_at: datetime | None = None
     completed_at: datetime | None = None
+
+
+class RetryAvailability(BaseModel):
+    """Whether a failed job can be retried in place, with attempt accounting."""
+
+    available: bool
+    attempts: int
+    max_attempts: int

--- a/lamb-kb-server/backend/tasks/worker.py
+++ b/lamb-kb-server/backend/tasks/worker.py
@@ -16,9 +16,14 @@ Design:
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
-from config import INGESTION_TASK_TIMEOUT_SECONDS, MAX_CONCURRENT_INGESTIONS, MAX_JOB_ATTEMPTS
+from config import (
+    INGESTION_TASK_TIMEOUT_SECONDS,
+    MAX_CONCURRENT_INGESTIONS,
+    MAX_JOB_ATTEMPTS,
+    RETRY_CACHE_TTL_MINUTES,
+)
 from database.connection import get_session_direct
 from database.models import Collection, IngestionJob
 from sqlalchemy.orm import Session
@@ -32,22 +37,31 @@ _executor: ThreadPoolExecutor | None = None
 _running = False
 
 # In-memory store for embedding credentials — never written to disk (ADR-4).
-# Maps job_id → credentials dict. Entries are removed once the worker picks
-# them up. If the service restarts before the worker picks up a job, the
-# credentials are lost and the job fails cleanly — exactly the behavior the
-# Library Manager uses for its own API keys.
+# Maps job_id → credentials dict. The document payload itself is persisted in
+# the ``ingestion_jobs`` row, so only the credentials need to survive in
+# memory. Unlike the original design (which popped credentials on first
+# pickup), entries are RETAINED across attempts so a failed job can be retried
+# without the client re-sending credentials. They are discarded when the job
+# succeeds, exhausts its attempts, or ages past ``RETRY_CACHE_TTL_MINUTES``
+# (see ``_purge_expired_credentials``). A restart still loses them, in which
+# case a retry requires a fresh add-content request.
 _job_credentials: dict[str, dict[str, str]] = {}
+# Parallel map of job_id → when the credentials were stored, for TTL expiry.
+_job_cred_stored_at: dict[str, datetime] = {}
 
 # How often (seconds) the worker checks for new pending jobs.
 _POLL_INTERVAL = 2.0
+# How often (seconds) expired credentials are purged from the retry cache.
+_CLEANUP_INTERVAL = 600.0
 
 
 def store_credentials(job_id: str, credentials: dict[str, str] | None) -> None:
-    """Hold embedding credentials in memory for a job until the worker runs it.
+    """Hold embedding credentials in memory for a job and its retries.
 
     Called by ``ingestion_service`` immediately after committing the job row
-    to SQLite. Credentials live only in the module-level dict and are popped
-    by the worker when processing starts.
+    to SQLite. Credentials live only in the module-level dict and are retained
+    until the job reaches a terminal state, exhausts its attempts, or the
+    retention window elapses.
 
     Args:
         job_id: The ingestion job ID.
@@ -55,6 +69,40 @@ def store_credentials(job_id: str, credentials: dict[str, str] | None) -> None:
     """
     if credentials:
         _job_credentials[job_id] = credentials
+        _job_cred_stored_at[job_id] = datetime.now(UTC)
+
+
+def _discard_credentials(job_id: str) -> None:
+    """Forget a job's cached credentials (terminal state or exhausted retries)."""
+    _job_credentials.pop(job_id, None)
+    _job_cred_stored_at.pop(job_id, None)
+
+
+def retry_available(job_id: str) -> bool:
+    """Whether a failed job can still be retried with its cached credentials.
+
+    True only while the credentials remain in memory (i.e. within the
+    retention window and before a restart). The HTTP layer combines this with
+    the job's status and attempt count to decide whether to offer a retry.
+    """
+    return job_id in _job_credentials
+
+
+def _purge_expired_credentials() -> None:
+    """Drop cached credentials older than ``RETRY_CACHE_TTL_MINUTES``.
+
+    Bounds the in-memory footprint and enforces the retention window: once a
+    failed job's credentials age out, a retry must re-send them. Called
+    periodically by the cleanup loop and once during stale-job recovery.
+    """
+    cutoff = datetime.now(UTC) - timedelta(minutes=RETRY_CACHE_TTL_MINUTES)
+    expired = [jid for jid, ts in _job_cred_stored_at.items() if ts < cutoff]
+    for jid in expired:
+        _discard_credentials(jid)
+    if expired:
+        logger.info(
+            "Purged credentials for %d job(s) past the retry window", len(expired)
+        )
 
 
 def is_worker_running() -> bool:
@@ -102,10 +150,11 @@ def _process_job_sync(job_id: str) -> None:
         # respect that and return without flipping back to processing.
         if job.status == "cancelled":
             logger.info("Job %s was cancelled before pickup — skipping", job_id)
-            _job_credentials.pop(job_id, None)
+            _discard_credentials(job_id)
             return
 
-        credentials = _job_credentials.pop(job_id, {})
+        # Read (do not pop) so the credentials survive for a possible retry.
+        credentials = _job_credentials.get(job_id, {})
 
         collection = (
             db.query(Collection).filter(Collection.id == job.collection_id).first()
@@ -119,6 +168,8 @@ def _process_job_sync(job_id: str) -> None:
             job.error_message = error_msg
             job.completed_at = datetime.now(UTC)
             db.commit()
+            # The collection is gone — retrying cannot help, so free creds.
+            _discard_credentials(job_id)
             logger.error("Job %s aborted — collection missing", job_id)
             return
 
@@ -141,11 +192,13 @@ def _process_job_sync(job_id: str) -> None:
             # noticed and bailed out. Leave the row alone so the cancellation
             # timestamp / status survive.
             logger.info("Job %s cancelled cooperatively: %s", job_id, exc)
+            _discard_credentials(job_id)
             return
 
         job.status = "completed"
         job.completed_at = datetime.now(UTC)
         db.commit()
+        _discard_credentials(job_id)
 
         logger.info(
             "Job %s completed — %d documents, %d chunks",
@@ -167,6 +220,10 @@ def _process_job_sync(job_id: str) -> None:
                 job.error_message = error_msg
                 job.completed_at = datetime.now(UTC)
                 db.commit()
+                # Keep the credentials so the user can retry, unless the job
+                # has exhausted its attempts — then a retry is not allowed.
+                if job.attempts >= _MAX_ATTEMPTS:
+                    _discard_credentials(job_id)
         except Exception:
             logger.exception("Failed to record error for job %s", job_id)
     finally:
@@ -196,6 +253,8 @@ async def _process_job_async(job_id: str) -> None:
                 job.error_message = timeout_msg
                 job.completed_at = datetime.now(UTC)
                 db.commit()
+                if job.attempts >= _MAX_ATTEMPTS:
+                    _discard_credentials(job_id)
         finally:
             db.close()
 
@@ -267,6 +326,17 @@ async def start_worker() -> None:
     )
 
     asyncio.create_task(_poll_loop())
+    asyncio.create_task(_cleanup_loop())
+
+
+async def _cleanup_loop() -> None:
+    """Periodically purge credentials of jobs past the retry window."""
+    while _running:
+        await asyncio.sleep(_CLEANUP_INTERVAL)
+        try:
+            _purge_expired_credentials()
+        except Exception:  # noqa: BLE001 — never let cleanup kill the loop
+            logger.exception("Credential purge failed")
 
 
 async def stop_worker() -> None:
@@ -290,6 +360,7 @@ def recover_stale_jobs() -> None:
     Jobs exceeding ``_MAX_ATTEMPTS`` are marked failed instead of being
     retried. Called once at startup, before the worker begins polling.
     """
+    _purge_expired_credentials()
     db = _get_db()
     try:
         stale = (
@@ -305,6 +376,7 @@ def recover_stale_jobs() -> None:
                 )
                 job.status = "failed"
                 job.error_message = error_msg
+                _discard_credentials(job.id)
                 logger.warning(
                     "Job %s exceeded max attempts, marked failed", job.id
                 )

--- a/lamb-kb-server/tests/integration/test_retry.py
+++ b/lamb-kb-server/tests/integration/test_retry.py
@@ -1,0 +1,158 @@
+"""Tests for failed-job retry with bounded in-memory credential retention.
+
+Covers the worker-level credential cache (retain across attempts, discard on
+terminal/exhausted states, TTL purge) and the HTTP retry endpoints.
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from config import MAX_JOB_ATTEMPTS
+from database.connection import get_session_direct
+from database.models import IngestionJob
+from httpx import AsyncClient
+from tasks import worker
+
+from tests.conftest import AUTH_HEADERS
+
+
+def _insert_job(status: str, attempts: int) -> str:
+    job_id = uuid4().hex
+    db = get_session_direct()
+    try:
+        db.add(
+            IngestionJob(
+                id=job_id,
+                collection_id="some-collection",
+                organization_id=f"org-{uuid4().hex[:8]}",
+                documents_json="[]",
+                status=status,
+                documents_total=0,
+                documents_processed=0,
+                chunks_created=0,
+                attempts=attempts,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+    return job_id
+
+
+# ---------------------------------------------------------------------------
+# Worker-level credential cache
+# ---------------------------------------------------------------------------
+
+
+def test_store_and_retry_available() -> None:
+    job_id = uuid4().hex
+    worker.store_credentials(job_id, {"api_key": "k", "api_endpoint": ""})
+    assert worker.retry_available(job_id) is True
+    worker._discard_credentials(job_id)
+    assert worker.retry_available(job_id) is False
+
+
+def test_purge_expired_credentials_drops_old_entries() -> None:
+    job_id = uuid4().hex
+    worker.store_credentials(job_id, {"api_key": "k"})
+    # Backdate the stored timestamp beyond the retention window.
+    worker._job_cred_stored_at[job_id] = datetime.now(UTC) - timedelta(
+        minutes=worker.RETRY_CACHE_TTL_MINUTES + 1
+    )
+    worker._purge_expired_credentials()
+    assert worker.retry_available(job_id) is False
+
+
+def test_purge_keeps_fresh_entries() -> None:
+    job_id = uuid4().hex
+    worker.store_credentials(job_id, {"api_key": "k"})
+    worker._purge_expired_credentials()
+    assert worker.retry_available(job_id) is True
+    worker._discard_credentials(job_id)
+
+
+# ---------------------------------------------------------------------------
+# HTTP retry endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_job_with_creds_requeues(client: AsyncClient) -> None:
+    job_id = _insert_job("failed", attempts=1)
+    worker.store_credentials(job_id, {"api_key": "k", "api_endpoint": ""})
+    try:
+        resp = await client.post(f"/jobs/{job_id}/retry", headers=AUTH_HEADERS)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "pending"
+        assert body["error_message"] is None
+    finally:
+        worker._discard_credentials(job_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_without_creds_returns_410(client: AsyncClient) -> None:
+    job_id = _insert_job("failed", attempts=1)  # no store_credentials
+    resp = await client.post(f"/jobs/{job_id}/retry", headers=AUTH_HEADERS)
+    assert resp.status_code == 410
+    assert "re-submit" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_retry_non_failed_job_returns_409(client: AsyncClient) -> None:
+    job_id = _insert_job("completed", attempts=1)
+    worker.store_credentials(job_id, {"api_key": "k"})
+    try:
+        resp = await client.post(f"/jobs/{job_id}/retry", headers=AUTH_HEADERS)
+        assert resp.status_code == 409
+    finally:
+        worker._discard_credentials(job_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausted_attempts_returns_409(client: AsyncClient) -> None:
+    job_id = _insert_job("failed", attempts=MAX_JOB_ATTEMPTS)
+    worker.store_credentials(job_id, {"api_key": "k"})
+    try:
+        resp = await client.post(f"/jobs/{job_id}/retry", headers=AUTH_HEADERS)
+        assert resp.status_code == 409
+        assert "exhausted" in resp.json()["detail"].lower()
+    finally:
+        worker._discard_credentials(job_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_unknown_job_returns_404(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/jobs/00000000-0000-0000-0000-000000000000/retry", headers=AUTH_HEADERS
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_retry_available_endpoint(client: AsyncClient) -> None:
+    job_id = _insert_job("failed", attempts=1)
+    # Without creds → not available.
+    resp = await client.get(f"/jobs/{job_id}/retry-available", headers=AUTH_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "available": False,
+        "attempts": 1,
+        "max_attempts": MAX_JOB_ATTEMPTS,
+    }
+    # With creds → available.
+    worker.store_credentials(job_id, {"api_key": "k"})
+    try:
+        resp = await client.get(
+            f"/jobs/{job_id}/retry-available", headers=AUTH_HEADERS
+        )
+        assert resp.json()["available"] is True
+    finally:
+        worker._discard_credentials(job_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_requires_auth(client: AsyncClient) -> None:
+    resp = await client.post("/jobs/whatever/retry")
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Purpose

The Knowledge Store "Retry" button did nothing — `retryIngestion()` threw `not_implemented` and the modal showed "coming soon" (#440). The real blocker was on the KB Server: per-request embedding credentials (ADR-4) were **popped** from memory on first pickup, so any retry dead-ended with empty credentials. This implements retry end-to-end by retaining credentials for a bounded window so they can be reused without re-sending.

## Changes

**KB Server (`lamb-kb-server`)**
- `tasks/worker.py` — credentials are now **read, not popped**, on pickup and retained across attempts. They are discarded on success, cooperative cancellation, missing-collection, and once a job exhausts `MAX_JOB_ATTEMPTS`; otherwise kept so a failed job can retry. A `_cleanup_loop` and `recover_stale_jobs` purge entries older than `RETRY_CACHE_TTL_MINUTES` (default 90 = 3 × the task timeout). New `retry_available()` helper.
- `routers/jobs.py` — `POST /jobs/{id}/retry` (flips `failed`→`pending`, reusing cached payload+credentials; **409** if not failed / attempts exhausted, **410** if the retention window elapsed) and `GET /jobs/{id}/retry-available`.
- `config.py` / `schemas/jobs.py` — `RETRY_CACHE_TTL_MINUTES` env + `RetryAvailability` schema.

**LAMB (Creator Interface)**
- `knowledge_store_client.py` — `retry_job` / `get_job_retry_available` proxies.
- `knowledge_store_router.py` — `POST /{ks}/content/{item}/retry` resolves the link's job, proxies the retry, flips the link back to `pending` and clears the prior error (passes `""` so the None-skipping updater actually clears it).

**Frontend**
- `knowledgeStoreService.js` — `retryIngestion()` calls the real endpoint and rethrows the backend detail (so the 410 "re-add the content" message shows).
- `IngestionProgressModal.svelte` — drop the dead `not_implemented` / "coming soon" branch; the existing optimistic flip + toast handle the rest.

Restart still clears the in-memory cache (consistent with ADR-4) — the UI then reports the window has elapsed and the user re-adds the content.

## Verification

- `lamb-kb-server`: **531 passed** (521 baseline + new `tests/integration/test_retry.py`: requeue-with-creds, 410-without-creds, 409-not-failed, 409-exhausted, 404, retry-available, auth, and worker-level retain/discard/TTL-purge). `ruff check backend/` clean.
- LAMB: `test_creator_knowledge_stores_integration.py` 13 passed; modules import-clean.
- Frontend: `prettier --check` clean on both changed files; no new `svelte-check` errors.

## Related

- Closes #440