### PR TITLE
feat(#445): opt-in clickable citation links to cited sources

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,6 +30,13 @@ LAMB_BACKEND_HOST=http://backend:9099
 #PIPELINES_BEARER_TOKEN=0p3n-w3bu!
 LAMB_BEARER_TOKEN=0p3n-w3bu!
 
+# Secret used to HMAC-sign the public citation permalinks students click from
+# chat. Per-org keys are derived from it, so rotating it revokes every signed
+# link at once. MUST stay stable across restarts (changing it breaks links in
+# existing chats). Defaults to LAMB_BEARER_TOKEN if unset; set a dedicated
+# value in production.
+#LAMB_PERMALINK_SIGNING_SECRET=change-me-to-a-long-random-string
+
 
 # Signup Configuration
 SIGNUP_ENABLED=true

--- a/backend/config.py
+++ b/backend/config.py
@@ -38,6 +38,16 @@ if not lamb_token:
 lamb_token = lamb_token.strip()
 
 LAMB_BEARER_TOKEN = lamb_token
+
+# Secret used to HMAC-sign public citation permalinks (the signed "capability"
+# URLs students click from chat). Per-org keys are derived from this master
+# secret, so rotating it revokes every signed link at once. MUST be stable
+# across restarts — if it changes, links in existing chats stop resolving.
+# Falls back to LAMB_BEARER_TOKEN so the feature works out of the box, but a
+# dedicated value is recommended in production.
+LAMB_PERMALINK_SIGNING_SECRET = (
+    os.getenv('LAMB_PERMALINK_SIGNING_SECRET') or lamb_token
+)
 PIPELINES_BEARER_TOKEN = lamb_token  # Legacy alias for backward compatibility
 PIPELINES_DIR = os.getenv("PIPELINES_DIR", "./lamb_assistants")
 

--- a/backend/creator_interface/library_router.py
+++ b/backend/creator_interface/library_router.py
@@ -1072,6 +1072,118 @@ async def export_library(
 permalink_proxy_router = APIRouter()
 
 
+# ----------------------------------------------------------------------
+# Public, HMAC-signed citation permalinks (student-clickable, no login)
+# ----------------------------------------------------------------------
+# Defined BEFORE the authenticated catch-all below so `/docs/public/...` is not
+# swallowed by `/docs/{org_id}/.../{subpath:path}` (FastAPI matches in order).
+# A student clicking a citation in the OpenWebUI chat arrives with no LAMB
+# credential, so the link authorizes itself via an org-scoped HMAC signature
+# (see permalink_signing). Traffic still flows OpenWebUI -> LAMB -> Library
+# Manager; OWI never contacts the Library Manager directly.
+
+_PUBLIC_VIEW_CSS = (
+    "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;"
+    "max-width:820px;margin:0 auto;padding:1.5rem;color:#1f2937;line-height:1.6}"
+    "header{display:flex;align-items:center;justify-content:space-between;gap:1rem;"
+    "border-bottom:1px solid #e5e7eb;padding-bottom:.75rem;margin-bottom:1.25rem}"
+    "h1{font-size:1.15rem;margin:0;word-break:break-word}"
+    "a.dl{flex:none;background:#2271b3;color:#fff;text-decoration:none;border-radius:6px;"
+    "padding:.45rem .8rem;font-size:.85rem}"
+    "article img{max-width:100%}article pre{overflow:auto;background:#f3f4f6;padding:.75rem;border-radius:6px}"
+    "article table{border-collapse:collapse}article td,article th{border:1px solid #e5e7eb;padding:.3rem .5rem}"
+)
+
+
+@permalink_proxy_router.get("/docs/public/{org_id}/{library_id}/{item_id}/view")
+async def public_permalink_view(
+    org_id: str,
+    library_id: str,
+    item_id: str,
+    name: str = Query("", description="Display filename for the cited item"),
+    sig: str = Query(..., description="Org-scoped HMAC signature"),
+):
+    """Render a cited item's content as an HTML page titled with its filename.
+
+    Public (signature-authorized) — no login required. Shows the item's
+    extracted markdown rendered to HTML under the original filename, plus a
+    "Download original" button when an original file exists.
+    """
+    from html import escape  # noqa: PLC0415
+    from urllib.parse import quote  # noqa: PLC0415
+
+    from creator_interface.permalink_signing import sign, verify  # noqa: PLC0415
+
+    if not verify(org_id, f"{org_id}/{library_id}/{item_id}/view", sig):
+        raise HTTPException(status_code=403, detail="Invalid or expired link")
+
+    # Proxy the full markdown from the Library Manager using a system context
+    # (the signature is the authorization; there is no end-user identity here).
+    response = await _client.proxy_content(
+        library_id=library_id,
+        item_id=item_id,
+        subpath="content",
+        creator_user={},
+    )
+    markdown_text = response.content.decode("utf-8", errors="replace")
+
+    try:
+        from markdown_it import MarkdownIt  # noqa: PLC0415
+        body_html = MarkdownIt("commonmark", {"html": False, "linkify": True}).render(markdown_text)
+    except Exception:  # noqa: BLE001 — fall back to preformatted text
+        body_html = f"<pre>{escape(markdown_text)}</pre>"
+
+    title = escape(name or "Source document")
+    download_html = ""
+    # Offer the original download only when the cited item is a real file
+    # (has an extension); URL/transcript sources have no original to download.
+    if name and "." in name:
+        dl_sig = sign(org_id, f"{org_id}/{library_id}/{item_id}/original/{name}")
+        dl_url = (
+            f"/docs/public/{org_id}/{library_id}/{item_id}/original/{quote(name)}?sig={dl_sig}"
+        )
+        download_html = f'<a class="dl" href="{escape(dl_url)}">Download original</a>'
+
+    page = (
+        f"<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+        f"<title>{title}</title><style>{_PUBLIC_VIEW_CSS}</style></head>"
+        f"<body><header><h1>{title}</h1>{download_html}</header>"
+        f"<article>{body_html}</article></body></html>"
+    )
+    return Response(content=page, media_type="text/html; charset=utf-8")
+
+
+@permalink_proxy_router.get(
+    "/docs/public/{org_id}/{library_id}/{item_id}/original/{filename:path}"
+)
+async def public_permalink_original(
+    org_id: str,
+    library_id: str,
+    item_id: str,
+    filename: str,
+    sig: str = Query(..., description="Org-scoped HMAC signature"),
+):
+    """Stream the original uploaded file for a cited item (signature-authorized)."""
+    from creator_interface.permalink_signing import verify  # noqa: PLC0415
+
+    if not verify(org_id, f"{org_id}/{library_id}/{item_id}/original/{filename}", sig):
+        raise HTTPException(status_code=403, detail="Invalid or expired link")
+
+    response = await _client.proxy_content(
+        library_id=library_id,
+        item_id=item_id,
+        subpath=f"original/{filename}",
+        creator_user={},
+    )
+    content_type = response.headers.get("content-type", "application/octet-stream")
+    return Response(
+        content=response.content,
+        media_type=content_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
 @permalink_proxy_router.get("/docs/{org_id}/{library_id}/{item_id}/{subpath:path}")
 async def permalink_proxy(
     org_id: str,

--- a/backend/creator_interface/permalink_signing.py
+++ b/backend/creator_interface/permalink_signing.py
@@ -1,0 +1,52 @@
+"""HMAC signing for public citation permalinks.
+
+When a learning assistant cites a source in chat, the student clicking the
+citation arrives as an unauthenticated, cross-origin browser navigation that
+carries no LAMB credential. So the link must authorize itself: it embeds an
+HMAC signature that a public serving route verifies.
+
+Design (decided with the project lead):
+- **Per-organization isolation.** The signing key is derived from the master
+  secret AND the org id, so a signature minted for one org's item can never be
+  reused to forge another org's link. Rotating one org's effective key (by
+  rotating the master secret) is the kill-switch.
+- **No expiry.** Links live as long as the chat history that contains them, so
+  old conversations stay consistent. Revocation is coarse by design: rotate
+  ``LAMB_PERMALINK_SIGNING_SECRET`` (revokes everything) or delete the library
+  item (its link then 404s at the proxy).
+- **Capability semantics.** Within an org, anyone holding a specific link can
+  open that one item — there is no identity to check on the click. This is the
+  accepted trade-off for letting students reach cited sources without a login.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from config import LAMB_PERMALINK_SIGNING_SECRET
+
+_MASTER = (LAMB_PERMALINK_SIGNING_SECRET or "").encode("utf-8")
+
+
+def _org_key(org_id: str) -> bytes:
+    """Derive a per-organization signing key from the master secret."""
+    return hmac.new(_MASTER, f"perm:{org_id}".encode(), hashlib.sha256).digest()
+
+
+def sign(org_id: str, resource: str) -> str:
+    """Return the hex HMAC signature for ``resource`` scoped to ``org_id``.
+
+    ``resource`` is a canonical, slash-joined string identifying exactly what
+    may be served, e.g. ``"3/lib-uuid/item-uuid/view"`` or
+    ``"3/lib-uuid/item-uuid/original/cv.pdf"``.
+    """
+    return hmac.new(_org_key(str(org_id)), resource.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def verify(org_id: str, resource: str, signature: str) -> bool:
+    """Constant-time check that ``signature`` is valid for ``(org_id, resource)``."""
+    if not signature:
+        return False
+    expected = sign(org_id, resource)
+    return hmac.compare_digest(expected, signature)

--- a/backend/lamb/completions/citation_sources.py
+++ b/backend/lamb/completions/citation_sources.py
@@ -1,0 +1,87 @@
+"""Build the ``sources`` payload that Open WebUI renders as a citations panel.
+
+LAMB controls the full SSE stream to Open WebUI. OWI natively parses a
+top-level ``sources`` field out of the stream, renders a clickable, persisted
+citations panel, and auto-links inline ``[N]`` markers in the answer to it —
+but only when the source's ``name`` is the literal string ``"N"`` and its
+``url`` is an absolute ``http(s)`` link. This module maps LAMB's internal RAG
+sources to that exact shape, minting org-scoped HMAC-signed "view" URLs so a
+student can open the cited item without logging in.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote
+
+from config import LAMB_WEB_HOST
+from creator_interface.permalink_signing import sign
+from lamb.logging_config import get_logger
+
+logger = get_logger(__name__, component="RAG")
+
+
+def _parse_permalink(source: Dict[str, Any]) -> Optional[tuple]:
+    """Extract ``(org, lib, item, original_filename)`` from a source's permalinks.
+
+    Permalinks have the form ``/docs/{org}/{lib}/{item}/...``; the original
+    filename (when present) is the last segment of ``permalink_original``.
+    """
+    for key in ("permalink_markdown", "permalink_page", "permalink_original"):
+        permalink = source.get(key)
+        if permalink and permalink.startswith("/docs/"):
+            parts = permalink.split("/")  # ['', 'docs', org, lib, item, ...]
+            if len(parts) >= 5:
+                org, lib, item = parts[2], parts[3], parts[4]
+                filename = ""
+                original = source.get("permalink_original")
+                if original:
+                    filename = original.rstrip("/").split("/")[-1]
+                return org, lib, item, filename
+    return None
+
+
+def _signed_view_url(org: str, lib: str, item: str, filename: str) -> str:
+    """Mint the absolute, org-scoped signed URL for a cited item's view page."""
+    sig = sign(org, f"{org}/{lib}/{item}/view")
+    base = LAMB_WEB_HOST.rstrip("/")
+    return f"{base}/docs/public/{org}/{lib}/{item}/view?name={quote(filename)}&sig={sig}"
+
+
+def build_owi_sources(rag_context: Any) -> List[Dict[str, Any]]:
+    """Map LAMB RAG sources to Open WebUI's citations schema.
+
+    Each entry is named with its 1-based citation number so OWI auto-links the
+    inline ``[N]`` markers, carries the supporting excerpt under the real
+    filename, and points at a signed view URL. Returns ``[]`` when there are no
+    sources (so no citations event is emitted).
+    """
+    if not isinstance(rag_context, dict):
+        return []
+    owi: List[Dict[str, Any]] = []
+    for src in rag_context.get("sources", []) or []:
+        n = src.get("n")
+        name = str(n) if n is not None else (src.get("title") or "?")
+        text = src.get("text") or ""
+        filename = src.get("title") or "Source"
+
+        url = ""
+        parsed = _parse_permalink(src)
+        if parsed:
+            org, lib, item, original_filename = parsed
+            filename = original_filename or filename
+            try:
+                url = _signed_view_url(org, lib, item, filename)
+            except Exception:  # noqa: BLE001 — never let citation building break a chat
+                logger.warning("Failed to sign citation URL for source %s", name)
+
+        excerpt = f"**{filename}**\n\n{text}" if text else f"**{filename}**"
+        score = src.get("score")
+        owi.append({
+            # name == "N" so OWI links the inline [N] marker to this entry.
+            "source": {"name": name, "url": url},
+            "document": [excerpt],
+            "metadata": [{"name": name, "filename": filename}],
+            "distances": [score] if isinstance(score, (int, float)) else [],
+        })
+    return owi

--- a/backend/lamb/completions/citation_sources.py
+++ b/backend/lamb/completions/citation_sources.py
@@ -1,12 +1,18 @@
-"""Build the ``sources`` payload that Open WebUI renders as a citations panel.
+"""Render RAG citations so a student can click through to the cited item.
 
-LAMB controls the full SSE stream to Open WebUI. OWI natively parses a
-top-level ``sources`` field out of the stream, renders a clickable, persisted
-citations panel, and auto-links inline ``[N]`` markers in the answer to it —
-but only when the source's ``name`` is the literal string ``"N"`` and its
-``url`` is an absolute ``http(s)`` link. This module maps LAMB's internal RAG
-sources to that exact shape, minting org-scoped HMAC-signed "view" URLs so a
-student can open the cited item without logging in.
+Open WebUI's backend, on the normal (websocket) chat path, forwards only the
+assistant's ``content`` from an external model's stream — it drops any
+top-level ``sources`` field (it renders only sources it generates itself). So
+to surface clickable citations through OWI we append a Markdown **Sources**
+section to the answer content; OWI renders it like any other markdown.
+
+Each source links to a LAMB-served view page via an org-scoped, HMAC-signed
+"capability" URL (see ``creator_interface.permalink_signing``) so a logged-out
+student can open the cited item. The inline ``[N]`` markers in the body point
+at the numbered list.
+
+``build_owi_sources`` (the OWI ``sources`` schema) is kept for non-streaming /
+spec-compliant clients that *do* consume the field.
 """
 
 from __future__ import annotations
@@ -48,13 +54,60 @@ def _signed_view_url(org: str, lib: str, item: str, filename: str) -> str:
     return f"{base}/docs/public/{org}/{lib}/{item}/view?name={quote(filename)}&sig={sig}"
 
 
+def build_sources_markdown(rag_context: Any) -> str:
+    """Build a Markdown 'Sources' section appended to the answer content.
+
+    Sources are grouped by library item (chunks are numbered individually by
+    the RAG processor, but several chunks often come from the same document).
+    Each line lists every citation number that points at the item followed by a
+    clickable link, e.g. ``[1][3][5] [cv.pdf](https://…/view?…)`` — so every
+    inline ``[N]`` marker in the answer resolves to a clickable entry. Returns
+    ``""`` when there are no sources. Lines deliberately avoid the ``[N]: url``
+    reference-definition form, which OWI strips.
+    """
+    if not isinstance(rag_context, dict):
+        return ""
+    groups: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
+    for src in rag_context.get("sources", []) or []:
+        n = src.get("n")
+        filename = src.get("title") or "Source"
+        url = ""
+        parsed = _parse_permalink(src)
+        item_key = None
+        if parsed:
+            org, lib, item, original_filename = parsed
+            item_key = f"{org}/{lib}/{item}"
+            filename = original_filename or filename
+            try:
+                url = _signed_view_url(org, lib, item, filename)
+            except Exception:  # noqa: BLE001 — never let citation building break a chat
+                logger.warning("Failed to sign citation URL for source %s", n)
+        key = item_key or f"_{n}"
+        if key not in groups:
+            groups[key] = {"ns": [], "filename": filename, "url": url}
+            order.append(key)
+        if n is not None:
+            groups[key]["ns"].append(n)
+
+    if not order:
+        return ""
+    lines: List[str] = []
+    for key in order:
+        g = groups[key]
+        marks = "".join(f"[{n}]" for n in sorted(g["ns"])) or "-"
+        link = f"[{g['filename']}]({g['url']})" if g["url"] else g["filename"]
+        lines.append(f"{marks} {link}")
+    return "\n\n---\n\n**Sources**\n\n" + "\n\n".join(lines) + "\n"
+
+
 def build_owi_sources(rag_context: Any) -> List[Dict[str, Any]]:
     """Map LAMB RAG sources to Open WebUI's citations schema.
 
-    Each entry is named with its 1-based citation number so OWI auto-links the
-    inline ``[N]`` markers, carries the supporting excerpt under the real
-    filename, and points at a signed view URL. Returns ``[]`` when there are no
-    sources (so no citations event is emitted).
+    Kept for non-streaming responses and any spec-compliant client that
+    consumes a top-level ``sources`` field. (OWI's websocket chat path drops
+    this for external models — the Markdown section above is what reaches the
+    student there.)
     """
     if not isinstance(rag_context, dict):
         return []
@@ -64,7 +117,6 @@ def build_owi_sources(rag_context: Any) -> List[Dict[str, Any]]:
         name = str(n) if n is not None else (src.get("title") or "?")
         text = src.get("text") or ""
         filename = src.get("title") or "Source"
-
         url = ""
         parsed = _parse_permalink(src)
         if parsed:
@@ -72,13 +124,11 @@ def build_owi_sources(rag_context: Any) -> List[Dict[str, Any]]:
             filename = original_filename or filename
             try:
                 url = _signed_view_url(org, lib, item, filename)
-            except Exception:  # noqa: BLE001 — never let citation building break a chat
+            except Exception:  # noqa: BLE001
                 logger.warning("Failed to sign citation URL for source %s", name)
-
         excerpt = f"**{filename}**\n\n{text}" if text else f"**{filename}**"
         score = src.get("score")
         owi.append({
-            # name == "N" so OWI links the inline [N] marker to this entry.
             "source": {"name": name, "url": url},
             "document": [excerpt],
             "metadata": [{"name": name, "filename": filename}],

--- a/backend/lamb/completions/main.py
+++ b/backend/lamb/completions/main.py
@@ -257,6 +257,26 @@ def get_assistant_details(assistant: int) -> Any:
     return assistant_details
 
 
+def _assistant_exposes_sources(assistant: Any) -> bool:
+    """Whether this assistant opts in to student-clickable cited-source links.
+
+    Reads ``metadata.capabilities.expose_sources`` (mirroring the vision /
+    image_generation capability flags). Defaults to False, so existing
+    assistants — and any whose JSON lacks the key — never expose their cited
+    documents until the creator explicitly enables it.
+    """
+    if not assistant:
+        return False
+    metadata_str = getattr(assistant, "metadata", None) or getattr(assistant, "api_callback", None)
+    if not metadata_str:
+        return False
+    try:
+        capabilities = json.loads(metadata_str).get("capabilities", {}) or {}
+        return bool(capabilities.get("expose_sources", False))
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+
 def _provider_for_connector(connector: str) -> str | None:
     """Map connector name to provider string used in model_pricing table."""
     return {"openai": "openai", "anthropic": "anthropic"}.get(connector)
@@ -484,6 +504,9 @@ async def run_lamb_assistant(
         rag_context = await get_rag_context(request, rag_processors, plugin_config["rag_processor"], assistant_details)
         document_context = await get_rag_context(request, rag_processors, plugin_config.get("document_rag", ""), assistant_details)
         messages = process_completion_request(request, assistant_details, plugin_config, rag_context, pps, document_context)
+        # Clickable source links are opt-in per assistant (default off): only
+        # expose cited documents to students when the creator enabled it.
+        expose_sources = _assistant_exposes_sources(assistant_details)
         stream = request.get("stream", False)
         llm = plugin_config.get("llm") # Get LLM from config
 
@@ -516,7 +539,7 @@ async def run_lamb_assistant(
                 # Open WebUI's chat path forwards only `choices[].delta.content`
                 # from an external model and drops any `sources` field.
                 from lamb.completions.citation_sources import build_sources_markdown  # noqa: PLC0415
-                sources_md = build_sources_markdown(rag_context)
+                sources_md = build_sources_markdown(rag_context) if expose_sources else ""
                 sources_chunk = None
                 if sources_md:
                     _delta = {"choices": [{
@@ -588,7 +611,7 @@ async def run_lamb_assistant(
             # Attach OpenWebUI-shaped citations so the panel renders on the
             # non-streaming path too (standard OpenAI clients ignore the key).
             from lamb.completions.citation_sources import build_owi_sources  # noqa: PLC0415
-            owi_sources = build_owi_sources(rag_context)
+            owi_sources = build_owi_sources(rag_context) if expose_sources else []
             if owi_sources:
                 llm_response["sources"] = owi_sources
 

--- a/backend/lamb/completions/main.py
+++ b/backend/lamb/completions/main.py
@@ -510,27 +510,32 @@ async def run_lamb_assistant(
                 generator, usage_out = llm_response, None
 
             async def _tracked_stream():
-                # Build the OpenWebUI citations payload from the retrieved RAG
-                # sources and emit it as one SSE event just before [DONE] so OWI
-                # renders a clickable, persisted citations panel and links the
-                # inline [N] markers to it.
-                from lamb.completions.citation_sources import build_owi_sources  # noqa: PLC0415
-                owi_sources = build_owi_sources(rag_context)
-                sources_event = (
-                    f"data: {json.dumps({'sources': owi_sources})}\n\n"
-                    if owi_sources else None
-                )
+                # Append a Markdown "Sources" section (clickable signed links)
+                # to the answer content just before [DONE]. We deliver it as
+                # answer CONTENT — not a top-level `sources` field — because
+                # Open WebUI's chat path forwards only `choices[].delta.content`
+                # from an external model and drops any `sources` field.
+                from lamb.completions.citation_sources import build_sources_markdown  # noqa: PLC0415
+                sources_md = build_sources_markdown(rag_context)
+                sources_chunk = None
+                if sources_md:
+                    _delta = {"choices": [{
+                        "index": 0,
+                        "delta": {"content": sources_md},
+                        "finish_reason": None,
+                    }]}
+                    sources_chunk = f"data: {json.dumps(_delta)}\n\n"
                 sources_sent = False
                 async for chunk in generator:
                     if (
-                        sources_event and not sources_sent
+                        sources_chunk and not sources_sent
                         and isinstance(chunk, str) and "data: [DONE]" in chunk
                     ):
-                        yield sources_event
+                        yield sources_chunk
                         sources_sent = True
                     yield chunk
-                if sources_event and not sources_sent:
-                    yield sources_event
+                if sources_chunk and not sources_sent:
+                    yield sources_chunk
                 # Log usage when stream completes for tracked connectors
                 if connector != "ollama" and usage_out and provider and assistant_details.organization_id is not None:
                     db_manager.log_token_usage(

--- a/backend/lamb/completions/main.py
+++ b/backend/lamb/completions/main.py
@@ -510,8 +510,27 @@ async def run_lamb_assistant(
                 generator, usage_out = llm_response, None
 
             async def _tracked_stream():
+                # Build the OpenWebUI citations payload from the retrieved RAG
+                # sources and emit it as one SSE event just before [DONE] so OWI
+                # renders a clickable, persisted citations panel and links the
+                # inline [N] markers to it.
+                from lamb.completions.citation_sources import build_owi_sources  # noqa: PLC0415
+                owi_sources = build_owi_sources(rag_context)
+                sources_event = (
+                    f"data: {json.dumps({'sources': owi_sources})}\n\n"
+                    if owi_sources else None
+                )
+                sources_sent = False
                 async for chunk in generator:
+                    if (
+                        sources_event and not sources_sent
+                        and isinstance(chunk, str) and "data: [DONE]" in chunk
+                    ):
+                        yield sources_event
+                        sources_sent = True
                     yield chunk
+                if sources_event and not sources_sent:
+                    yield sources_event
                 # Log usage when stream completes for tracked connectors
                 if connector != "ollama" and usage_out and provider and assistant_details.organization_id is not None:
                     db_manager.log_token_usage(
@@ -560,6 +579,13 @@ async def run_lamb_assistant(
                         "sources": rag_context.get("sources", []),
                     }
                 }
+
+            # Attach OpenWebUI-shaped citations so the panel renders on the
+            # non-streaming path too (standard OpenAI clients ignore the key).
+            from lamb.completions.citation_sources import build_owi_sources  # noqa: PLC0415
+            owi_sources = build_owi_sources(rag_context)
+            if owi_sources:
+                llm_response["sources"] = owi_sources
 
             return Response(
                 content=json.dumps(llm_response, indent=2), # Ensure pretty printing if desired

--- a/backend/lamb/completions/pps/kvcache_augment.py
+++ b/backend/lamb/completions/pps/kvcache_augment.py
@@ -27,45 +27,25 @@ CITATION_INSTRUCTION = (
 )
 
 
-def _format_sources_block(sources: List[Dict[str, Any]]) -> str:
-    """Render a numbered ``## Available Sources`` markdown block.
-
-    Each source is labelled with its citation number ``n`` (assigned by the
-    KS RAG processor so it aligns with the ``[N]`` markers in the context). A
-    relevance score is shown when available.
-    """
-    if not sources:
-        return ""
-    lines = ["\n\n## Available Sources\n"]
-    for i, source in enumerate(sources, 1):
-        n = source.get("n", i)
-        title = source.get("title", "Unknown")
-        url = source.get("url", "")
-        score = source.get("score")
-        score_str = (
-            f" (relevance: {score:.3f})" if isinstance(score, (int, float)) else ""
-        )
-        if url:
-            lines.append(f"[{n}] [{title}]({url}){score_str}")
-        else:
-            lines.append(f"[{n}] {title}{score_str}")
-    return "\n".join(lines)
-
-
 def _build_full_context(rag_context: Any) -> str:
-    """Combine retrieved context, the numbered sources block, and the inline
-    citation instruction into the text that replaces ``{context}``.
+    """Build the text that replaces ``{context}``: the numbered context plus the
+    inline citation instruction.
 
-    The citation instruction is only appended when there are sources to cite,
-    so answers without retrieved context are never told to fabricate markers.
+    The retrieved context is already prefixed per chunk with ``[N]`` markers by
+    the KS RAG processor, so the model can cite from it directly. We do NOT
+    inject a visible sources list here — the source titles and clickable links
+    are rendered by the OpenWebUI citations panel (see
+    ``lamb.completions.citation_sources``), so echoing a second list in the
+    answer would be redundant and would surface non-clickable raw URLs. The
+    citation instruction is only appended when there are sources to cite, so
+    answers without retrieved context are never told to fabricate markers.
     """
     if not isinstance(rag_context, dict):
         return str(rag_context) if rag_context else ""
     context = rag_context.get("context", "") or ""
     sources = rag_context.get("sources", []) or []
-    sources_block = _format_sources_block(sources)
-    if sources_block:
-        return context + sources_block + "\n\n" + CITATION_INSTRUCTION
+    if sources:
+        return context + "\n\n" + CITATION_INSTRUCTION
     return context
 
 

--- a/backend/lamb/completions/pps/kvcache_augment.py
+++ b/backend/lamb/completions/pps/kvcache_augment.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List, Optional
 from lamb.lamb_classes import Assistant
 import json
+import re
 from lamb.logging_config import get_logger
 
 logger = get_logger(__name__, component="MAIN")
@@ -27,26 +28,48 @@ CITATION_INSTRUCTION = (
 )
 
 
-def _build_full_context(rag_context: Any) -> str:
-    """Build the text that replaces ``{context}``: the numbered context plus the
-    inline citation instruction.
+def _build_full_context(rag_context: Any, cite: bool = True) -> str:
+    """Build the text that replaces ``{context}``.
 
     The retrieved context is already prefixed per chunk with ``[N]`` markers by
-    the KS RAG processor, so the model can cite from it directly. We do NOT
-    inject a visible sources list here — the source titles and clickable links
-    are rendered by the OpenWebUI citations panel (see
-    ``lamb.completions.citation_sources``), so echoing a second list in the
-    answer would be redundant and would surface non-clickable raw URLs. The
-    citation instruction is only appended when there are sources to cite, so
-    answers without retrieved context are never told to fabricate markers.
+    the KS RAG processor. When ``cite`` is True we keep those markers and append
+    the inline citation instruction so the model cites — the clickable source
+    list is then rendered separately (see ``lamb.completions.citation_sources``).
+
+    When ``cite`` is False (the assistant did NOT opt in to exposing sources),
+    we strip the ``[N]`` prefixes and omit the instruction, so the answer has no
+    citation markers at all — students never see ``[1]`` pointing at a source
+    they cannot open.
     """
     if not isinstance(rag_context, dict):
         return str(rag_context) if rag_context else ""
     context = rag_context.get("context", "") or ""
     sources = rag_context.get("sources", []) or []
-    if sources:
+    if sources and cite:
         return context + "\n\n" + CITATION_INSTRUCTION
+    if not cite and context:
+        # Drop the per-chunk "[N] " citation prefixes so the model has no cue
+        # to emit citation markers it cannot link to.
+        context = re.sub(r"(?m)^\[\d+\]\s+", "", context)
     return context
+
+
+def _exposes_sources(assistant: Assistant) -> bool:
+    """Whether this assistant opts in to student-clickable cited sources.
+
+    Mirrors ``_has_vision_capability``; defaults to False so citations are only
+    produced when the creator enabled ``capabilities.expose_sources``.
+    """
+    if not assistant:
+        return False
+    metadata_str = getattr(assistant, 'metadata', None) or getattr(assistant, 'api_callback', None)
+    if not metadata_str:
+        return False
+    try:
+        capabilities = json.loads(metadata_str).get('capabilities', {}) or {}
+        return bool(capabilities.get('expose_sources', False))
+    except (json.JSONDecodeError, AttributeError):
+        return False
 
 
 def _has_vision_capability(assistant: Assistant) -> bool:
@@ -86,6 +109,10 @@ def prompt_processor(
     messages = request.get('messages', [])
     if not messages:
         return messages
+
+    # Only cite (inline [N] markers + clickable sources) when the assistant
+    # opted in to exposing sources; otherwise produce no citation markers.
+    cite = _exposes_sources(assistant)
 
     last_message = messages[-1]['content']
     processed_messages = []
@@ -130,7 +157,7 @@ def prompt_processor(
                 augmented_text = assistant.prompt_template.replace("{user_input}", "\n\n" + user_input_text + "\n\n")
 
                 if rag_context:
-                    full_context = _build_full_context(rag_context)
+                    full_context = _build_full_context(rag_context, cite)
                     augmented_text = augmented_text.replace("{context}", "\n\n" + full_context + "\n\n")
                 else:
                     augmented_text = augmented_text.replace("{context}", "")
@@ -158,7 +185,7 @@ def prompt_processor(
                 prompt = assistant.prompt_template.replace("{user_input}", "\n\n" + user_input_text + "\n\n")
 
                 if rag_context:
-                    full_context = _build_full_context(rag_context)
+                    full_context = _build_full_context(rag_context, cite)
                     prompt = prompt.replace("{context}", "\n\n" + full_context + "\n\n")
                 else:
                     prompt = prompt.replace("{context}", "")
@@ -189,7 +216,7 @@ def prompt_processor(
                     user_input_text = str(last_message)
 
                 prompt = effective_template.replace("{user_input}", "\n\n" + user_input_text + "\n\n")
-                full_context = _build_full_context(rag_context)
+                full_context = _build_full_context(rag_context, cite)
                 prompt = prompt.replace("{context}", "\n\n" + full_context + "\n\n")
 
                 processed_messages.append({

--- a/backend/lamb/completions/rag/_ks_query_helpers.py
+++ b/backend/lamb/completions/rag/_ks_query_helpers.py
@@ -140,6 +140,9 @@ def build_context_and_sources(
             context_parts.append(f"[{n}] {text}")
             source = _build_source(ks_id, chunk)
             source["n"] = n
+            # Keep the chunk text on the source so the citation UI can show the
+            # supporting excerpt (e.g. OWI's citations panel).
+            source["text"] = text
             sources.append(source)
     combined_context = "\n\n".join(context_parts) if context_parts else ""
     return combined_context, sources

--- a/backend/tests/test_citation_sources.py
+++ b/backend/tests/test_citation_sources.py
@@ -1,0 +1,64 @@
+"""Tests for mapping LAMB RAG sources to the OpenWebUI citations schema."""
+
+from urllib.parse import parse_qs, urlparse
+
+from lamb.completions.citation_sources import build_owi_sources
+from creator_interface.permalink_signing import verify
+
+
+def _source(n, **over):
+    src = {
+        "n": n,
+        "title": "Doc",
+        "score": 0.9,
+        "text": "supporting excerpt",
+        "permalink_markdown": "/docs/3/lib-1/item-1/content",
+        "permalink_original": "/docs/3/lib-1/item-1/original/noa-ventura-cv.pdf",
+    }
+    src.update(over)
+    return src
+
+
+class TestBuildOwiSources:
+    def test_empty_when_no_sources(self):
+        assert build_owi_sources({"sources": []}) == []
+        assert build_owi_sources(None) == []
+
+    def test_shape_matches_owi_contract(self):
+        out = build_owi_sources({"sources": [_source(1)]})
+        assert len(out) == 1
+        entry = out[0]
+        # name == "1" so OWI auto-links the inline [1] marker.
+        assert entry["source"]["name"] == "1"
+        assert entry["metadata"][0]["name"] == "1"
+        # document[] holds the excerpt under the real filename.
+        assert entry["document"][0].startswith("**noa-ventura-cv.pdf**")
+        assert "supporting excerpt" in entry["document"][0]
+        assert entry["metadata"][0]["filename"] == "noa-ventura-cv.pdf"
+        assert entry["distances"] == [0.9]
+
+    def test_url_is_absolute_signed_and_verifiable(self):
+        out = build_owi_sources({"sources": [_source(1)]})
+        url = out[0]["source"]["url"]
+        assert url.startswith("http")  # OWI only links http(s) urls
+        parsed = urlparse(url)
+        assert parsed.path == "/docs/public/3/lib-1/item-1/view"
+        sig = parse_qs(parsed.query)["sig"][0]
+        assert verify("3", "3/lib-1/item-1/view", sig) is True
+        # filename carried for the page title / download
+        assert parse_qs(parsed.query)["name"][0] == "noa-ventura-cv.pdf"
+
+    def test_numbering_preserved_across_multiple_sources(self):
+        out = build_owi_sources({"sources": [_source(1), _source(2, title="Doc2")]})
+        assert [e["source"]["name"] for e in out] == ["1", "2"]
+
+    def test_missing_score_yields_empty_distances(self):
+        out = build_owi_sources({"sources": [_source(1, score=None)]})
+        assert out[0]["distances"] == []
+
+    def test_no_permalink_leaves_url_empty(self):
+        src = {"n": 1, "title": "Doc", "text": "x"}
+        out = build_owi_sources({"sources": [src]})
+        # No permalink → no signed URL (OWI renders it non-clickable).
+        assert out[0]["source"]["url"] == ""
+        assert out[0]["document"][0].startswith("**Doc**")

--- a/backend/tests/test_citation_sources.py
+++ b/backend/tests/test_citation_sources.py
@@ -2,7 +2,7 @@
 
 from urllib.parse import parse_qs, urlparse
 
-from lamb.completions.citation_sources import build_owi_sources
+from lamb.completions.citation_sources import build_owi_sources, build_sources_markdown
 from creator_interface.permalink_signing import verify
 
 
@@ -62,3 +62,37 @@ class TestBuildOwiSources:
         # No permalink → no signed URL (OWI renders it non-clickable).
         assert out[0]["source"]["url"] == ""
         assert out[0]["document"][0].startswith("**Doc**")
+
+
+class TestBuildSourcesMarkdown:
+    def test_empty_when_no_sources(self):
+        assert build_sources_markdown({"sources": []}) == ""
+        assert build_sources_markdown(None) == ""
+
+    def test_renders_clickable_numbered_list(self):
+        md = build_sources_markdown({"sources": [_source(1)]})
+        assert "**Sources**" in md
+        # [N] marker plus a clickable markdown link to the signed view page.
+        assert "[1] [noa-ventura-cv.pdf](http" in md
+        # Not the reference-definition form (OWI strips "[1]: url").
+        assert "[1]:" not in md
+
+    def test_groups_chunks_from_same_item_into_one_line(self):
+        # Two chunks from the same item → one line listing BOTH numbers so each
+        # inline marker resolves: "[1][2] [filename](url)".
+        a = _source(1)
+        b = _source(2)  # same permalinks/item as _source default
+        md = build_sources_markdown({"sources": [a, b]})
+        assert md.count("[noa-ventura-cv.pdf](") == 1  # one clickable link
+        assert "[1][2] [noa-ventura-cv.pdf](http" in md
+
+    def test_distinct_items_each_listed(self):
+        a = _source(1)
+        b = _source(
+            2,
+            permalink_markdown="/docs/3/lib-2/item-2/content",
+            permalink_original="/docs/3/lib-2/item-2/original/other.pdf",
+        )
+        md = build_sources_markdown({"sources": [a, b]})
+        assert "noa-ventura-cv.pdf" in md and "other.pdf" in md
+        assert "[1]" in md and "[2]" in md

--- a/backend/tests/test_kvcache_augment.py
+++ b/backend/tests/test_kvcache_augment.py
@@ -1,9 +1,13 @@
-"""Tests for the inline-citation rendering in the kvcache_augment PPS."""
+"""Tests for the inline-citation handling in the kvcache_augment PPS.
+
+The PPS no longer injects a visible sources list (the OpenWebUI citations panel
+renders sources now). It only ensures the numbered context reaches the model
+and that the citation instruction is appended when sources exist.
+"""
 
 from lamb.completions.pps.kvcache_augment import (
     CITATION_INSTRUCTION,
     _build_full_context,
-    _format_sources_block,
     prompt_processor,
 )
 from lamb.lamb_classes import Assistant
@@ -28,40 +32,17 @@ def _make_assistant(**overrides):
     return Assistant(**defaults)
 
 
-class TestFormatSourcesBlock:
-    def test_empty_sources_returns_empty(self):
-        assert _format_sources_block([]) == ""
-
-    def test_uses_citation_number_and_renders_score(self):
-        sources = [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.873}]
-        block = _format_sources_block(sources)
-        assert "## Available Sources" in block
-        assert "[1] [Doc A](/docs/a.md)" in block
-        # The relevance score (the KS `score` field) renders — not 0.000.
-        assert "relevance: 0.873" in block
-
-    def test_missing_score_is_omitted_gracefully(self):
-        sources = [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": None}]
-        block = _format_sources_block(sources)
-        assert "[1] [Doc A](/docs/a.md)" in block
-        assert "relevance" not in block
-
-    def test_falls_back_to_enumeration_when_n_absent(self):
-        sources = [{"title": "Doc A", "url": ""}]
-        block = _format_sources_block(sources)
-        assert "[1] Doc A" in block
-
-
 class TestBuildFullContext:
-    def test_appends_sources_block_and_instruction(self):
+    def test_appends_instruction_when_sources_exist(self):
         rag_context = {
             "context": "[1] some retrieved text",
-            "sources": [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.9}],
+            "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
         }
         full = _build_full_context(rag_context)
         assert "[1] some retrieved text" in full
-        assert "## Available Sources" in full
         assert CITATION_INSTRUCTION in full
+        # No visible sources list is injected anymore (OWI renders it).
+        assert "## Available Sources" not in full
 
     def test_no_sources_means_no_citation_instruction(self):
         rag_context = {"context": "plain context", "sources": []}
@@ -75,31 +56,30 @@ class TestBuildFullContext:
 
 
 class TestPromptProcessorInjection:
-    def test_no_template_branch_injects_sources_and_instruction(self):
-        """Even without a prompt_template, the sources block + citation
+    def test_no_template_branch_injects_instruction(self):
+        """Even without a prompt_template, the numbered context + citation
         instruction must reach the model."""
         assistant = _make_assistant(prompt_template="")
         request = {"messages": [{"role": "user", "content": "What is X?"}]}
         rag_context = {
             "context": "[1] X is a thing.",
-            "sources": [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.9}],
+            "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
         }
         out = prompt_processor(request, assistant=assistant, rag_context=rag_context)
         user_msg = out[-1]["content"]
-        assert "## Available Sources" in user_msg
         assert CITATION_INSTRUCTION in user_msg
         assert "[1] X is a thing." in user_msg
+        assert "## Available Sources" not in user_msg
 
-    def test_template_branch_injects_sources_and_instruction(self):
+    def test_template_branch_injects_instruction(self):
         assistant = _make_assistant(
             prompt_template="Context:\n{context}\n\nQ: {user_input}"
         )
         request = {"messages": [{"role": "user", "content": "What is X?"}]}
         rag_context = {
             "context": "[1] X is a thing.",
-            "sources": [{"n": 1, "title": "Doc A", "url": "/docs/a.md", "score": 0.9}],
+            "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
         }
         out = prompt_processor(request, assistant=assistant, rag_context=rag_context)
         user_msg = out[-1]["content"]
-        assert "## Available Sources" in user_msg
         assert CITATION_INSTRUCTION in user_msg

--- a/backend/tests/test_kvcache_augment.py
+++ b/backend/tests/test_kvcache_augment.py
@@ -1,19 +1,24 @@
-"""Tests for the inline-citation handling in the kvcache_augment PPS.
+"""Tests for the citation handling in the kvcache_augment PPS.
 
-The PPS no longer injects a visible sources list (the OpenWebUI citations panel
-renders sources now). It only ensures the numbered context reaches the model
-and that the citation instruction is appended when sources exist.
+Citations are opt-in per assistant via ``capabilities.expose_sources``. When
+off (the default), no inline ``[N]`` markers or instruction reach the model and
+the ``[N]`` context prefixes are stripped. When on, the numbered context and
+the cite instruction are kept (the clickable source list is rendered
+separately).
 """
+
+import json
 
 from lamb.completions.pps.kvcache_augment import (
     CITATION_INSTRUCTION,
     _build_full_context,
+    _exposes_sources,
     prompt_processor,
 )
 from lamb.lamb_classes import Assistant
 
 
-def _make_assistant(**overrides):
+def _make_assistant(expose_sources=False, **overrides):
     defaults = {
         "id": 1,
         "name": "Test",
@@ -23,7 +28,7 @@ def _make_assistant(**overrides):
         "RAG_collections": "ks-1",
         "RAG_Top_k": 3,
         "owner": "user@test.com",
-        "api_callback": "",
+        "api_callback": json.dumps({"capabilities": {"expose_sources": expose_sources}}),
         "pre_retrieval_endpoint": "",
         "post_retrieval_endpoint": "",
         "RAG_endpoint": "",
@@ -32,54 +37,78 @@ def _make_assistant(**overrides):
     return Assistant(**defaults)
 
 
+class TestExposesSources:
+    def test_defaults_false(self):
+        assert _exposes_sources(_make_assistant()) is False
+        assert _exposes_sources(None) is False
+
+    def test_true_when_enabled(self):
+        assert _exposes_sources(_make_assistant(expose_sources=True)) is True
+
+    def test_false_on_missing_or_bad_metadata(self):
+        assert _exposes_sources(_make_assistant(api_callback="")) is False
+        assert _exposes_sources(_make_assistant(api_callback="not json")) is False
+
+
 class TestBuildFullContext:
-    def test_appends_instruction_when_sources_exist(self):
+    def test_cite_true_appends_instruction_and_keeps_markers(self):
         rag_context = {
             "context": "[1] some retrieved text",
             "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
         }
-        full = _build_full_context(rag_context)
+        full = _build_full_context(rag_context, cite=True)
         assert "[1] some retrieved text" in full
         assert CITATION_INSTRUCTION in full
-        # No visible sources list is injected anymore (OWI renders it).
         assert "## Available Sources" not in full
 
-    def test_no_sources_means_no_citation_instruction(self):
-        rag_context = {"context": "plain context", "sources": []}
-        full = _build_full_context(rag_context)
-        assert full == "plain context"
+    def test_cite_false_strips_markers_and_omits_instruction(self):
+        rag_context = {
+            "context": "[1] first chunk\n\n[2] second chunk",
+            "sources": [{"n": 1}, {"n": 2}],
+        }
+        full = _build_full_context(rag_context, cite=False)
         assert CITATION_INSTRUCTION not in full
+        # The [N] prefixes are removed so the model has no cue to cite.
+        assert "[1]" not in full and "[2]" not in full
+        assert "first chunk" in full and "second chunk" in full
+
+    def test_no_sources_means_no_instruction(self):
+        rag_context = {"context": "plain context", "sources": []}
+        assert _build_full_context(rag_context, cite=True) == "plain context"
 
     def test_non_dict_context_is_stringified(self):
         assert _build_full_context("raw") == "raw"
         assert _build_full_context(None) == ""
 
 
-class TestPromptProcessorInjection:
-    def test_no_template_branch_injects_instruction(self):
-        """Even without a prompt_template, the numbered context + citation
-        instruction must reach the model."""
-        assistant = _make_assistant(prompt_template="")
+class TestPromptProcessorGating:
+    _RAG = {
+        "context": "[1] X is a thing.",
+        "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
+    }
+
+    def test_opted_in_assistant_gets_citation_instruction(self):
+        assistant = _make_assistant(expose_sources=True, prompt_template="")
         request = {"messages": [{"role": "user", "content": "What is X?"}]}
-        rag_context = {
-            "context": "[1] X is a thing.",
-            "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
-        }
-        out = prompt_processor(request, assistant=assistant, rag_context=rag_context)
+        out = prompt_processor(request, assistant=assistant, rag_context=self._RAG)
         user_msg = out[-1]["content"]
         assert CITATION_INSTRUCTION in user_msg
         assert "[1] X is a thing." in user_msg
-        assert "## Available Sources" not in user_msg
 
-    def test_template_branch_injects_instruction(self):
+    def test_default_assistant_gets_no_citation_markers(self):
+        assistant = _make_assistant(expose_sources=False, prompt_template="")
+        request = {"messages": [{"role": "user", "content": "What is X?"}]}
+        out = prompt_processor(request, assistant=assistant, rag_context=self._RAG)
+        user_msg = out[-1]["content"]
+        assert CITATION_INSTRUCTION not in user_msg
+        # The [1] prefix is stripped; the underlying text remains.
+        assert "[1]" not in user_msg
+        assert "X is a thing." in user_msg
+
+    def test_template_branch_respects_opt_in(self):
         assistant = _make_assistant(
-            prompt_template="Context:\n{context}\n\nQ: {user_input}"
+            expose_sources=True, prompt_template="Context:\n{context}\n\nQ: {user_input}"
         )
         request = {"messages": [{"role": "user", "content": "What is X?"}]}
-        rag_context = {
-            "context": "[1] X is a thing.",
-            "sources": [{"n": 1, "title": "Doc A", "score": 0.9}],
-        }
-        out = prompt_processor(request, assistant=assistant, rag_context=rag_context)
-        user_msg = out[-1]["content"]
-        assert CITATION_INSTRUCTION in user_msg
+        out = prompt_processor(request, assistant=assistant, rag_context=self._RAG)
+        assert CITATION_INSTRUCTION in out[-1]["content"]

--- a/backend/tests/test_permalink_signing.py
+++ b/backend/tests/test_permalink_signing.py
@@ -1,0 +1,39 @@
+"""Tests for the per-org HMAC permalink signing used by public citation links."""
+
+from creator_interface.permalink_signing import sign, verify
+
+
+class TestSignVerify:
+    def test_roundtrip(self):
+        sig = sign("3", "3/lib-1/item-1/view")
+        assert verify("3", "3/lib-1/item-1/view", sig) is True
+
+    def test_rejects_tampered_resource(self):
+        sig = sign("3", "3/lib-1/item-1/view")
+        assert verify("3", "3/lib-1/item-2/view", sig) is False
+
+    def test_rejects_empty_signature(self):
+        assert verify("3", "3/lib-1/item-1/view", "") is False
+        assert verify("3", "3/lib-1/item-1/view", None) is False
+
+    def test_rejects_garbage_signature(self):
+        assert verify("3", "3/lib-1/item-1/view", "deadbeef") is False
+
+    def test_per_org_isolation(self):
+        # A signature minted for org 3 must not validate for org 7, even for an
+        # identical resource path — the signing key is org-derived.
+        sig_org3 = sign("3", "3/lib-1/item-1/view")
+        assert verify("7", "3/lib-1/item-1/view", sig_org3) is False
+        # And the two orgs produce different signatures for the same resource.
+        assert sign("3", "x/y/z/view") != sign("7", "x/y/z/view")
+
+    def test_org_id_int_or_str_consistent(self):
+        # Callers may pass org_id as int or str; signing normalizes to str.
+        assert sign(3, "3/lib/item/view") == sign("3", "3/lib/item/view")
+
+    def test_original_download_resource_distinct_from_view(self):
+        view = sign("3", "3/lib/item/view")
+        original = sign("3", "3/lib/item/original/cv.pdf")
+        assert view != original
+        assert verify("3", "3/lib/item/original/cv.pdf", original) is True
+        assert verify("3", "3/lib/item/original/cv.pdf", view) is False

--- a/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/AssistantForm.svelte
@@ -495,6 +495,7 @@
 					bind:selectedRagProcessor={form.selectedRagProcessor}
 					bind:visionEnabled={form.visionEnabled}
 					bind:imageGenerationEnabled={form.imageGenerationEnabled}
+					bind:exposeSourcesEnabled={form.exposeSourcesEnabled}
 					bind:RAG_Top_k={form.RAG_Top_k}
 					ownedKnowledgeBases={form.ownedKnowledgeBases}
 					sharedKnowledgeBases={form.sharedKnowledgeBases}

--- a/frontend/svelte-app/src/lib/components/assistants/components/ConfigurationPanel.svelte
+++ b/frontend/svelte-app/src/lib/components/assistants/components/ConfigurationPanel.svelte
@@ -23,6 +23,7 @@
 		selectedRagProcessor = $bindable(''),
 		visionEnabled = $bindable(false),
 		imageGenerationEnabled = $bindable(false),
+		exposeSourcesEnabled = $bindable(false),
 		RAG_Top_k = $bindable(3),
 		ownedKnowledgeBases = [],
 		sharedKnowledgeBases = [],
@@ -175,6 +176,19 @@
 			</label>
 		</div>
 	{/if}
+
+	<div class="mb-3">
+		<label class="inline-flex items-start cursor-pointer">
+			<input type="checkbox" bind:checked={exposeSourcesEnabled} onchange={onchange} class="sr-only peer" />
+			<div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600 shrink-0 mt-0.5"></div>
+			<div class="ms-3">
+				<span class="text-sm font-medium text-gray-900 dark:text-gray-300">{$_('assistants.form.exposeSources.label', { default: 'Let students open cited sources' })}</span>
+				<p class="text-xs text-gray-500 mt-1">
+					{$_('assistants.form.exposeSources.description', { default: 'Show students clickable links to open and download the documents this assistant cites in its answers. Off by default.' })}
+				</p>
+			</div>
+		</label>
+	</div>
 
 	{#if selectedConnector === 'banana_img' || imageGenerationEnabled || currentConnectorMetadata?.capabilities?.image_generation}
 		<div class="mb-3">

--- a/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormState.svelte.js
+++ b/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormState.svelte.js
@@ -53,6 +53,7 @@ export function createAssistantFormState() {
 		// --- Capabilities ---
 		visionEnabled: false,
 		imageGenerationEnabled: false,
+		exposeSourcesEnabled: false,
 
 		// --- Knowledge Base state ---
 		/** @type {any[]} */
@@ -172,6 +173,7 @@ export function resetFormFieldsToDefaults(form, getAvailableModels) {
 	form.documentRagEnabled = false;
 	form.visionEnabled = false;
 	form.imageGenerationEnabled = false;
+	form.exposeSourcesEnabled = false;
 }
 
 /**
@@ -248,6 +250,7 @@ export function populateFormFields(form, data, getAvailableModels, preserveDescr
 		try {
 			form.visionEnabled = metadata?.capabilities?.vision || false;
 			form.imageGenerationEnabled = metadata?.capabilities?.image_generation || false;
+			form.exposeSourcesEnabled = metadata?.capabilities?.expose_sources || false;
 		} catch (e) {
 			console.warn('Failed to parse vision capability from metadata:', e);
 			form.visionEnabled = false;

--- a/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormSubmit.js
+++ b/frontend/svelte-app/src/lib/components/assistants/logic/assistantFormSubmit.js
@@ -32,7 +32,8 @@ export function buildAssistantPayload(form) {
 		rag_processor: form.selectedRagProcessor,
 		capabilities: {
 			vision: form.visionEnabled,
-			image_generation: form.imageGenerationEnabled
+			image_generation: form.imageGenerationEnabled,
+			expose_sources: form.exposeSourcesEnabled
 		}
 	};
 

--- a/frontend/svelte-app/src/lib/locales/ca.json
+++ b/frontend/svelte-app/src/lib/locales/ca.json
@@ -130,6 +130,10 @@
         "requiredForModelPrefix": "Necessari per a aquest model - ",
         "geminiDescription": "Permetre que aquest assistent generi imatges usant Google Gemini"
       },
+      "exposeSources": {
+        "label": "Permet que els estudiants obrin les fonts citades",
+        "description": "Mostra als estudiants enllaços per obrir i descarregar els documents que aquest assistent cita a les seves respostes. Desactivat per defecte."
+      },
 			"ragProcessor": {
 				"label": "Processador RAG"
 			},

--- a/frontend/svelte-app/src/lib/locales/en.json
+++ b/frontend/svelte-app/src/lib/locales/en.json
@@ -268,6 +268,10 @@
         "requiredForModelPrefix": "Required for this model - ",
         "geminiDescription": "Allow this assistant to generate images using Google Gemini"
       },
+      "exposeSources": {
+        "label": "Let students open cited sources",
+        "description": "Show students clickable links to open and download the documents this assistant cites in its answers. Off by default."
+      },
 			"ragProcessor": {
 				"label": "RAG Processor"
 			},

--- a/frontend/svelte-app/src/lib/locales/es.json
+++ b/frontend/svelte-app/src/lib/locales/es.json
@@ -130,6 +130,10 @@
         "requiredForModelPrefix": "Necesario para este modelo - ",
         "geminiDescription": "Permitir que este asistente genere imágenes usando Google Gemini"
       },
+      "exposeSources": {
+        "label": "Permitir que los estudiantes abran las fuentes citadas",
+        "description": "Muestra a los estudiantes enlaces para abrir y descargar los documentos que este asistente cita en sus respuestas. Desactivado por defecto."
+      },
 			"ragProcessor": {
 				"label": "Procesador RAG"
 			},

--- a/frontend/svelte-app/src/lib/locales/eu.json
+++ b/frontend/svelte-app/src/lib/locales/eu.json
@@ -268,6 +268,10 @@
         "requiredForModelPrefix": "Beharrezkoa modelo honentzat - ",
         "geminiDescription": "Baimendu laguntzaile honi irudiak sortzea Google Gemini erabiliz"
       },
+      "exposeSources": {
+        "label": "Utzi ikasleei aipatutako iturriak irekitzen",
+        "description": "Erakutsi ikasleei esteka klikagarriak laguntzaile honek bere erantzunetan aipatzen dituen dokumentuak ireki eta deskargatzeko. Desgaituta lehenetsita."
+      },
 			"ragProcessor": {
 				"label": "RAG Prozesatzailea"
 			},


### PR DESCRIPTION
## Purpose

PR #430 produced inline `[N]` citation markers but they were plain text pointing nowhere. This lets a student **click a citation and open the cited library document** — under its real filename, with a download-original option — without logging in, while keeping **OpenWebUI → LAMB → Library** (OWI never contacts the Library Manager directly). Access is **opt-in per assistant, off by default**.

## Design (decided with the lead, verified live)

- **Delivery via answer content, not a `sources` field.** OpenWebUI's chat path forwards only `choices[].delta.content` from an external model and **drops any top-level `sources` field** (it renders only sources it generates itself; OWI is vendored and unmodifiable). So citations are appended to the answer as a clickable **Markdown "Sources" section**. Sources are grouped per item with all their numbers, e.g. `[1][3][5] [cv.pdf](signed-url)`, so each inline `[N]` resolves.
- **Auth on click = the link itself.** A student's click is a top-level navigation carrying no LAMB credential (different origin; completion runs as the assistant owner). Each link authorizes itself with an **org-scoped HMAC signature** — per-organization isolated (no cross-org access; rotate the secret to revoke) and **no expiry** (old chats keep working). Within an org the link is a capability.
- **Opt-in, default OFF.** Cited documents are exposed only when the assistant creator enables `capabilities.expose_sources`. When off, there are **no inline `[N]` markers and no Sources section at all** (the cite instruction is withheld and the `[N]` context prefixes are stripped), so students never see citations they cannot open.

## Changes

- **`lamb/completions/citation_sources.py`** (new) — `build_sources_markdown` (per-item clickable Sources list with signed view URLs); `build_owi_sources` kept for non-streaming / spec-compliant clients. Appended to the stream in `main.py` before `[DONE]`, gated by the opt-in flag.
- **`creator_interface/permalink_signing.py`** (new) — per-org HMAC (key from `LAMB_PERMALINK_SIGNING_SECRET` + org id), no expiry.
- **`creator_interface/library_router.py`** — two public, signature-checked routes (before the authenticated `/docs` catch-all): `…/view` (HTML page titled with the filename, markdown rendered via `markdown-it`, "Download original" button) and `…/original/{filename}` (attachment), proxying to the Library Manager with a system context.
- **`lamb/completions/main.py`** — `_assistant_exposes_sources` gate; **`pps/kvcache_augment.py`** — gate the cite instruction and strip `[N]` prefixes when off; **`rag/_ks_query_helpers.py`** — carry chunk `text` on each source.
- **Frontend** — "Let students open cited sources" toggle in the assistant builder (ConfigurationPanel), wired through form state/submit, with i18n in en/es/ca/eu.
- **`config.py` / `.env.example`** — `LAMB_PERMALINK_SIGNING_SECRET` (falls back to `LAMB_BEARER_TOKEN`).

## Verification

- Live, end-to-end on the running stack: opt-in OFF → 0 inline markers, no Sources section; ON → inline `[N]` + `**Sources**\n\n[1][2][3][4][5] [gold_en_corpus.md](http://…/docs/public/…/view?…&sig=…)`. Signed view page → 200 HTML titled with the real filename, content rendered, **Download original** → 200 `application/pdf` (3.7 MB). Bad signature → 403. Routes ordered before the auth catch-all.
- Unit tests: signing (per-org isolation, tamper), citation markdown grouping + signed-and-verifiable URLs, OWI shape, the opt-in gate (markers present only when enabled). Sweep green.

## Related

- Closes #445