### PR TITLE
fix(library-manager): delete_folder reparent-collision under non-root parent (#447)

### DIFF
--- a/library-manager/backend/services/folder_service.py
+++ b/library-manager/backend/services/folder_service.py
@@ -272,10 +272,15 @@ def delete_folder(db: Session, folder_id: str) -> str:
         .all()
     )
     for sub in subfolders:
-        sub.parent_folder_id = new_parent_id
+        # Compute the deduped name against the destination parent BEFORE
+        # reassigning parent_folder_id. _next_available_name issues queries
+        # that trigger an autoflush; if the row were already reparented with
+        # its still-colliding name, that flush would violate
+        # uq_folder_sibling_name when the parent is non-NULL.
         sub.name = _next_available_name(
             db, folder.library_id, new_parent_id, sub.name, exclude_id=sub.id
         )
+        sub.parent_folder_id = new_parent_id
 
     db.delete(folder)
     db.commit()

--- a/library-manager/tests/unit/test_service_folder.py
+++ b/library-manager/tests/unit/test_service_folder.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 from _helpers import unique_id
 from database.models import ContentItem, Library
-from sqlalchemy.exc import IntegrityError
 from services import folder_service
 from services.folder_service import (
     FolderConflictError,
@@ -337,8 +336,8 @@ def test_delete_folder_collision_renames_with_suffix(db_session, lib):
     """delete_folder appends ``(2)`` when a reparented subfolder name collides.
 
     NOTE: the deleted folder is at the library root so its children reparent
-    to a NULL parent. This is the only code path the suffix logic survives —
-    see the bug reported in the final summary for the non-NULL-parent case.
+    to a NULL parent. The non-root case is covered by
+    test_delete_folder_collision_under_nonroot_parent.
     """
     # Root already has a "Drafts".
     folder_service.create_folder(
@@ -376,23 +375,12 @@ def test_delete_folder_collision_increments_suffix(db_session, lib):
     assert collide.name == "Drafts (3)"
 
 
-@pytest.mark.xfail(
-    raises=IntegrityError,
-    strict=True,
-    reason=(
-        "BUG: delete_folder sets sub.parent_folder_id before _next_available_name "
-        "computes the deduped name; the autoflush during that query writes the still-"
-        "colliding name and violates uq_folder_sibling_name when the new parent is "
-        "non-NULL. Masked for root (NULL) reparents because SQLite treats NULL as "
-        "distinct. Fix: assign sub.name before sub.parent_folder_id, or wrap in "
-        "db.no_autoflush. When fixed, this strict xfail will fail — unmark it then."
-    ),
-)
 def test_delete_folder_collision_under_nonroot_parent(db_session, lib):
-    """A reparented subfolder colliding under a NON-root parent should be renamed.
+    """A reparented subfolder colliding under a NON-root parent is renamed.
 
-    Pins the known delete_folder bug (see xfail reason). The expected behaviour
-    is that the collided 'Drafts' is renamed to 'Drafts (2)' under the parent.
+    The collided 'Drafts' is renamed to 'Drafts (2)' under the parent. The
+    deduped name is computed before parent_folder_id is reassigned, so the
+    autoflush during _next_available_name never writes a colliding row.
     """
     parent = folder_service.create_folder(
         db_session, library_id=lib, name="Parent", parent_folder_id=None


### PR DESCRIPTION
## Summary

`delete_folder` re-homes a deleted folder's subfolders to the deleted folder's parent, deduping names on collision. The loop assigned `sub.parent_folder_id = new_parent_id` **before** calling `_next_available_name(...)`. That helper issues queries which trigger a SQLAlchemy **autoflush**; the flush wrote the already-reparented row with its *still-colliding* name, violating the `uq_folder_sibling_name` UNIQUE constraint and raising `IntegrityError`. This only manifested when the parent was non-NULL (a nested folder); the root/NULL case was masked because SQLite treats NULL as distinct in UNIQUE constraints.

**Fix:** compute the deduped name (against `new_parent_id`, excluding `sub.id`) *before* reassigning `sub.parent_folder_id`. `_next_available_name` queries siblings under `new_parent_id` excluding the row's own id, so it is independent of the row's current parent — making the reorder provably correct with no behaviour change beyond fixing the bug. Root-case behaviour is unchanged.

Scope: `library-manager/backend/services/folder_service.py` and the pinned regression test only.

## Tests

- The formerly strict-xfail test `tests/unit/test_service_folder.py::test_delete_folder_collision_under_nonroot_parent` is now a normal passing test (xfail decorator removed; docstring updated). Stale "the bug / final summary" notes on the two sibling collision tests were corrected, and the now-unused `IntegrityError` import was removed.
- Targeted: `pytest tests/unit/test_service_folder.py` → 37 passed, **0 xfailed**.
- Full gate: `./scripts/run_tests.sh` → **678 passed**, coverage 97.90%, ending with "All tiers passed and coverage gate (>=95%) satisfied."
- The e2e tier still has exactly **1 xfail** remaining (`test_non_latin1_token_is_401_not_500`) — that is the pin for issue #448 and is expected/unrelated to this PR.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)