### PR TITLE
fix(library-manager): verify_token 500 on non-ASCII bearer token (#448)

### DIFF
--- a/library-manager/backend/dependencies.py
+++ b/library-manager/backend/dependencies.py
@@ -21,6 +21,11 @@ async def verify_token(
 
     Uses ``hmac.compare_digest`` for timing-safe comparison to prevent
     timing attacks that could reveal the token character by character.
+    Operands are encoded to bytes first because ``hmac.compare_digest``
+    raises ``TypeError`` on ``str`` inputs containing non-ASCII characters;
+    comparing bytes keeps the comparison timing-safe while ensuring any
+    invalid token (including non-ASCII) is rejected with 401 rather than
+    crashing with a 500.
 
     Args:
         credentials: The Authorization header parsed by HTTPBearer.
@@ -31,7 +36,9 @@ async def verify_token(
     Raises:
         HTTPException: 401 if token is missing or invalid.
     """
-    if not hmac.compare_digest(credentials.credentials, LAMB_API_TOKEN):
+    if not hmac.compare_digest(
+        credentials.credentials.encode("utf-8"), LAMB_API_TOKEN.encode("utf-8")
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid service token.",

--- a/library-manager/tests/e2e/test_auth_boundary.py
+++ b/library-manager/tests/e2e/test_auth_boundary.py
@@ -27,18 +27,6 @@ def test_wrong_bearer_token(server) -> None:
     assert resp.status_code == 401, resp.text
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "SOURCE BUG: dependencies.verify_token calls hmac.compare_digest() with the "
-        "raw credential, which raises TypeError on non-ASCII strings ('comparing "
-        "strings with non-ASCII characters is not supported'). That propagates as a "
-        "500. A bad token must be rejected with 401, never crash the service. The "
-        "fix is to guard compare_digest (e.g. encode to bytes / catch the TypeError) "
-        "and return 401. This test asserts the correct behaviour and xfails until "
-        "the bug is fixed."
-    ),
-)
 def test_non_latin1_token_is_401_not_500(server) -> None:
     """A non-Latin-1 token must be rejected (401), never crash the server (500)."""
     # httpx encodes headers as latin-1; pass raw bytes to smuggle non-ASCII


### PR DESCRIPTION
## Summary

`library-manager/backend/dependencies.py::verify_token` compared the bearer token with `hmac.compare_digest(credentials.credentials, LAMB_API_TOKEN)` on raw `str` values. `hmac.compare_digest` raises `TypeError: comparing strings with non-ASCII characters is not supported` whenever the supplied token contains non-ASCII characters, and the unhandled `TypeError` surfaced as **HTTP 500** instead of a clean **401**. A client could trip a 500 on the auth path with a single malformed `Authorization` header.

**Fix:** encode both operands to bytes before comparing — `hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8"))`. Bytes never hit the non-ASCII `TypeError`, so any invalid token (including non-ASCII) is rejected with 401, while the valid-token path keeps its constant-time (timing-safe) comparison.

## Tests

- `tests/e2e/test_auth_boundary.py::test_non_latin1_token_is_401_not_500` now passes **unmarked** (the strict `@pytest.mark.xfail` decorator was removed). The auth-boundary file passes with **0 xfails**.
- Full gate `./scripts/run_tests.sh` is green: **677 passed, 1 xfailed**, coverage 97.90% — the ≥95% coverage gate is satisfied ("All tiers passed and coverage gate (>=95%) satisfied."). The Docker e2e tier exercises the auth change inside the container.
- The 1 remaining xfail is the **#447 folder pin** (`test_delete_folder_collision_under_nonroot_parent`) from PR #449, which is unrelated to this change and disappears once that PR merges.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)