### PR TITLE
fix(frontend): Libraries "Mine" filter shows all instead of only owned

### DIFF
--- a/frontend/svelte-app/src/lib/components/libraries/LibrariesList.svelte
+++ b/frontend/svelte-app/src/lib/components/libraries/LibrariesList.svelte
@@ -109,7 +109,7 @@
 	let activePredicates = $derived.by(() => {
 		/** @type {Array<(item: any) => boolean>} */
 		const preds = [];
-		if (sharingFilter === 'my') preds.push((l) => l.is_owner !== false);
+		if (sharingFilter === 'my') preds.push((l) => l.is_owner !== false && !l.is_shared);
 		if (sharingFilter === 'shared') preds.push((l) => l.is_shared === true);
 		if (hasItemsFilter === 'with-items') preds.push((l) => (l.item_count ?? 0) > 0);
 		if (hasItemsFilter === 'empty') preds.push((l) => (l.item_count ?? 0) === 0);


### PR DESCRIPTION
## Summary

On the **Libraries** page the ownership filter has two options, **Mine** and **Shared**. Clicking **Shared** filtered correctly, but clicking **Mine** showed *all* libraries instead of only the user's own.

**Root cause** — `frontend/svelte-app/src/lib/components/libraries/LibrariesList.svelte` (line 112): the `my` predicate was

```js
if (sharingFilter === 'my') preds.push((l) => l.is_owner !== false);
```

`is_owner !== false` passes any item whose `is_owner` is `true` **or** `undefined`, so it never excluded shared items — effectively showing everything. The `shared` predicate (`l.is_shared === true`) was already correct, which is why **Shared** worked.

**Fix** (one line) — bring it to parity with the already-correct sibling `KnowledgeStoresList.svelte` (line 158):

```js
if (sharingFilter === 'my') preds.push((l) => l.is_owner !== false && !l.is_shared);
```

`Mine` now means *owned and not shared*; `Shared` means *shared*. The two buckets partition cleanly. The fix is robust even if `is_owner` arrives `undefined`, because `is_shared` (proven correct by the working Shared filter) carries the real signal.

Only this one predicate changed. Knowledge Stores already used the correct form; Knowledge Bases and Prompt Templates use a different owned/shared-array mechanism and are unaffected.

## Testing

- `npx prettier --check` on the changed file — clean.
- No new ESLint or `svelte-check` errors introduced (the file's pre-existing baseline warnings on unrelated lines are unchanged).
- Manual: on the Libraries page, **Mine** → only the user's own non-shared libraries; **Shared** → only shared libraries; clearing the filter → all return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
