### PR TITLE
docs(kb-server): correct combined coverage figure to ~94%

### DIFF
--- a/lamb-kb-server/README.md
+++ b/lamb-kb-server/README.md
@@ -107,7 +107,7 @@ ruff check backend/ tests/
 
 The e2e tier requires Docker (Qdrant + Ollama containers brought up automatically by the session fixture). If `QDRANT_TEST_PORT` and `OLLAMA_TEST_PORT` env vars are set, the fixture uses those pre-started containers instead of spinning up its own. If Docker is unavailable, the entire e2e tier is skipped with a clear message.
 
-Combined coverage hits **99%** line + branch on `backend/` (572 tests). The remaining 1% is structurally unreachable: a `sys.exit(1)` startup guard, an `ImportError` re-raise inside an `except ImportError` block, and a defensive branch the splitter algorithm never enters.
+Combined coverage is **~94%** line + branch on `backend/` (594 tests). The uncovered remainder is dominated by code paths that the e2e tier exercises only over real HTTP — that work runs in a uvicorn subprocess the parent `pytest-cov` process cannot instrument — together with a few structurally unreachable guards: a `sys.exit(1)` startup guard, an `ImportError` re-raise inside an `except ImportError` block, and a defensive branch the splitter algorithm never enters.
 
 ### Docker
 

--- a/lamb-kb-server/tests/README.md
+++ b/lamb-kb-server/tests/README.md
@@ -1,6 +1,6 @@
 # Test suite
 
-Three tiers, each with its own scope, fixtures, and runtime profile. The combined run hits **99% line + branch coverage** on `backend/`.
+Three tiers, each with its own scope, fixtures, and runtime profile. The combined run reaches **~94% line + branch coverage** on `backend/` (the e2e tier's server runs in a subprocess the parent coverage process cannot instrument, so its server-side paths are not counted).
 
 | Tier | Where | Tests | Runtime | What it proves |
 |---|---|---|---|---|


### PR DESCRIPTION
## What changed

`lamb-kb-server/README.md` and `lamb-kb-server/tests/README.md` stated **99%** combined line+branch coverage on `backend/`. The actual figure from the combined three-tier run (unit + integration + e2e, **594 tests**) is **~94%**.

## Why

This is not a coverage regression. The e2e tier exercises the backend over real HTTP, and that work runs in a **uvicorn subprocess that the parent `pytest-cov` process cannot instrument** — so the server-side paths it covers are not counted in the combined number. The remaining gap is a few structurally unreachable guards (the `sys.exit(1)` startup guard, an `ImportError` re-raise, and a defensive splitter branch).

Verified by running `pytest tests/unit tests/integration tests/e2e --cov=backend --cov-branch` (the same command as `scripts/run_tests.sh`): 594 passed, TOTAL 94%.