### PR TITLE
fix(#460, #461): whoami serialises any stored email; lamb-cli user create accepts --org

### DIFF
--- a/backend/creator_interface/main.py
+++ b/backend/creator_interface/main.py
@@ -207,7 +207,10 @@ class SignupErrorResponse(BaseModel):
 
 class UserResponse(BaseModel):
     id: int
-    email: EmailStr
+    # Plain str, not EmailStr: response models must be able to serialise every
+    # address the write path accepted. EmailStr rejects reserved TLDs (.test,
+    # .local), which turned a stored address into an unhandled 500 (#460).
+    email: str
     name: str
     role: str
     user_config: dict
@@ -293,7 +296,7 @@ class RoleUpdateResponse(BaseModel):
 
 class CurrentUserResponse(BaseModel):
     id: int
-    email: EmailStr
+    email: str  # see UserResponse.email — #460
     name: str
 
 

--- a/lamb-cli/src/lamb_cli/commands/user.py
+++ b/lamb-cli/src/lamb_cli/commands/user.py
@@ -84,9 +84,14 @@ def create_user(
     password: str = typer.Argument(..., help="User password."),
     user_type: str = typer.Option("creator", "--user-type", "-t", help="User type: creator or end_user."),
     enabled: bool = typer.Option(True, "--enabled/--disabled", help="Enable or disable the user."),
+    org: Optional[str] = typer.Option(None, "--org", help="Organization slug to create the user in (admin only). Defaults to your own organization."),
     output: str = typer.Option(None, "-o", "--output", help="Output format: table, json, plain."),
 ) -> None:
-    """Create a new user."""
+    """Create a new user.
+
+    Without --org the user is created in your own organization. Admins can
+    target another organization by slug (#461).
+    """
     fmt = output or get_output_format()
     body: dict = {
         "email": email,
@@ -95,9 +100,14 @@ def create_user(
         "user_type": user_type,
         "enabled": enabled,
     }
+    params: dict = {}
+    if org:
+        params["org"] = org
     with get_client() as client:
-        data = client.post("/creator/admin/org-admin/users", json=body)
-    print_success(f"User created: {data.get('email', data.get('id', ''))}")
+        data = client.post("/creator/admin/org-admin/users", json=body, params=params)
+    # Name the organization explicitly: silent placement in the caller's org was
+    # the actual defect behind #461, not just the missing flag.
+    print_success(f"User created: {data.get('email', data.get('id', ''))} (organization: {org or 'your own'})")
     format_output(data, USER_LIST_COLUMNS, fmt)
 
 


### PR DESCRIPTION
Closes #460. Closes #461.

Both bugs were found by an automated black-box agent run against the dev stack, then reproduced and isolated by hand before filing.

## #460 — `whoami` returned 500 for reserved-TLD email addresses

`CurrentUserResponse.email` and `UserResponse.email` were typed `EmailStr`, which rejects reserved and special-use TLDs (`.test`, `.local`). The handler completed normally and FastAPI then raised `ResponseValidationError` while serialising, so the caller saw an unhandled 500 with no explanation.

The underlying defect was an asymmetry between the write path and the read path: user creation accepted an address the read path could not serialise, leaving accounts that exist, authenticate, and work everywhere except when reporting their own identity. Test and CI environments use `.test` addresses routinely, so every such account was broken.

Response models now use plain `str`. Input validation is unchanged — this only relaxes what the API is willing to hand back, never what it accepts.

## #461 — `lamb user create` silently placed users in the caller's organization

The CLI had no `--org` option, so users landed in whatever organization the authenticated admin belonged to, with a success message that gave no hint of where the account actually went. The backend endpoint already accepted `?org=<slug>` — the same parameter `lamb user list` uses — so this is a CLI-side gap only.

`lamb user create` now takes `--org <slug>` and names the target organization in its output, because the silent placement was the more damaging half of the bug.

## Verification

Both fixes were exercised against the local dev stack: the account that previously returned 500 now returns its identity, and a user created with `--org` appears in the target organization's roster rather than the admin's.
